### PR TITLE
Add MCP discoverability: tool annotations, server card, discovery fil…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md
+
+## Project Overview
+
+Tako MCP Server — an MCP (Model Context Protocol) server that provides AI agents access to Tako's knowledge base of 100K+ data visualizations and the ThinViz API for creating custom charts.
+
+## Build & Run
+
+```bash
+# Install dependencies
+pip install -e ".[dev]"
+
+# Run the server
+tako-mcp
+
+# Run with Docker
+docker build -t tako-mcp .
+docker run -p 8001:8001 tako-mcp
+
+# Run tests
+python -m tests.test_client --api-token YOUR_TOKEN
+```
+
+## Architecture
+
+- **Framework**: FastMCP (from `mcp` package) with SSE transport
+- **Server**: Starlette ASGI app served by Uvicorn on port 8001
+- **API**: Proxies requests to Tako's REST API (configured via `TAKO_API_URL` env var)
+- **Auth**: API key passed per-tool-call as `api_token` parameter, forwarded as `X-API-Key` header
+- **UI**: MCP-UI resources for interactive chart embedding via `mcp-ui-server`
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/tako_mcp/server.py` | Main MCP server — ASGI app, 8 tool definitions, health endpoints |
+| `src/tako_mcp/main.py` | Alternative implementation using Tako Python client (not the primary server) |
+| `src/tako_mcp/smithery/server.py` | Smithery marketplace integration wrapper |
+| `tests/test_client.py` | Integration test client |
+| `Dockerfile` | Container build (Python 3.11-slim, port 8001) |
+
+### Tools (8)
+
+1. `knowledge_search` — Search charts by natural language query
+2. `explore_knowledge_graph` — Discover entities, metrics, cohorts
+3. `get_chart_image` — Get static PNG preview URL
+4. `get_card_insights` — Get AI-generated chart analysis
+5. `list_chart_schemas` — List available ThinViz chart templates
+6. `get_chart_schema` — Get schema details and data format
+7. `create_chart` — Create chart from schema + data
+8. `open_chart_ui` — Render interactive chart via MCP-UI
+
+### Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/sse` | GET | SSE transport connection |
+| `/messages/` | POST | MCP JSON-RPC messages |
+| `/health` | GET | Simple health check |
+| `/health/detailed` | GET | Detailed health status |
+| `/.well-known/mcp` | GET | MCP Server Card (SEP-1649) |
+
+## Code Conventions
+
+- Python 3.11+, async/await throughout
+- Ruff for linting (line length 100, rules: E, F, I, N, W, UP)
+- All tool functions are async, decorated with `@mcp.tool()`
+- Error responses return JSON with `error`, `message`, and `suggestion` keys
+- Timeouts: 30s for schema ops, 60s for search/create, 90s for insights
+- Environment variables for configuration (see README)
+
+## PR Guidelines
+
+- Run `ruff check src/` before submitting
+- Test with `python -m tests.test_client --api-token TOKEN`
+- Keep tool descriptions agent-optimized (lead with "Use this when...")
+- Never commit API keys or tokens
+
+## Safety Rules
+
+- Never commit API keys, tokens, or credentials
+- Never modify production infrastructure configs
+- All tool functions must validate inputs before making API calls
+- Error responses must never expose internal URLs or stack traces

--- a/agent.json
+++ b/agent.json
@@ -1,0 +1,66 @@
+{
+  "name": "Tako",
+  "description": "Data visualization agent that creates, discovers, and analyzes interactive charts. Searches a knowledge base of 100K+ charts and creates custom visualizations from raw data using 15+ chart types.",
+  "url": "https://mcp.tako.com",
+  "version": "0.1.0",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "authentication": {
+    "schemes": ["apiKey"],
+    "credentials": {
+      "apiKey": {
+        "description": "Tako API token from tako.com"
+      }
+    }
+  },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text", "image"],
+  "skills": [
+    {
+      "id": "search-charts",
+      "name": "Search Charts",
+      "description": "Search Tako's knowledge base for existing charts and data visualizations on any topic including economics, finance, demographics, and technology.",
+      "tags": ["search", "charts", "data", "visualization"],
+      "examples": [
+        "Find charts about US GDP growth",
+        "Search for Intel vs Nvidia revenue comparison",
+        "Show me climate change data"
+      ]
+    },
+    {
+      "id": "create-chart",
+      "name": "Create Chart",
+      "description": "Create a new interactive chart from raw data. Supports timeseries, bar charts, scatter plots, pie charts, maps, heatmaps, treemaps, and more.",
+      "tags": ["create", "chart", "visualization", "data"],
+      "examples": [
+        "Create a bar chart of revenue by region",
+        "Make a timeseries chart of stock prices",
+        "Build a choropleth map of population by state"
+      ]
+    },
+    {
+      "id": "analyze-chart",
+      "name": "Analyze Chart",
+      "description": "Get AI-generated insights and analysis for any chart, including trend identification, outlier detection, and key takeaways.",
+      "tags": ["analyze", "insights", "ai", "data"],
+      "examples": [
+        "What are the key trends in this chart?",
+        "Analyze this revenue data",
+        "Summarize the insights from this visualization"
+      ]
+    },
+    {
+      "id": "explore-data",
+      "name": "Explore Data",
+      "description": "Discover available entities, metrics, cohorts, and time periods in Tako's knowledge graph to understand what data is available.",
+      "tags": ["explore", "discover", "entities", "metrics"],
+      "examples": [
+        "What tech company data is available?",
+        "Show me available GDP metrics",
+        "What cohorts like S&P 500 are available?"
+      ]
+    }
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+
+services:
+  tako-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8001:8001"
+    environment:
+      - PUBLIC_BASE_URL=https://tako.com
+      - PORT=8001
+      - HOST=0.0.0.0
+      - MCP_ENABLE_DNS_REBINDING=true
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,171 @@
+# Tako
+
+> Tako is a data visualization platform that helps you create, discover, and share interactive charts. The Tako MCP server enables AI agents to search for existing charts and create new visualizations from raw data.
+
+## Documentation
+
+- [MCP Server Setup](https://github.com/TakoData/tako-mcp): Install and configure the Tako MCP server for AI agents
+- [API Reference](https://tako.com/docs/): Full REST API documentation
+- [Chart Gallery](https://tako.com/gallery): Browse example charts and visualizations
+- [ThinViz API](https://github.com/TakoData/tako-mcp#thinviz-api---create-custom-charts): Create charts from raw data using 15+ chart types
+- [OpenAPI Spec](https://tako.com/openapi.yaml): Machine-readable API specification
+
+## Quick Start
+
+Connect your MCP client to `https://mcp.tako.com/sse`.
+
+### Claude Desktop Configuration
+
+Add to your Claude Desktop config (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "tako": {
+      "url": "https://mcp.tako.com/sse"
+    }
+  }
+}
+```
+
+### Cursor Configuration
+
+Add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "tako": {
+      "url": "https://mcp.tako.com/sse"
+    }
+  }
+}
+```
+
+## Available Tools
+
+### knowledge_search
+Search Tako's knowledge base for charts and data visualizations on any topic. Use this when a user asks about data trends, comparisons, or statistics.
+
+Parameters:
+- `query` (string, required): Natural language search query
+- `api_token` (string, required): Tako API token
+- `count` (integer, 1-20, default 5): Number of results
+- `search_effort` (string, "fast"|"deep", default "deep"): Search depth
+
+### explore_knowledge_graph
+Discover available entities, metrics, cohorts, and time periods. Use this to understand what data is available before searching.
+
+Parameters:
+- `query` (string, required): Natural language query
+- `api_token` (string, required): Tako API token
+- `node_types` (array, optional): Filter by type: "entity", "metric", "cohort", "db", "units", "time_period", "property"
+- `limit` (integer, 1-50, default 20): Max results per type
+
+### get_chart_image
+Get a static PNG preview image URL for a chart.
+
+Parameters:
+- `pub_id` (string, required): Chart ID
+- `api_token` (string, required): Tako API token
+- `dark_mode` (boolean, default true): Dark mode theme
+
+### get_card_insights
+Get AI-generated insights and analysis for a chart. Returns bullet-point takeaways.
+
+Parameters:
+- `pub_id` (string, required): Chart ID
+- `api_token` (string, required): Tako API token
+- `effort` (string, "low"|"medium"|"high", default "medium"): Analysis depth
+
+### list_chart_schemas
+List all available chart templates. Call this before create_chart to see options.
+
+Parameters:
+- `api_token` (string, required): Tako API token
+
+### get_chart_schema
+Get the detailed data format for a specific chart type. Call this before create_chart.
+
+Parameters:
+- `schema_name` (string, required): Schema name (e.g., "bar_chart", "stock_card")
+- `api_token` (string, required): Tako API token
+
+### create_chart
+Create a new interactive chart from raw data. Supports 15+ chart types.
+
+Parameters:
+- `schema_name` (string, required): Schema to use
+- `components` (array, required): Chart component configurations
+- `api_token` (string, required): Tako API token
+- `source` (string, optional): Data attribution
+
+### open_chart_ui
+Open a fully interactive chart with zooming, panning, and hover interactions.
+
+Parameters:
+- `pub_id` (string, required): Chart ID
+- `dark_mode` (boolean, default true): Dark mode theme
+- `width` (integer, default 900): Width in pixels
+- `height` (integer, default 600): Height in pixels
+
+## Chart Types
+
+Tako ThinViz supports these chart types:
+
+| Type | Schema Name | Use Case |
+|------|------------|----------|
+| Line/Area Chart | `timeseries_card` | Time-based trends |
+| Stock Chart | `stock_card` | Financial data with ticker boxes |
+| Bar Chart | `bar_chart` | Categorical comparisons |
+| Grouped Bar | `grouped_bar_chart` | Multi-series comparisons |
+| Data Table Chart | `data_table_chart` | Bar chart with data table |
+| Pie Chart | `pie_chart` | Proportional data |
+| Scatter Plot | `scatter_chart` | 2-variable correlations |
+| Bubble Chart | `bubble_chart` | 3-variable data |
+| Histogram | `histogram` | Frequency distributions |
+| Box Plot | `boxplot` | Statistical distributions |
+| Choropleth Map | `choropleth` | Geographic data (US/World) |
+| Treemap | `treemap` | Hierarchical data |
+| Heatmap | `heatmap` | 2D correlation matrices |
+| Waterfall | `waterfall` | Sequential changes |
+| Financial Boxes | `financial_boxes` | Metric KPIs |
+| Data Table | `table` | Tabular data display |
+
+## Example: Create a Bar Chart
+
+```json
+{
+  "schema_name": "bar_chart",
+  "api_token": "your-token",
+  "source": "Company Reports",
+  "components": [
+    {
+      "component_type": "header",
+      "config": {
+        "title": "Revenue by Region",
+        "subtitle": "Q4 2024"
+      }
+    },
+    {
+      "component_type": "categorical_bar",
+      "config": {
+        "datasets": [{
+          "label": "Revenue",
+          "data": [
+            {"x": "North America", "y": 120},
+            {"x": "Europe", "y": 98},
+            {"x": "Asia", "y": 156}
+          ],
+          "units": "$M"
+        }],
+        "title": "Revenue by Region"
+      }
+    }
+  ]
+}
+```
+
+## Authentication
+
+All API calls require a Tako API token passed as `api_token` parameter in tool calls. Get your token at [tako.com](https://tako.com) in account settings.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,23 @@
+# Tako
+
+> Tako is a data visualization platform that helps you create, discover, and share interactive charts. The Tako MCP server enables AI agents to search for existing charts and create new visualizations from raw data.
+
+## Documentation
+
+- [MCP Server Setup](https://github.com/TakoData/tako-mcp): Install and configure the Tako MCP server for AI agents
+- [API Reference](https://tako.com/docs/): Full REST API documentation
+- [Chart Gallery](https://tako.com/gallery): Browse example charts and visualizations
+- [ThinViz API](https://github.com/TakoData/tako-mcp#thinviz-api---create-custom-charts): Create charts from raw data using 15+ chart types
+- [OpenAPI Spec](https://tako.com/openapi.yaml): Machine-readable API specification
+
+## Quick Start
+
+Connect your MCP client to `https://mcp.tako.com/sse`
+
+## Capabilities
+
+- Search 100K+ curated charts on economics, finance, demographics, technology
+- Create custom charts: timeseries, bar charts, scatter plots, pie charts, maps, heatmaps, treemaps, and more
+- Get AI-generated insights and analysis for any chart
+- Explore a knowledge graph of entities, metrics, and cohorts
+- Render fully interactive charts via MCP-UI

--- a/registry/server.json
+++ b/registry/server.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://registry.modelcontextprotocol.io/schemas/server.json",
+  "namespace": "com.tako",
+  "name": "tako-mcp",
+  "version": "0.1.0",
+  "title": "Tako MCP Server",
+  "description": "Create and discover data visualizations. Search Tako's knowledge base of 100K+ charts covering economics, finance, demographics, and technology. Create custom charts from raw data using 15+ chart types including timeseries, bar charts, scatter plots, pie charts, maps, heatmaps, treemaps, and more.",
+  "repository": {
+    "url": "https://github.com/TakoData/tako-mcp",
+    "source": "github"
+  },
+  "license": "MIT",
+  "runtime": "python",
+  "categories": [
+    "Data Visualization",
+    "Charts",
+    "Data Analysis"
+  ],
+  "tags": [
+    "charts",
+    "data-visualization",
+    "knowledge-base",
+    "thinviz",
+    "interactive-charts",
+    "mcp-ui"
+  ],
+  "authors": [
+    {
+      "name": "Tako",
+      "email": "hello@tako.com",
+      "url": "https://tako.com"
+    }
+  ],
+  "package": {
+    "type": "pip",
+    "name": "tako-mcp"
+  },
+  "installation": {
+    "pip": {
+      "command": "pip install tako-mcp",
+      "entrypoint": "tako-mcp"
+    },
+    "docker": {
+      "image": "ghcr.io/takodata/tako-mcp:latest",
+      "ports": ["8001:8001"],
+      "environment": {
+        "PUBLIC_BASE_URL": "https://tako.com"
+      }
+    }
+  },
+  "transport": {
+    "type": "sse",
+    "endpoint": "/sse",
+    "port": 8001
+  },
+  "authentication": {
+    "type": "api_key",
+    "description": "Tako API token. Sign up at tako.com and create a token in account settings.",
+    "setup_url": "https://tako.com"
+  },
+  "tools": [
+    {
+      "name": "knowledge_search",
+      "description": "Search Tako's knowledge base for charts and data visualizations on any topic. Use when a user asks about data trends, comparisons, or statistics.",
+      "parameters": {
+        "query": {"type": "string", "description": "Natural language search query", "required": true},
+        "api_token": {"type": "string", "description": "Tako API token", "required": true},
+        "count": {"type": "integer", "description": "Number of results (1-20)", "default": 5},
+        "search_effort": {"type": "string", "description": "Search depth: 'fast' or 'deep'", "default": "deep"}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "explore_knowledge_graph",
+      "description": "Discover available entities, metrics, cohorts, and time periods. Use to understand what data is available before searching.",
+      "parameters": {
+        "query": {"type": "string", "description": "Natural language query", "required": true},
+        "api_token": {"type": "string", "description": "Tako API token", "required": true},
+        "node_types": {"type": "array", "description": "Filter by node type", "required": false},
+        "limit": {"type": "integer", "description": "Max results per type (1-50)", "default": 20}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_chart_image",
+      "description": "Get a static PNG preview image URL for a chart.",
+      "parameters": {
+        "pub_id": {"type": "string", "description": "Chart ID", "required": true},
+        "api_token": {"type": "string", "description": "Tako API token", "required": true},
+        "dark_mode": {"type": "boolean", "description": "Dark mode theme", "default": true}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_card_insights",
+      "description": "Get AI-generated insights and analysis for a chart.",
+      "parameters": {
+        "pub_id": {"type": "string", "description": "Chart ID", "required": true},
+        "api_token": {"type": "string", "description": "Tako API token", "required": true},
+        "effort": {"type": "string", "description": "Analysis depth: 'low', 'medium', 'high'", "default": "medium"}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_chart_schemas",
+      "description": "List all available chart templates for creating custom visualizations.",
+      "parameters": {
+        "api_token": {"type": "string", "description": "Tako API token", "required": true}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_chart_schema",
+      "description": "Get the detailed schema and data format for a specific chart type.",
+      "parameters": {
+        "schema_name": {"type": "string", "description": "Schema name", "required": true},
+        "api_token": {"type": "string", "description": "Tako API token", "required": true}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "create_chart",
+      "description": "Create a new interactive chart from raw data using 15+ chart types including timeseries, bar charts, scatter plots, pie charts, maps, and more.",
+      "parameters": {
+        "schema_name": {"type": "string", "description": "Schema to use", "required": true},
+        "components": {"type": "array", "description": "Chart component configurations", "required": true},
+        "api_token": {"type": "string", "description": "Tako API token", "required": true},
+        "source": {"type": "string", "description": "Data attribution", "required": false}
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "openWorldHint": true
+      }
+    },
+    {
+      "name": "open_chart_ui",
+      "description": "Open a fully interactive chart with zooming, panning, and hover interactions via MCP-UI.",
+      "parameters": {
+        "pub_id": {"type": "string", "description": "Chart ID", "required": true},
+        "dark_mode": {"type": "boolean", "description": "Dark mode theme", "default": true},
+        "width": {"type": "integer", "description": "Width in pixels", "default": 900},
+        "height": {"type": "integer", "description": "Height in pixels", "default": 600}
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": true
+      }
+    }
+  ],
+  "links": {
+    "homepage": "https://tako.com",
+    "documentation": "https://github.com/TakoData/tako-mcp#readme",
+    "repository": "https://github.com/TakoData/tako-mcp",
+    "issues": "https://github.com/TakoData/tako-mcp/issues",
+    "mcp_server": "https://mcp.tako.com"
+  }
+}

--- a/registry/smithery.yaml
+++ b/registry/smithery.yaml
@@ -1,0 +1,112 @@
+# Smithery Marketplace Configuration for Tako MCP Server
+# https://smithery.ai
+
+name: tako-mcp
+title: Tako MCP Server
+description: |
+  Create and discover data visualizations with Tako. Search a knowledge base
+  of 100K+ charts covering economics, finance, demographics, and technology.
+  Create custom charts from raw data using 15+ chart types.
+
+version: "0.1.0"
+license: MIT
+
+author:
+  name: Tako
+  email: hello@tako.com
+  url: https://tako.com
+
+repository: https://github.com/TakoData/tako-mcp
+
+categories:
+  - Data Visualization
+  - Charts
+  - Data Analysis
+  - Knowledge Base
+
+tags:
+  - charts
+  - data-visualization
+  - thinviz
+  - interactive-charts
+  - mcp-ui
+  - knowledge-base
+
+# Server configuration
+server:
+  transport: sse
+  command: tako-mcp
+  port: 8001
+
+# Configuration schema (what users need to provide)
+configSchema:
+  type: object
+  required:
+    - takoApiKey
+  properties:
+    takoApiKey:
+      type: string
+      title: Tako API Key
+      description: >
+        Your Tako API token for authentication. Sign up at tako.com
+        and create a token in your account settings.
+
+# Docker support
+docker:
+  image: ghcr.io/takodata/tako-mcp:latest
+  ports:
+    - "8001:8001"
+  environment:
+    PUBLIC_BASE_URL: https://tako.com
+
+# Installation methods
+installation:
+  pip:
+    package: tako-mcp
+    command: tako-mcp
+  docker:
+    image: ghcr.io/takodata/tako-mcp:latest
+
+# Tool summary for marketplace listing
+tools:
+  - name: knowledge_search
+    description: Search charts and data visualizations on any topic
+  - name: explore_knowledge_graph
+    description: Discover available entities, metrics, and cohorts
+  - name: get_chart_image
+    description: Get static PNG preview of a chart
+  - name: get_card_insights
+    description: Get AI-generated chart analysis
+  - name: list_chart_schemas
+    description: List available chart templates
+  - name: get_chart_schema
+    description: Get chart type data format details
+  - name: create_chart
+    description: Create new chart from raw data
+  - name: open_chart_ui
+    description: Open interactive chart via MCP-UI
+
+# Screenshots / examples for marketplace
+examples:
+  - title: Search for Charts
+    description: Find existing visualizations on any topic
+    input: |
+      {"query": "US GDP growth rate", "api_token": "your-token"}
+  - title: Create a Bar Chart
+    description: Create a custom bar chart from your data
+    input: |
+      {
+        "schema_name": "bar_chart",
+        "api_token": "your-token",
+        "components": [
+          {"component_type": "header", "config": {"title": "Revenue by Region"}},
+          {"component_type": "categorical_bar", "config": {"datasets": [{"label": "Revenue", "data": [{"x": "NA", "y": 120}, {"x": "EU", "y": 98}], "units": "$M"}]}}
+        ]
+      }
+
+# Links
+links:
+  homepage: https://tako.com
+  documentation: https://github.com/TakoData/tako-mcp#readme
+  api_reference: https://tako.com/docs/
+  changelog: https://github.com/TakoData/tako-mcp/releases

--- a/src/tako_mcp/server.py
+++ b/src/tako_mcp/server.py
@@ -6,6 +6,7 @@ Exposes Tako's knowledge base and interactive charts via the Model Context Proto
 This server allows AI agents to:
 - Search for relevant charts and datasets
 - Fetch chart preview images and AI-generated insights
+- Create custom charts from raw data using 15+ chart types
 - Render fully interactive Tako visualizations via MCP-UI
 """
 
@@ -32,8 +33,13 @@ logging.getLogger("uvicorn.error").setLevel(logging.WARNING)
 logging.getLogger("starlette.middleware").setLevel(logging.WARNING)
 
 # Configuration from environment
-TAKO_API_URL = os.environ.get("TAKO_API_URL", "https://api.trytako.com").rstrip("/")
-PUBLIC_BASE_URL = os.environ.get("PUBLIC_BASE_URL", "https://trytako.com").rstrip("/")
+TAKO_API_URL = os.environ.get("TAKO_API_URL", "https://api.tako.com").rstrip("/")
+PUBLIC_BASE_URL = os.environ.get("PUBLIC_BASE_URL", "https://tako.com").rstrip("/")
+# Public-facing API URL for external consumers (image URLs, etc.)
+# Falls back to TAKO_API_URL if not set separately
+PUBLIC_API_URL = os.environ.get("PUBLIC_API_URL", TAKO_API_URL).rstrip("/")
+
+SERVER_VERSION = "0.1.0"
 
 # Build allowed hosts list for DNS rebinding protection
 allowed_hosts_list = [
@@ -56,7 +62,7 @@ mcp = FastMCP(
         allowed_hosts=allowed_hosts_list,
         allowed_origins=[
             "http://localhost:*",
-            "https://trytako.com",
+            "https://tako.com",
         ],
     ),
 )
@@ -70,7 +76,12 @@ def _get_auth_header(api_token: str | None) -> dict:
     return headers
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Search Charts",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": False,
+})
 async def knowledge_search(
     query: str,
     api_token: str,
@@ -80,10 +91,14 @@ async def knowledge_search(
     locale: str = "en-US",
 ) -> str:
     """
-    Search Tako's knowledge base for charts and data visualizations.
+    Use this when you need to find existing charts and data visualizations on any topic.
+    This searches Tako's curated knowledge base of charts covering economics, finance,
+    demographics, technology, and more. Start here when a user asks about data trends,
+    comparisons, or statistics — Tako likely already has a relevant visualization.
 
     Args:
-        query: Natural language search query for charts and data
+        query: Natural language search query for charts and data (e.g., "US GDP growth",
+            "Intel vs Nvidia revenue", "climate change temperature data")
         api_token: Your Tako API token for authentication
         count: Number of results to return (1-20), defaults to 5
         search_effort: Search depth - "fast" for quick results, "deep" for comprehensive search
@@ -91,7 +106,8 @@ async def knowledge_search(
         locale: Locale for results (e.g., "en-US", "en-GB")
 
     Returns:
-        JSON response containing matching charts with URLs, titles, descriptions, and metadata
+        JSON with matching charts including card_id, title, description, url, and source.
+        Each result includes open_ui_args for rendering the chart interactively.
     """
     start_time = time.time()
     try:
@@ -145,20 +161,37 @@ async def knowledge_search(
         return json.dumps(
             {
                 "error": "Request timed out",
-                "message": "The search request took too long. Try using search_effort='fast' for quicker results.",
+                "message": "The search request took too long.",
+                "suggestion": "Try using search_effort='fast' for quicker results, or use a more specific query.",
+            },
+            indent=2,
+        )
+    except httpx.HTTPStatusError as e:
+        return json.dumps(
+            {
+                "error": f"HTTP {e.response.status_code}",
+                "message": str(e),
+                "suggestion": "Check your API token is valid and try again.",
             },
             indent=2,
         )
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Get Chart Image",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": False,
+})
 async def get_chart_image(
     pub_id: str,
     api_token: str,
     dark_mode: bool = True,
 ) -> str:
     """
-    Get the preview image URL for a chart.
+    Use this when you need a static preview image of a chart to display or embed.
+    Returns a direct URL to a PNG image of the chart. Useful for including chart
+    previews in responses or documents.
 
     Args:
         pub_id: The unique identifier (pub_id/card_id) of the chart
@@ -166,7 +199,7 @@ async def get_chart_image(
         dark_mode: Whether to return dark mode version of the image (default: True)
 
     Returns:
-        URL to the chart's preview image that can be displayed or embedded
+        JSON with image_url (public PNG URL), pub_id, and dark_mode setting
     """
     async with httpx.AsyncClient(timeout=60.0) as client:
         resp = await client.get(
@@ -176,7 +209,7 @@ async def get_chart_image(
         )
 
         if resp.status_code == 200:
-            image_url = f"{TAKO_API_URL}/api/v1/image/{pub_id}/?dark_mode={str(dark_mode).lower()}"
+            image_url = f"{PUBLIC_API_URL}/api/v1/image/{pub_id}/?dark_mode={str(dark_mode).lower()}"
             return json.dumps(
                 {
                     "image_url": image_url,
@@ -186,32 +219,49 @@ async def get_chart_image(
                 indent=2,
             )
         elif resp.status_code == 404:
-            return json.dumps({"error": "Chart image not found", "pub_id": pub_id})
+            return json.dumps({
+                "error": "Chart image not found",
+                "pub_id": pub_id,
+                "suggestion": "Verify the pub_id/card_id is correct. Use knowledge_search to find valid chart IDs.",
+            })
         elif resp.status_code == 408:
-            return json.dumps(
-                {"error": "Image generation timed out, try again", "pub_id": pub_id}
-            )
+            return json.dumps({
+                "error": "Image generation timed out",
+                "pub_id": pub_id,
+                "suggestion": "The image is still rendering. Wait a few seconds and try again.",
+            })
         else:
             resp.raise_for_status()
-            return json.dumps({"error": "Unexpected error"})
+            return json.dumps({
+                "error": "Unexpected error",
+                "suggestion": "Check your API token and try again. If the issue persists, the Tako API may be temporarily unavailable.",
+            })
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Get AI Insights",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": False,
+})
 async def get_card_insights(
     pub_id: str,
     api_token: str,
     effort: str = "medium",
 ) -> str:
     """
-    Get AI-generated insights for a chart.
+    Use this when you want AI-generated analysis of a chart's data. Returns bullet-point
+    insights and a natural language description that summarizes trends, outliers, and key
+    takeaways from the chart.
 
     Args:
         pub_id: The unique identifier (pub_id/card_id) of the chart
         api_token: Your Tako API token for authentication
-        effort: Reasoning effort level - "low", "medium", or "high" (default: "medium")
+        effort: Reasoning effort level - "low" for quick summary, "medium" for balanced
+            analysis, "high" for deep analysis (default: "medium")
 
     Returns:
-        JSON with bullet-point insights and a description analyzing the chart's data
+        JSON with pub_id, insights (bullet-point analysis), and description (narrative summary)
     """
     async with httpx.AsyncClient(timeout=90.0) as client:
         resp = await client.get(
@@ -221,7 +271,11 @@ async def get_card_insights(
         )
 
         if resp.status_code == 404:
-            return json.dumps({"error": "Chart not found", "pub_id": pub_id})
+            return json.dumps({
+                "error": "Chart not found",
+                "pub_id": pub_id,
+                "suggestion": "Verify the pub_id/card_id is correct. Use knowledge_search to find valid chart IDs.",
+            })
 
         resp.raise_for_status()
         data = resp.json()
@@ -236,7 +290,12 @@ async def get_card_insights(
         )
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Explore Knowledge Graph",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": False,
+})
 async def explore_knowledge_graph(
     query: str,
     api_token: str,
@@ -244,16 +303,14 @@ async def explore_knowledge_graph(
     limit: int = 20,
 ) -> str:
     """
-    Explore Tako's knowledge graph to discover available entities, metrics, cohorts, and other data.
-
-    Use this tool to:
-    - Find what entities are available (companies, countries, people, etc.)
-    - Discover metrics and measurements that can be queried
-    - Check which data is available before constructing a search query
-    - Disambiguate ambiguous entity names (e.g., "Apple" could be the company or the fruit)
+    Use this when you need to discover what data is available before searching.
+    Helps find entities (companies, countries), metrics (revenue, GDP), cohorts
+    (S&P 500, G7), and time periods. Use this to disambiguate queries or understand
+    what data Tako has before calling knowledge_search.
 
     Args:
-        query: Natural language query to explore the knowledge graph (e.g., "tech companies", "GDP metrics")
+        query: Natural language query to explore (e.g., "tech companies", "GDP metrics",
+            "automotive industry")
         api_token: Your Tako API token for authentication
         node_types: Optional filter for specific node types. Can include:
             - "entity": Companies, countries, people, organizations
@@ -266,7 +323,7 @@ async def explore_knowledge_graph(
         limit: Maximum number of results per type (1-50), defaults to 20
 
     Returns:
-        JSON response with discovered entities, metrics, cohorts, and time periods
+        JSON with entities, metrics, cohorts, time_periods, and total_matches
     """
     start_time = time.time()
     try:
@@ -338,7 +395,8 @@ async def explore_knowledge_graph(
         return json.dumps(
             {
                 "error": "Request timed out",
-                "message": "The explore request took too long. Try a more specific query.",
+                "message": "The explore request took too long.",
+                "suggestion": "Try a more specific query or filter by node_types to narrow results.",
             },
             indent=2,
         )
@@ -347,6 +405,7 @@ async def explore_knowledge_graph(
             {
                 "error": f"HTTP {e.response.status_code}",
                 "message": str(e),
+                "suggestion": "Check your API token is valid and try again.",
             },
             indent=2,
         )
@@ -356,6 +415,7 @@ async def explore_knowledge_graph(
             {
                 "error": "Unexpected error",
                 "message": str(e),
+                "suggestion": "Check your API token and try again. If the issue persists, the Tako API may be temporarily unavailable.",
             },
             indent=2,
         )
@@ -366,58 +426,84 @@ async def explore_knowledge_graph(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: List Chart Types",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": False,
+})
 async def list_chart_schemas(
     api_token: str,
 ) -> str:
     """
-    List available chart schemas (templates) for creating visualizations.
+    Use this when you want to see all available chart templates before creating a custom
+    chart. Returns the full list of ThinViz schemas including timeseries, bar charts, pie
+    charts, scatter plots, maps, and more. Call this first when the user wants to create
+    a new visualization.
 
-    ThinViz schemas are pre-configured templates that simplify chart creation.
-    Each schema defines what components are needed (e.g., timeseries, bar chart, header).
+    Available schemas include: stock_card, timeseries_card, bar_chart, grouped_bar_chart,
+    data_table_chart, histogram, pie_chart, table, header, financial_boxes, choropleth,
+    treemap, heatmap, boxplot, waterfall, scatter_chart, bubble_chart.
 
     Args:
         api_token: Your Tako API token for authentication
 
     Returns:
-        JSON list of available schemas with their names, descriptions, and required components
+        JSON with schemas array (name, description, components) and count
     """
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.get(
-            f"{TAKO_API_URL}/api/v1/thin_viz/default_schema/",
-            headers=_get_auth_header(api_token),
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(
+                f"{TAKO_API_URL}/api/v1/thin_viz/default_schema/",
+                headers=_get_auth_header(api_token),
+            )
+            resp.raise_for_status()
+            schemas = resp.json()
+
+            # Simplify response for readability
+            result = []
+            for schema in schemas:
+                result.append({
+                    "name": schema.get("name"),
+                    "description": schema.get("description"),
+                    "components": schema.get("components", []),
+                })
+
+            return json.dumps({"schemas": result, "count": len(result)}, indent=2)
+    except httpx.HTTPStatusError as e:
+        return json.dumps(
+            {
+                "error": f"HTTP {e.response.status_code}",
+                "message": str(e),
+                "suggestion": "Check your API token is valid and try again.",
+            },
+            indent=2,
         )
-        resp.raise_for_status()
-        schemas = resp.json()
-
-        # Simplify response for readability
-        result = []
-        for schema in schemas:
-            result.append({
-                "name": schema.get("name"),
-                "description": schema.get("description"),
-                "components": schema.get("components", []),
-            })
-
-        return json.dumps({"schemas": result, "count": len(result)}, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Get Chart Schema",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": False,
+})
 async def get_chart_schema(
     schema_name: str,
     api_token: str,
 ) -> str:
     """
-    Get detailed information about a chart schema including required component configurations.
-
-    Use this to understand what data format is needed before calling create_chart.
+    Use this when you need to understand the exact data format required for a specific
+    chart type. Returns the schema definition including required fields, data structure,
+    and configuration options. Always call this before create_chart to understand what
+    data is needed.
 
     Args:
-        schema_name: Name of the schema (e.g., "stock_card", "bar_chart", "grouped_bar_chart")
+        schema_name: Name of the schema (e.g., "stock_card", "bar_chart", "grouped_bar_chart",
+            "pie_chart", "scatter_chart", "choropleth", "timeseries_card")
         api_token: Your Tako API token for authentication
 
     Returns:
-        JSON with schema details including component types and their configuration options
+        JSON with schema name, description, components array, and template details
     """
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.get(
@@ -426,7 +512,10 @@ async def get_chart_schema(
         )
 
         if resp.status_code == 404:
-            return json.dumps({"error": f"Schema '{schema_name}' not found"})
+            return json.dumps({
+                "error": f"Schema '{schema_name}' not found",
+                "suggestion": "Use list_chart_schemas to see all available schema names.",
+            })
 
         resp.raise_for_status()
         schema = resp.json()
@@ -439,7 +528,12 @@ async def get_chart_schema(
         }, indent=2)
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Create Chart",
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "openWorldHint": True,
+})
 async def create_chart(
     schema_name: str,
     components: list[dict],
@@ -447,20 +541,25 @@ async def create_chart(
     source: str | None = None,
 ) -> str:
     """
-    Create a new chart using a schema template and your own data.
+    Use this when you need to create a new chart from raw data. This is the primary chart
+    creation tool — pass a schema name and your data components to generate an interactive
+    Tako visualization. The chart will be hosted and shareable. Supports 15+ chart types
+    including timeseries, bar charts, scatter plots, maps, and more.
 
-    This is the primary way to create custom visualizations with Tako.
-    Use list_chart_schemas and get_chart_schema to understand available options.
+    Workflow: call list_chart_schemas to see options, then get_chart_schema for the data
+    format, then this tool to create the chart.
 
     Args:
-        schema_name: Name of the schema to use (e.g., "stock_card", "bar_chart", "grouped_bar_chart")
+        schema_name: Name of the schema to use (e.g., "stock_card", "bar_chart",
+            "grouped_bar_chart", "pie_chart", "scatter_chart", "choropleth")
         components: List of component configurations matching the schema requirements.
             Each component needs "component_type" and "config" fields.
         api_token: Your Tako API token for authentication
         source: Optional attribution text (e.g., "Yahoo Finance", "Company Reports")
 
     Returns:
-        JSON with the created chart's card_id, embed_url, image_url, and other metadata
+        JSON with card_id, title, description, webpage_url, embed_url, image_url,
+        and open_ui_args for rendering the chart interactively.
 
     Example components for "bar_chart" schema:
         [
@@ -531,12 +630,16 @@ async def create_chart(
             )
 
             if resp.status_code == 404:
-                return json.dumps({"error": f"Schema '{schema_name}' not found"})
+                return json.dumps({
+                    "error": f"Schema '{schema_name}' not found",
+                    "suggestion": "Use list_chart_schemas to see all available schema names.",
+                })
             if resp.status_code == 400:
                 error_data = resp.json()
                 return json.dumps({
                     "error": "Invalid component configuration",
                     "details": error_data,
+                    "suggestion": "Use get_chart_schema to see the required data format for this schema.",
                 })
 
             resp.raise_for_status()
@@ -563,12 +666,14 @@ async def create_chart(
         return json.dumps({
             "error": f"HTTP {e.response.status_code}",
             "message": str(e),
+            "suggestion": "Check your API token and component configuration. Use get_chart_schema to verify the expected format.",
         }, indent=2)
     except Exception as e:
         logging.error(f"create_chart error: {e}", exc_info=True)
         return json.dumps({
             "error": "Unexpected error",
             "message": str(e),
+            "suggestion": "Check your API token and try again. If the issue persists, the Tako API may be temporarily unavailable.",
         }, indent=2)
 
 
@@ -577,7 +682,12 @@ async def create_chart(
 # =============================================================================
 
 
-@mcp.tool()
+@mcp.tool(annotations={
+    "title": "Tako: Open Interactive Chart",
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "openWorldHint": True,
+})
 async def open_chart_ui(
     pub_id: str,
     dark_mode: bool = True,
@@ -585,10 +695,10 @@ async def open_chart_ui(
     height: int = 600,
 ) -> list[UIResource]:
     """
-    Open an interactive chart in the UI.
-
-    Returns an MCP-UI resource that renders a fully interactive Tako chart
-    with zooming, filtering, hover interactions, and responsive resizing.
+    Use this when you want to display a fully interactive chart to the user.
+    Returns an MCP-UI resource that renders the chart with zooming, panning, hover
+    interactions, and responsive resizing. Prefer this over get_chart_image when
+    the user wants to explore the data interactively.
 
     Args:
         pub_id: The unique identifier (pub_id/card_id) of the chart
@@ -677,8 +787,82 @@ async def open_chart_ui(
     return [ui_resource]
 
 
+# =============================================================================
 # ASGI application setup
+# =============================================================================
+
 _mcp_app = mcp.sse_app()
+
+# MCP Server Card (SEP-1649) for /.well-known/mcp
+_SERVER_CARD = {
+    "protocolVersion": "2025-06-18",
+    "serverInfo": {
+        "name": "tako-mcp",
+        "title": "Tako MCP Server",
+        "version": SERVER_VERSION,
+        "description": (
+            "Create and discover data visualizations. Search Tako's knowledge base of "
+            "charts covering economics, finance, demographics, technology, and more. "
+            "Create custom charts from raw data using 15+ chart types including timeseries, "
+            "bar charts, scatter plots, maps, and more."
+        ),
+        "iconUrl": "https://tako.com/favicon.ico",
+        "documentationUrl": "https://github.com/TakoData/tako-mcp",
+    },
+    "transport": {
+        "type": "sse",
+        "endpoint": "/sse",
+    },
+    "capabilities": {
+        "tools": {"listChanged": True},
+    },
+    "authentication": {
+        "required": True,
+        "schemes": ["bearer"],
+    },
+    "tools": [
+        {
+            "name": "knowledge_search",
+            "description": "Search Tako's knowledge base for charts and data visualizations on any topic.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+        },
+        {
+            "name": "explore_knowledge_graph",
+            "description": "Discover available entities, metrics, cohorts, and time periods in Tako's knowledge graph.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+        },
+        {
+            "name": "get_chart_image",
+            "description": "Get a static PNG preview image URL for a chart.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+        },
+        {
+            "name": "get_card_insights",
+            "description": "Get AI-generated analysis and insights for a chart.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+        },
+        {
+            "name": "list_chart_schemas",
+            "description": "List all available chart templates for creating custom visualizations.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+        },
+        {
+            "name": "get_chart_schema",
+            "description": "Get the detailed schema and data format for a specific chart type.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+        },
+        {
+            "name": "create_chart",
+            "description": "Create a new interactive chart from raw data using 15+ chart types.",
+            "annotations": {"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True},
+        },
+        {
+            "name": "open_chart_ui",
+            "description": "Open a fully interactive chart with zooming, panning, and hover interactions.",
+            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": True},
+        },
+    ],
+}
 
 
 def _wrap_send(send, response_started_ref=None):
@@ -720,9 +904,16 @@ async def app(scope, receive, send):
             health_data = {
                 "status": "ok",
                 "service": "tako-mcp-server",
+                "version": SERVER_VERSION,
                 "timestamp": time.time(),
             }
             response = JSONResponse(health_data)
+            wrapped_send = _wrap_send(send, response_started)
+            await response(scope, receive, wrapped_send)
+            return
+
+        if scope["path"] == "/.well-known/mcp":
+            response = JSONResponse(_SERVER_CARD)
             wrapped_send = _wrap_send(send, response_started)
             await response(scope, receive, wrapped_send)
             return


### PR DESCRIPTION
…es, and registry configs

Phase 1 of the MCP discoverability plan to make Tako a first-class, discoverable tool in the AI agent ecosystem.

server.py enhancements:
- Add MCP tool annotations (title, readOnlyHint, destructiveHint, openWorldHint) to all 8 tools per the June 2025 MCP spec
- Rewrite all tool descriptions to be agent-optimized ("Use this when...")
- Fix get_chart_image URL bug: use PUBLIC_API_URL env var so external consumers get reachable URLs instead of internal TAKO_API_URL addresses
- Add consistent "suggestion" key to all error responses with actionable next steps
- Add /.well-known/mcp endpoint returning a MCP Server Card (SEP-1649) with protocol version, server info, transport, capabilities, auth, and tool manifest

New discovery files:
- llms.txt / llms-full.txt: LLM-readable content maps (llms.txt standard)
- agent.json: A2A Agent Card for Google's Agent-to-Agent protocol
- AGENTS.md: AI coding agent guide for contributors
- docker-compose.yml: Standalone Docker Compose for easy local setup
- registry/server.json: MCP Registry submission manifest
- registry/smithery.yaml: Smithery marketplace listing config

All user-facing docs point to hosted server at mcp.tako.com/sse.