### PR TITLE
Mcp discoverability phase2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ python -m tests.test_client --api-token YOUR_TOKEN
 
 | Path | Method | Description |
 |------|--------|-------------|
+| `/mcp` | POST | Streamable HTTP transport (recommended) |
 | `/sse` | GET | SSE transport connection |
-| `/messages/` | POST | MCP JSON-RPC messages |
+| `/messages/` | POST | SSE JSON-RPC messages |
 | `/health` | GET | Simple health check |
 | `/health/detailed` | GET | Detailed health status |
 | `/.well-known/mcp` | GET | MCP Server Card (SEP-1649) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,15 @@ python -m tests.test_client --api-token YOUR_TOKEN
 
 | File | Purpose |
 |------|---------|
-| `src/tako_mcp/server.py` | Main MCP server — ASGI app, 8 tool definitions, health endpoints |
+| `src/tako_mcp/server.py` | Main MCP server — ASGI app, 8 tools, OAuth 2.1, discovery endpoints |
 | `src/tako_mcp/main.py` | Alternative implementation using Tako Python client (not the primary server) |
 | `src/tako_mcp/smithery/server.py` | Smithery marketplace integration wrapper |
+| `integrations/langchain_tako.py` | LangChain/LangGraph tool wrapper |
+| `integrations/crewai_tako.py` | CrewAI tool wrapper |
+| `integrations/autogen_tako.py` | AutoGen (Microsoft) tool wrapper |
+| `integrations/vercel_ai_tako.ts` | Vercel AI SDK tool wrapper |
+| `integrations/openai_actions.yaml` | OpenAI GPT Actions spec |
+| `openapi.yaml` | OpenAPI 3.1.0 spec with agent hints |
 | `tests/test_client.py` | Integration test client |
 | `Dockerfile` | Container build (Python 3.11-slim, port 8001) |
 
@@ -60,13 +66,19 @@ python -m tests.test_client --api-token YOUR_TOKEN
 | `/health` | GET | Simple health check |
 | `/health/detailed` | GET | Detailed health status |
 | `/.well-known/mcp` | GET | MCP Server Card (SEP-1649) |
+| `/v1/tools` | GET | Agent-friendly tool descriptions |
+| `/.well-known/oauth-authorization-server` | GET | OAuth 2.1 metadata |
+| `/oauth/register` | POST | Dynamic client registration |
+| `/oauth/authorize` | GET | Authorization endpoint |
+| `/oauth/token` | POST | Token exchange endpoint |
 
 ## Code Conventions
 
 - Python 3.11+, async/await throughout
 - Ruff for linting (line length 100, rules: E, F, I, N, W, UP)
 - All tool functions are async, decorated with `@mcp.tool()`
-- Error responses return JSON with `error`, `message`, and `suggestion` keys
+- Tools return Pydantic models for structured output (`structuredContent`)
+- Errors raised as `TakoToolError` exceptions (converted to MCP error responses)
 - Timeouts: 30s for schema ops, 60s for search/create, 90s for insights
 - Environment variables for configuration (see README)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ COPY src/ src/
 EXPOSE 8001
 
 # Environment variables (override at runtime)
-ENV TAKO_API_URL=https://api.trytako.com
-ENV PUBLIC_BASE_URL=https://trytako.com
+ENV PUBLIC_BASE_URL=https://tako.com
 ENV PORT=8001
 ENV HOST=0.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,137 +1,61 @@
 # Tako MCP Server
 
-An MCP (Model Context Protocol) server that provides access to Tako's knowledge base and interactive data visualizations.
+[![MCP](https://img.shields.io/badge/MCP-Compatible-blue)](https://modelcontextprotocol.io)
+[![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## What is this?
+An MCP server that gives AI agents the ability to search, create, and interact with data visualizations via [Tako](https://tako.com).
 
-This MCP server enables AI agents to:
+## Connect
 
-- **Search** Tako's knowledge base for charts and data visualizations
-- **Fetch** chart preview images and AI-generated insights
-- **Render** fully interactive Tako charts via MCP-UI
+Point your MCP client to the hosted server:
 
-## Installation
-
-```bash
-pip install tako-mcp
+```
+https://mcp.tako.com/sse
 ```
 
-Or install from source:
+### Claude Desktop
 
-```bash
-git clone https://github.com/anthropics/tako-mcp.git
-cd tako-mcp
-pip install -e .
-```
-
-## Quick Start
-
-### Get an API Token
-
-Sign up at [trytako.com](https://trytako.com) and create an API token in your account settings.
-
-### Run the Server
-
-```bash
-tako-mcp
-```
-
-Or with Docker:
-
-```bash
-docker build -t tako-mcp .
-docker run -p 8001:8001 tako-mcp
-```
-
-### Connect Your Agent
-
-Point your MCP client to `http://localhost:8001`.
-
-## Available Tools
-
-### `knowledge_search`
-
-Search Tako's knowledge base for charts and data visualizations.
+Add to `claude_desktop_config.json`:
 
 ```json
 {
-  "query": "Intel vs Nvidia headcount",
-  "api_token": "your-api-token",
-  "count": 5,
-  "search_effort": "deep"
+  "mcpServers": {
+    "tako": {
+      "url": "https://mcp.tako.com/sse"
+    }
+  }
 }
 ```
 
-Returns matching charts with IDs, titles, descriptions, and URLs.
+### Cursor
 
-### `get_chart_image`
-
-Get a preview image URL for a chart.
+Add to `.cursor/mcp.json`:
 
 ```json
 {
-  "pub_id": "chart-id",
-  "api_token": "your-api-token",
-  "dark_mode": true
+  "mcpServers": {
+    "tako": {
+      "url": "https://mcp.tako.com/sse"
+    }
+  }
 }
 ```
 
-### `get_card_insights`
+## Tools
 
-Get AI-generated insights for a chart.
+| Tool | Description |
+|------|-------------|
+| `knowledge_search` | Search 100K+ curated charts on any topic |
+| `explore_knowledge_graph` | Discover available entities, metrics, and cohorts |
+| `get_chart_image` | Get a static PNG preview of a chart |
+| `get_card_insights` | Get AI-generated analysis of a chart |
+| `list_chart_schemas` | List available chart templates (15+ types) |
+| `get_chart_schema` | Get the data format for a chart type |
+| `create_chart` | Create a new chart from raw data |
+| `open_chart_ui` | Render an interactive chart via MCP-UI |
 
-```json
-{
-  "pub_id": "chart-id",
-  "api_token": "your-api-token",
-  "effort": "medium"
-}
-```
-
-Returns bullet-point insights and a natural language description.
-
-### `explore_knowledge_graph`
-
-Discover available entities, metrics, and cohorts.
-
-```json
-{
-  "query": "tech companies",
-  "api_token": "your-api-token",
-  "limit": 20
-}
-```
-
-## ThinViz API - Create Custom Charts
-
-ThinViz lets you create charts with your own data using pre-configured templates.
-
-### `list_chart_schemas`
-
-List available chart templates.
-
-```json
-{
-  "api_token": "your-api-token"
-}
-```
-
-Returns schemas like `stock_card`, `bar_chart`, `grouped_bar_chart`.
-
-### `get_chart_schema`
-
-Get detailed info about a schema including required components.
-
-```json
-{
-  "schema_name": "bar_chart",
-  "api_token": "your-api-token"
-}
-```
-
-### `create_chart`
-
-Create a chart from a template with your data.
+## Example: Create a Bar Chart
 
 ```json
 {
@@ -141,10 +65,7 @@ Create a chart from a template with your data.
   "components": [
     {
       "component_type": "header",
-      "config": {
-        "title": "Revenue by Region",
-        "subtitle": "Q4 2024"
-      }
+      "config": { "title": "Revenue by Region", "subtitle": "Q4 2024" }
     },
     {
       "component_type": "categorical_bar",
@@ -165,94 +86,87 @@ Create a chart from a template with your data.
 }
 ```
 
-Returns the new chart's `card_id`, `embed_url`, and `image_url`.
+## Chart Types
 
-## MCP-UI - Interactive Charts
+| Type | Schema | Use Case |
+|------|--------|----------|
+| Line/Area | `timeseries_card` | Trends over time |
+| Stock | `stock_card` | Financial data with ticker boxes |
+| Bar | `bar_chart` | Categorical comparisons |
+| Grouped Bar | `grouped_bar_chart` | Multi-series comparisons |
+| Pie | `pie_chart` | Proportional data |
+| Scatter | `scatter_chart` | 2-variable correlations |
+| Bubble | `bubble_chart` | 3-variable data |
+| Histogram | `histogram` | Frequency distributions |
+| Box Plot | `boxplot` | Statistical distributions |
+| Map | `choropleth` | Geographic data (US/World) |
+| Treemap | `treemap` | Hierarchical data |
+| Heatmap | `heatmap` | 2D matrices |
+| Waterfall | `waterfall` | Sequential changes |
+| KPI Boxes | `financial_boxes` | Key metrics |
+| Table | `table` | Tabular data |
 
-### `open_chart_ui`
+## Architecture
 
-Open an interactive chart in the UI (MCP-UI).
-
-```json
-{
-  "pub_id": "chart-id",
-  "dark_mode": true,
-  "width": 900,
-  "height": 600
-}
+```
+AI Agent (Claude, Cursor, LangGraph, etc.)
+    |
+  MCP Protocol (SSE or Streamable HTTP)
+    |
+Tako MCP Server (port 8001)
+    |
+Tako API
 ```
 
-Returns a UIResource for rendering an interactive iframe.
+### Transports
 
-## Configuration
+| Transport | Endpoint | Status |
+|-----------|----------|--------|
+| SSE | `/sse` | Supported |
+| Streamable HTTP | `/mcp` | Supported |
 
-Environment variables:
+### Discovery Endpoints
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `TAKO_API_URL` | Tako API endpoint | `https://api.trytako.com` |
-| `PUBLIC_BASE_URL` | Public URL for chart embeds | `https://trytako.com` |
-| `PORT` | Server port | `8001` |
-| `HOST` | Server host | `0.0.0.0` |
-| `MCP_ALLOWED_HOSTS` | Additional allowed hosts (comma-separated) | |
-| `MCP_ENABLE_DNS_REBINDING` | Enable DNS rebinding protection | `true` |
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Health check |
+| `GET /health/detailed` | Detailed status with version |
+| `GET /.well-known/mcp` | MCP Server Card (SEP-1649) |
 
-## Testing
+## Authentication
 
-Run the test client:
+All tool calls require a Tako API token passed as the `api_token` parameter. Get your token at [tako.com](https://tako.com) in account settings.
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+tako-mcp
+```
+
+Or with Docker:
+
+```bash
+docker compose up
+```
+
+### Testing
 
 ```bash
 python -m tests.test_client --api-token YOUR_API_TOKEN
 ```
 
-This verifies:
-- MCP handshake and initialization
-- Tool discovery
-- Search, images, and insights
-- MCP-UI resource generation
+### Configuration
 
-## Example Flow
-
-1. User asks: "Show me a chart about Intel vs Nvidia headcount"
-2. Agent calls `knowledge_search` with the query
-3. Agent receives chart results with IDs
-4. Agent can:
-   - Call `get_card_insights` to summarize the data
-   - Call `get_chart_image` for a preview
-   - Call `open_chart_ui` to render an interactive chart
-
-## Health Checks
-
-- `GET /health` - Simple "ok" response
-- `GET /health/detailed` - JSON with status and timestamp
-
-## Architecture
-
-```
-AI Agent (LangGraph, CopilotKit, etc.)
-    ↓
-  MCP Protocol (SSE)
-    ↓
-Tako MCP Server
-    ↓
-Tako API
-```
-
-The server acts as a thin proxy that:
-1. Authenticates requests with your API token
-2. Translates MCP tool calls to Tako API requests
-3. Returns formatted results and UI resources
-
-## MCP-UI Support
-
-The `open_chart_ui` tool returns an MCP-UI resource that clients can render as an interactive iframe. The embedded chart supports:
-
-- Zooming and panning
-- Hover interactions
-- Responsive resizing via `postMessage`
-- Light and dark themes
-
-Clients that support MCP-UI (like CopilotKit) will automatically render these resources.
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TAKO_API_URL` | Tako API endpoint | Required |
+| `PUBLIC_BASE_URL` | Public URL for chart embeds | `https://tako.com` |
+| `PUBLIC_API_URL` | Public API URL for image URLs | Falls back to `TAKO_API_URL` |
+| `PORT` | Server port | `8001` |
+| `HOST` | Server host | `0.0.0.0` |
+| `MCP_ALLOWED_HOSTS` | Additional allowed hosts (comma-separated) | |
+| `MCP_ENABLE_DNS_REBINDING` | Enable DNS rebinding protection | `true` |
 
 ## License
 
@@ -260,6 +174,6 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Links
 
-- [Tako](https://trytako.com) - Data visualization platform
-- [MCP Specification](https://spec.modelcontextprotocol.io/) - Model Context Protocol
-- [MCP-UI](https://mcpui.dev/) - MCP UI rendering standard
+- [Tako](https://tako.com)
+- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [MCP-UI](https://mcpui.dev/)

--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Tako integrations for popular AI/ML frameworks (CrewAI, AutoGen, Vercel AI SDK, etc.)."""

--- a/integrations/autogen_tako.py
+++ b/integrations/autogen_tako.py
@@ -1,0 +1,553 @@
+"""
+Tako integration for Microsoft AutoGen.
+
+Provides AutoGen-compatible function definitions that wrap the Tako API,
+enabling agents in AutoGen multi-agent conversations to search for charts,
+create visualisations, list chart schemas, retrieve AI-generated insights,
+and fetch chart images.
+
+Usage:
+    import autogen
+    from integrations.autogen_tako import register_tako_tools
+
+    assistant = autogen.AssistantAgent("analyst", llm_config=llm_config)
+    register_tako_tools(assistant, api_token="your-tako-api-token")
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+try:
+    import autogen  # noqa: F401 – validate availability
+except ImportError:
+    raise ImportError(
+        "AutoGen is required for this integration. "
+        "Install it with: pip install pyautogen"
+    )
+
+try:
+    import httpx
+except ImportError:
+    raise ImportError(
+        "httpx is required for this integration. "
+        "Install it with: pip install httpx"
+    )
+
+DEFAULT_API_URL = "https://api.tako.com"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _headers(api_token: str) -> dict[str, str]:
+    """Build request headers with Tako API authentication."""
+    return {
+        "Content-Type": "application/json",
+        "X-API-Key": api_token,
+    }
+
+
+def _error_response(error: str, message: str, suggestion: str) -> str:
+    """Return a standardised JSON error string."""
+    return json.dumps(
+        {"error": error, "message": message, "suggestion": suggestion},
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Function definitions for AutoGen function_map
+# ---------------------------------------------------------------------------
+
+# Each factory returns a callable with the correct signature.  The api_token
+# and api_url are captured via closure so that they never need to be passed
+# by the LLM at call time.
+
+
+def _make_search_charts(api_token: str, api_url: str):
+    """Create the search_charts function bound to credentials."""
+
+    def search_charts(
+        query: str,
+        count: int = 5,
+        search_effort: str = "deep",
+        country_code: str = "US",
+        locale: str = "en-US",
+    ) -> str:
+        """Search Tako's knowledge base for charts and data visualisations.
+
+        Use this when you need to find existing charts and data visualisations on
+        any topic.  Searches Tako's curated knowledge base covering economics,
+        finance, demographics, technology, and more.
+
+        Args:
+            query: Natural language search query (e.g. "US GDP growth").
+            count: Number of results to return (1-20).
+            search_effort: "fast" or "deep".
+            country_code: ISO country code (e.g. "US").
+            locale: Locale string (e.g. "en-US").
+
+        Returns:
+            JSON string with matching chart results.
+        """
+        try:
+            with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+                resp = client.post(
+                    f"{api_url.rstrip('/')}/api/v1/knowledge_search",
+                    json={
+                        "inputs": {"text": query, "count": count},
+                        "source_indexes": ["tako"],
+                        "search_effort": search_effort,
+                        "country_code": country_code,
+                        "locale": locale,
+                    },
+                    headers=_headers(api_token),
+                )
+                resp.raise_for_status()
+
+                data = resp.json()
+                cards = data.get("outputs", {}).get("knowledge_cards", [])
+                results = [
+                    {
+                        "card_id": c.get("card_id"),
+                        "title": c.get("title"),
+                        "description": c.get("description"),
+                        "url": c.get("url"),
+                        "source": c.get("source"),
+                    }
+                    for c in cards
+                ]
+                return json.dumps({"results": results, "count": len(results)}, indent=2)
+
+        except httpx.TimeoutException:
+            return _error_response(
+                "Request timed out",
+                "The search request took too long.",
+                "Try search_effort='fast' or a more specific query.",
+            )
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+    return search_charts
+
+
+def _make_create_chart(api_token: str, api_url: str):
+    """Create the create_chart function bound to credentials."""
+
+    def create_chart(
+        schema_name: str,
+        components: list[dict[str, Any]],
+        source: Optional[str] = None,
+    ) -> str:
+        """Create a new chart on Tako from raw data.
+
+        Use this when you need to create a new interactive visualisation. Supports
+        15+ chart types. Call list_chart_schemas first to discover available types.
+
+        Args:
+            schema_name: Chart schema name (e.g. "bar_chart", "timeseries_card").
+            components: List of component dicts with "component_type" and "config".
+            source: Optional attribution text (e.g. "Yahoo Finance").
+
+        Returns:
+            JSON string with card_id, title, URLs, etc.
+        """
+        try:
+            payload: dict[str, Any] = {"components": components}
+            if source:
+                payload["source"] = source
+
+            with httpx.Client(timeout=60.0) as client:
+                resp = client.post(
+                    f"{api_url.rstrip('/')}/api/v1/thin_viz/default_schema/{schema_name}/create/",
+                    json=payload,
+                    headers=_headers(api_token),
+                )
+
+                if resp.status_code == 404:
+                    return json.dumps({
+                        "error": f"Schema '{schema_name}' not found",
+                        "suggestion": "Use list_chart_schemas to see available names.",
+                    })
+                if resp.status_code == 400:
+                    return json.dumps({
+                        "error": "Invalid component configuration",
+                        "details": resp.json(),
+                        "suggestion": "Check component structure against the schema.",
+                    })
+
+                resp.raise_for_status()
+                data = resp.json()
+                return json.dumps(
+                    {
+                        "card_id": data.get("card_id"),
+                        "title": data.get("title"),
+                        "description": data.get("description"),
+                        "webpage_url": data.get("webpage_url"),
+                        "embed_url": data.get("embed_url"),
+                        "image_url": data.get("image_url"),
+                    },
+                    indent=2,
+                )
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token and component configuration.",
+            )
+
+    return create_chart
+
+
+def _make_list_chart_schemas(api_token: str, api_url: str):
+    """Create the list_chart_schemas function bound to credentials."""
+
+    def list_chart_schemas() -> str:
+        """List all available chart schemas (templates) on Tako.
+
+        Use this when you want to see available chart types before creating a
+        chart. Returns schema names, descriptions, and component info.
+
+        Returns:
+            JSON string with available schemas.
+        """
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                resp = client.get(
+                    f"{api_url.rstrip('/')}/api/v1/thin_viz/default_schema/",
+                    headers=_headers(api_token),
+                )
+                resp.raise_for_status()
+                schemas = resp.json()
+                result = [
+                    {
+                        "name": s.get("name"),
+                        "description": s.get("description"),
+                        "components": s.get("components", []),
+                    }
+                    for s in schemas
+                ]
+                return json.dumps({"schemas": result, "count": len(result)}, indent=2)
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+    return list_chart_schemas
+
+
+def _make_get_chart_insights(api_token: str, api_url: str):
+    """Create the get_chart_insights function bound to credentials."""
+
+    def get_chart_insights(
+        pub_id: str,
+        effort: str = "medium",
+    ) -> str:
+        """Get AI-generated insights for a Tako chart.
+
+        Use this when you want analysis of a chart's data. Returns bullet-point
+        insights and a natural language description summarising trends and
+        key takeaways.
+
+        Args:
+            pub_id: The chart's unique identifier (pub_id / card_id).
+            effort: Reasoning depth - "low", "medium", or "high".
+
+        Returns:
+            JSON string with insights and description.
+        """
+        try:
+            with httpx.Client(timeout=90.0) as client:
+                resp = client.get(
+                    f"{api_url.rstrip('/')}/api/v1/internal/chart-configs/{pub_id}/chart-insights/",
+                    params={"effort": effort},
+                    headers=_headers(api_token),
+                )
+
+                if resp.status_code == 404:
+                    return json.dumps({
+                        "error": "Chart not found",
+                        "pub_id": pub_id,
+                        "suggestion": "Verify the pub_id/card_id is correct.",
+                    })
+
+                resp.raise_for_status()
+                data = resp.json()
+                return json.dumps(
+                    {
+                        "pub_id": pub_id,
+                        "insights": data.get("insights", ""),
+                        "description": data.get("description", ""),
+                    },
+                    indent=2,
+                )
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token and pub_id, then try again.",
+            )
+
+    return get_chart_insights
+
+
+def _make_get_chart_image(api_token: str, api_url: str):
+    """Create the get_chart_image function bound to credentials."""
+
+    def get_chart_image(
+        pub_id: str,
+        dark_mode: bool = True,
+    ) -> str:
+        """Get a static PNG preview image URL for a Tako chart.
+
+        Use this when you need a chart image to display or embed in a document.
+
+        Args:
+            pub_id: The chart's unique identifier (pub_id / card_id).
+            dark_mode: Whether to return the dark-mode version (default True).
+
+        Returns:
+            JSON string with image_url, pub_id, and dark_mode.
+        """
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                resp = client.get(
+                    f"{api_url.rstrip('/')}/api/v1/image/{pub_id}/",
+                    params={"dark_mode": str(dark_mode).lower()},
+                    headers=_headers(api_token),
+                )
+
+                if resp.status_code == 200:
+                    image_url = (
+                        f"{api_url.rstrip('/')}/api/v1/image/{pub_id}/"
+                        f"?dark_mode={str(dark_mode).lower()}"
+                    )
+                    return json.dumps(
+                        {
+                            "image_url": image_url,
+                            "pub_id": pub_id,
+                            "dark_mode": dark_mode,
+                        },
+                        indent=2,
+                    )
+                elif resp.status_code == 404:
+                    return json.dumps({
+                        "error": "Chart image not found",
+                        "pub_id": pub_id,
+                        "suggestion": "Verify the pub_id/card_id is correct.",
+                    })
+                elif resp.status_code == 408:
+                    return json.dumps({
+                        "error": "Image generation timed out",
+                        "pub_id": pub_id,
+                        "suggestion": "Wait a few seconds and try again.",
+                    })
+                else:
+                    resp.raise_for_status()
+                    return json.dumps({"error": "Unexpected error"})
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token and try again.",
+            )
+
+    return get_chart_image
+
+
+# ---------------------------------------------------------------------------
+# AutoGen function tool definitions (for register_for_llm)
+# ---------------------------------------------------------------------------
+
+TAKO_FUNCTION_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "search_charts",
+        "description": (
+            "Search Tako's knowledge base for charts and data visualisations on any "
+            "topic. Returns matching charts with titles, descriptions, and URLs."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural language search query (e.g. 'US GDP growth').",
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "Number of results (1-20). Default: 5.",
+                },
+                "search_effort": {
+                    "type": "string",
+                    "enum": ["fast", "deep"],
+                    "description": "Search depth. Default: 'deep'.",
+                },
+                "country_code": {
+                    "type": "string",
+                    "description": "ISO country code (e.g. 'US'). Default: 'US'.",
+                },
+                "locale": {
+                    "type": "string",
+                    "description": "Locale (e.g. 'en-US'). Default: 'en-US'.",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "create_chart",
+        "description": (
+            "Create a new interactive chart on Tako from raw data. Supports 15+ "
+            "chart types. Call list_chart_schemas first to see available types."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "schema_name": {
+                    "type": "string",
+                    "description": "Chart schema name (e.g. 'bar_chart', 'timeseries_card').",
+                },
+                "components": {
+                    "type": "array",
+                    "description": "Component configurations with 'component_type' and 'config'.",
+                    "items": {"type": "object"},
+                },
+                "source": {
+                    "type": "string",
+                    "description": "Optional attribution text (e.g. 'Yahoo Finance').",
+                },
+            },
+            "required": ["schema_name", "components"],
+        },
+    },
+    {
+        "name": "list_chart_schemas",
+        "description": (
+            "List all available chart schemas (templates) on Tako. Returns schema "
+            "names, descriptions, and component information."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "get_chart_insights",
+        "description": (
+            "Get AI-generated insights for a Tako chart. Returns bullet-point "
+            "analysis and a natural language description of trends and takeaways."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pub_id": {
+                    "type": "string",
+                    "description": "The chart's unique identifier (pub_id / card_id).",
+                },
+                "effort": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high"],
+                    "description": "Reasoning depth. Default: 'medium'.",
+                },
+            },
+            "required": ["pub_id"],
+        },
+    },
+    {
+        "name": "get_chart_image",
+        "description": (
+            "Get a static PNG preview image URL for a Tako chart. Useful for "
+            "embedding chart previews in responses or documents."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pub_id": {
+                    "type": "string",
+                    "description": "The chart's unique identifier (pub_id / card_id).",
+                },
+                "dark_mode": {
+                    "type": "boolean",
+                    "description": "Dark mode image. Default: true.",
+                },
+            },
+            "required": ["pub_id"],
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Registration helper
+# ---------------------------------------------------------------------------
+
+def register_tako_tools(
+    agent: Any,
+    api_token: str,
+    api_url: str = DEFAULT_API_URL,
+) -> dict[str, Any]:
+    """
+    Register Tako tools with an AutoGen agent.
+
+    This registers both the LLM-facing function definitions (so the model
+    knows how to call them) and the execution-side function_map (so AutoGen
+    can execute the calls).
+
+    Args:
+        agent: An AutoGen ConversableAgent (e.g. AssistantAgent or
+               UserProxyAgent).
+        api_token: Your Tako API token (from https://tako.com account settings).
+        api_url: Base URL for the Tako API. Defaults to https://api.tako.com.
+
+    Returns:
+        A dict mapping function names to their callables (the function_map),
+        which can also be passed to a UserProxyAgent if needed.
+
+    Example:
+        import autogen
+
+        config_list = [{"model": "gpt-4", "api_key": "..."}]
+        llm_config = {"config_list": config_list}
+
+        assistant = autogen.AssistantAgent("analyst", llm_config=llm_config)
+        user_proxy = autogen.UserProxyAgent("user", code_execution_config=False)
+
+        function_map = register_tako_tools(assistant, api_token="tak_...")
+
+        # If using a separate executor agent, register the function_map there:
+        user_proxy.register_function(function_map=function_map)
+    """
+    function_map = {
+        "search_charts": _make_search_charts(api_token, api_url),
+        "create_chart": _make_create_chart(api_token, api_url),
+        "list_chart_schemas": _make_list_chart_schemas(api_token, api_url),
+        "get_chart_insights": _make_get_chart_insights(api_token, api_url),
+        "get_chart_image": _make_get_chart_image(api_token, api_url),
+    }
+
+    # Register function definitions with the agent's LLM config so the model
+    # knows these tools are available.
+    if hasattr(agent, "llm_config") and agent.llm_config is not None:
+        functions = agent.llm_config.get("functions", [])
+        functions.extend(TAKO_FUNCTION_DEFINITIONS)
+        agent.llm_config["functions"] = functions
+
+    # Register function_map for execution.
+    if hasattr(agent, "register_function"):
+        agent.register_function(function_map=function_map)
+
+    return function_map

--- a/integrations/autogen_tako.py
+++ b/integrations/autogen_tako.py
@@ -368,6 +368,143 @@ def _make_get_chart_image(api_token: str, api_url: str):
     return get_chart_image
 
 
+def _make_explore_knowledge_graph(api_token: str, api_url: str):
+    """Create the explore_knowledge_graph function bound to credentials."""
+
+    def explore_knowledge_graph(
+        query: str,
+        node_types: Optional[list[str]] = None,
+        limit: int = 20,
+    ) -> str:
+        """Explore Tako's knowledge graph to discover available data.
+
+        Use this when you need to discover what data is available before
+        searching. Helps find entities, metrics, cohorts, and time periods.
+
+        Args:
+            query: Natural language query to explore.
+            node_types: Optional filter for node types.
+            limit: Maximum results per type (1-50).
+
+        Returns:
+            JSON string with entities, metrics, cohorts, time_periods.
+        """
+        try:
+            with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+                resp = client.post(
+                    f"{api_url.rstrip('/')}/api/v1/explore/",
+                    json={
+                        "query": query,
+                        "node_types": node_types,
+                        "limit": limit,
+                    },
+                    headers=_headers(api_token),
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                return json.dumps(
+                    {
+                        "query": data.get("query"),
+                        "total_matches": data.get("total_matches", 0),
+                        "entities": data.get("entities", []),
+                        "metrics": data.get("metrics", []),
+                        "cohorts": data.get("cohorts", []),
+                        "time_periods": data.get("time_periods", []),
+                    },
+                    indent=2,
+                )
+        except httpx.TimeoutException:
+            return _error_response(
+                "Request timed out",
+                "The exploration request took too long.",
+                "Try a more specific query or filter by node_types.",
+            )
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+    return explore_knowledge_graph
+
+
+def _make_get_chart_schema(api_token: str, api_url: str):
+    """Create the get_chart_schema function bound to credentials."""
+
+    def get_chart_schema(schema_name: str) -> str:
+        """Get the detailed schema definition for a specific chart type.
+
+        Use this when you need to understand the data format for a chart type.
+        Always call this before create_chart.
+
+        Args:
+            schema_name: Schema name (e.g. 'bar_chart', 'timeseries_card').
+
+        Returns:
+            JSON string with schema details.
+        """
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                resp = client.get(
+                    f"{api_url.rstrip('/')}/api/v1/thin_viz/default_schema/{schema_name}/",
+                    headers=_headers(api_token),
+                )
+                if resp.status_code == 404:
+                    return json.dumps({
+                        "error": f"Schema '{schema_name}' not found",
+                        "suggestion": "Use list_chart_schemas to see available names.",
+                    })
+                resp.raise_for_status()
+                schema = resp.json()
+                return json.dumps(
+                    {
+                        "name": schema.get("name"),
+                        "description": schema.get("description"),
+                        "components": schema.get("components", []),
+                        "template": schema.get("template"),
+                    },
+                    indent=2,
+                )
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+    return get_chart_schema
+
+
+def _make_open_chart_ui(api_token: str, api_url: str):
+    """Create the open_chart_ui function bound to credentials."""
+
+    def open_chart_ui(
+        pub_id: str,
+        dark_mode: bool = True,
+    ) -> str:
+        """Generate an interactive embed URL for a Tako chart.
+
+        Use this when you want to display an interactive chart to the user.
+        No API call is made — the URL is constructed locally.
+
+        Args:
+            pub_id: The chart's unique identifier (pub_id / card_id).
+            dark_mode: Whether to use dark mode (default True).
+
+        Returns:
+            JSON string with pub_id, embed_url, dark_mode.
+        """
+        theme = "dark" if dark_mode else "light"
+        embed_url = f"https://tako.com/embed/{pub_id}/?theme={theme}"
+        return json.dumps(
+            {"pub_id": pub_id, "embed_url": embed_url, "dark_mode": dark_mode},
+            indent=2,
+        )
+
+    return open_chart_ui
+
+
 # ---------------------------------------------------------------------------
 # AutoGen function tool definitions (for register_for_llm)
 # ---------------------------------------------------------------------------
@@ -402,6 +539,32 @@ TAKO_FUNCTION_DEFINITIONS: list[dict[str, Any]] = [
                 "locale": {
                     "type": "string",
                     "description": "Locale (e.g. 'en-US'). Default: 'en-US'.",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "explore_knowledge_graph",
+        "description": (
+            "Explore Tako's knowledge graph to discover available entities, metrics, "
+            "cohorts, and time periods. Use before search to understand what data exists."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Natural language query to explore.",
+                },
+                "node_types": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Filter by node types: entity, metric, cohort, db, units, time_period, property.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results per type (1-50). Default: 20.",
                 },
             },
             "required": ["query"],
@@ -446,6 +609,23 @@ TAKO_FUNCTION_DEFINITIONS: list[dict[str, Any]] = [
         },
     },
     {
+        "name": "get_chart_schema",
+        "description": (
+            "Get the detailed schema definition for a specific chart type. "
+            "Always call this before create_chart to understand the data format."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "schema_name": {
+                    "type": "string",
+                    "description": "Schema name (e.g. 'bar_chart', 'timeseries_card').",
+                },
+            },
+            "required": ["schema_name"],
+        },
+    },
+    {
         "name": "get_chart_insights",
         "description": (
             "Get AI-generated insights for a Tako chart. Returns bullet-point "
@@ -483,6 +663,27 @@ TAKO_FUNCTION_DEFINITIONS: list[dict[str, Any]] = [
                 "dark_mode": {
                     "type": "boolean",
                     "description": "Dark mode image. Default: true.",
+                },
+            },
+            "required": ["pub_id"],
+        },
+    },
+    {
+        "name": "open_chart_ui",
+        "description": (
+            "Generate an interactive embed URL for a Tako chart. Returns a URL "
+            "with zooming, panning, and hover interactions."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pub_id": {
+                    "type": "string",
+                    "description": "The chart's unique identifier (pub_id / card_id).",
+                },
+                "dark_mode": {
+                    "type": "boolean",
+                    "description": "Dark mode theme. Default: true.",
                 },
             },
             "required": ["pub_id"],
@@ -533,10 +734,13 @@ def register_tako_tools(
     """
     function_map = {
         "search_charts": _make_search_charts(api_token, api_url),
+        "explore_knowledge_graph": _make_explore_knowledge_graph(api_token, api_url),
         "create_chart": _make_create_chart(api_token, api_url),
         "list_chart_schemas": _make_list_chart_schemas(api_token, api_url),
+        "get_chart_schema": _make_get_chart_schema(api_token, api_url),
         "get_chart_insights": _make_get_chart_insights(api_token, api_url),
         "get_chart_image": _make_get_chart_image(api_token, api_url),
+        "open_chart_ui": _make_open_chart_ui(api_token, api_url),
     }
 
     # Register function definitions with the agent's LLM config so the model

--- a/integrations/crewai_tako.py
+++ b/integrations/crewai_tako.py
@@ -1,0 +1,397 @@
+"""
+Tako integration for CrewAI.
+
+Provides CrewAI-compatible tools that wrap the Tako API, enabling agents
+in CrewAI pipelines to search for charts, create visualizations, list
+available chart schemas, and retrieve AI-generated chart insights.
+
+Usage:
+    from integrations.crewai_tako import create_tako_tools
+
+    tools = create_tako_tools(api_token="your-tako-api-token")
+    agent = Agent(role="Data Analyst", tools=tools, ...)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+try:
+    from crewai.tools import BaseTool
+except ImportError:
+    raise ImportError(
+        "CrewAI is required for this integration. "
+        "Install it with: pip install crewai"
+    )
+
+try:
+    import httpx
+except ImportError:
+    raise ImportError(
+        "httpx is required for this integration. "
+        "Install it with: pip install httpx"
+    )
+
+DEFAULT_API_URL = "https://api.tako.com"
+
+
+def _headers(api_token: str) -> dict[str, str]:
+    """Build request headers with Tako API authentication."""
+    return {
+        "Content-Type": "application/json",
+        "X-API-Key": api_token,
+    }
+
+
+def _error_response(error: str, message: str, suggestion: str) -> str:
+    """Return a standardised JSON error string."""
+    return json.dumps(
+        {"error": error, "message": message, "suggestion": suggestion},
+        indent=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: Knowledge Search
+# ---------------------------------------------------------------------------
+
+class TakoSearchTool(BaseTool):
+    """Search Tako's knowledge base for charts and data visualisations."""
+
+    name: str = "tako_search"
+    description: str = (
+        "Use this when you need to find existing charts and data visualizations on "
+        "any topic. Searches Tako's curated knowledge base of charts covering "
+        "economics, finance, demographics, technology, and more. Returns matching "
+        "charts with titles, descriptions, URLs, and source information."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(
+        self,
+        query: str,
+        count: int = 5,
+        search_effort: str = "deep",
+        country_code: str = "US",
+        locale: str = "en-US",
+    ) -> str:
+        """
+        Search for charts and data visualisations.
+
+        Args:
+            query: Natural language search query (e.g. "US GDP growth",
+                   "Intel vs Nvidia revenue").
+            count: Number of results to return (1-20).
+            search_effort: "fast" for quick results or "deep" for comprehensive.
+            country_code: ISO country code for localised results (e.g. "US").
+            locale: Locale string (e.g. "en-US").
+
+        Returns:
+            JSON string with matching charts.
+        """
+        try:
+            with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+                resp = client.post(
+                    f"{self.api_url.rstrip('/')}/api/v1/knowledge_search",
+                    json={
+                        "inputs": {
+                            "text": query,
+                            "count": count,
+                        },
+                        "source_indexes": ["tako"],
+                        "search_effort": search_effort,
+                        "country_code": country_code,
+                        "locale": locale,
+                    },
+                    headers=_headers(self.api_token),
+                )
+                resp.raise_for_status()
+
+                data = resp.json()
+                cards = data.get("outputs", {}).get("knowledge_cards", [])
+
+                results = []
+                for card in cards:
+                    results.append(
+                        {
+                            "card_id": card.get("card_id"),
+                            "title": card.get("title"),
+                            "description": card.get("description"),
+                            "url": card.get("url"),
+                            "source": card.get("source"),
+                        }
+                    )
+
+                return json.dumps(
+                    {"results": results, "count": len(results)},
+                    indent=2,
+                )
+
+        except httpx.TimeoutException:
+            return _error_response(
+                "Request timed out",
+                "The search request took too long.",
+                "Try using search_effort='fast' or a more specific query.",
+            )
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: Create Chart
+# ---------------------------------------------------------------------------
+
+class TakoCreateChartTool(BaseTool):
+    """Create a new chart on Tako from raw data."""
+
+    name: str = "tako_create_chart"
+    description: str = (
+        "Use this when you need to create a new chart from raw data. Pass a schema "
+        "name and component configurations to generate an interactive Tako "
+        "visualisation. Supports 15+ chart types including timeseries, bar charts, "
+        "scatter plots, maps, and more. Call tako_list_schemas first to see "
+        "available chart types."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(
+        self,
+        schema_name: str,
+        components: list[dict[str, Any]],
+        source: Optional[str] = None,
+    ) -> str:
+        """
+        Create a chart from a schema template and data components.
+
+        Args:
+            schema_name: Chart schema (e.g. "bar_chart", "timeseries_card",
+                         "pie_chart", "scatter_chart", "choropleth").
+            components: List of component dicts, each with "component_type"
+                        and "config" keys.
+            source: Optional attribution text (e.g. "Yahoo Finance").
+
+        Returns:
+            JSON string with card_id, title, URLs, etc.
+        """
+        try:
+            payload: dict[str, Any] = {"components": components}
+            if source:
+                payload["source"] = source
+
+            with httpx.Client(timeout=60.0) as client:
+                resp = client.post(
+                    f"{self.api_url.rstrip('/')}/api/v1/thin_viz/default_schema/{schema_name}/create/",
+                    json=payload,
+                    headers=_headers(self.api_token),
+                )
+
+                if resp.status_code == 404:
+                    return json.dumps(
+                        {
+                            "error": f"Schema '{schema_name}' not found",
+                            "suggestion": "Use tako_list_schemas to see available schema names.",
+                        }
+                    )
+                if resp.status_code == 400:
+                    return json.dumps(
+                        {
+                            "error": "Invalid component configuration",
+                            "details": resp.json(),
+                            "suggestion": "Verify the component structure matches the schema.",
+                        }
+                    )
+
+                resp.raise_for_status()
+                data = resp.json()
+
+                return json.dumps(
+                    {
+                        "card_id": data.get("card_id"),
+                        "title": data.get("title"),
+                        "description": data.get("description"),
+                        "webpage_url": data.get("webpage_url"),
+                        "embed_url": data.get("embed_url"),
+                        "image_url": data.get("image_url"),
+                    },
+                    indent=2,
+                )
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token and component configuration.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: List Schemas
+# ---------------------------------------------------------------------------
+
+class TakoListSchemasTool(BaseTool):
+    """List all available chart schemas (templates) on Tako."""
+
+    name: str = "tako_list_schemas"
+    description: str = (
+        "Use this when you want to see all available chart templates before "
+        "creating a custom chart. Returns the full list of Tako chart schemas "
+        "including timeseries, bar charts, pie charts, scatter plots, maps, and "
+        "more. Call this first when the user wants to create a new visualisation."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(self) -> str:
+        """
+        List available chart schemas.
+
+        Returns:
+            JSON string with an array of schemas and their descriptions.
+        """
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                resp = client.get(
+                    f"{self.api_url.rstrip('/')}/api/v1/thin_viz/default_schema/",
+                    headers=_headers(self.api_token),
+                )
+                resp.raise_for_status()
+                schemas = resp.json()
+
+                result = []
+                for schema in schemas:
+                    result.append(
+                        {
+                            "name": schema.get("name"),
+                            "description": schema.get("description"),
+                            "components": schema.get("components", []),
+                        }
+                    )
+
+                return json.dumps(
+                    {"schemas": result, "count": len(result)},
+                    indent=2,
+                )
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: Get Insights
+# ---------------------------------------------------------------------------
+
+class TakoGetInsightsTool(BaseTool):
+    """Get AI-generated insights for a Tako chart."""
+
+    name: str = "tako_get_insights"
+    description: str = (
+        "Use this when you want AI-generated analysis of a chart's data. Returns "
+        "bullet-point insights and a natural language description summarising "
+        "trends, outliers, and key takeaways from the chart."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(
+        self,
+        pub_id: str,
+        effort: str = "medium",
+    ) -> str:
+        """
+        Retrieve AI-generated insights for a chart.
+
+        Args:
+            pub_id: The unique identifier (pub_id / card_id) of the chart.
+            effort: Reasoning depth - "low", "medium", or "high".
+
+        Returns:
+            JSON string with insights and description.
+        """
+        try:
+            with httpx.Client(timeout=90.0) as client:
+                resp = client.get(
+                    f"{self.api_url.rstrip('/')}/api/v1/internal/chart-configs/{pub_id}/chart-insights/",
+                    params={"effort": effort},
+                    headers=_headers(self.api_token),
+                )
+
+                if resp.status_code == 404:
+                    return json.dumps(
+                        {
+                            "error": "Chart not found",
+                            "pub_id": pub_id,
+                            "suggestion": "Verify the pub_id/card_id is correct.",
+                        }
+                    )
+
+                resp.raise_for_status()
+                data = resp.json()
+
+                return json.dumps(
+                    {
+                        "pub_id": pub_id,
+                        "insights": data.get("insights", ""),
+                        "description": data.get("description", ""),
+                    },
+                    indent=2,
+                )
+
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token and pub_id, then try again.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory
+# ---------------------------------------------------------------------------
+
+def create_tako_tools(
+    api_token: str,
+    api_url: str = DEFAULT_API_URL,
+) -> list[BaseTool]:
+    """
+    Create all Tako tools for use in a CrewAI agent.
+
+    Args:
+        api_token: Your Tako API token (from https://tako.com account settings).
+        api_url: Base URL for the Tako API. Defaults to https://api.tako.com.
+
+    Returns:
+        A list of CrewAI BaseTool instances ready to pass to an Agent.
+
+    Example:
+        from crewai import Agent
+        from integrations.crewai_tako import create_tako_tools
+
+        tools = create_tako_tools(api_token="tak_...")
+        analyst = Agent(
+            role="Data Analyst",
+            goal="Find and visualise data trends",
+            tools=tools,
+        )
+    """
+    kwargs = {"api_token": api_token, "api_url": api_url}
+    return [
+        TakoSearchTool(**kwargs),
+        TakoCreateChartTool(**kwargs),
+        TakoListSchemasTool(**kwargs),
+        TakoGetInsightsTool(**kwargs),
+    ]

--- a/integrations/crewai_tako.py
+++ b/integrations/crewai_tako.py
@@ -360,6 +360,200 @@ class TakoGetInsightsTool(BaseTool):
 
 
 # ---------------------------------------------------------------------------
+# Tool: Explore Knowledge Graph
+# ---------------------------------------------------------------------------
+
+class TakoExploreKnowledgeGraphTool(BaseTool):
+    """Explore Tako's knowledge graph to discover available data."""
+
+    name: str = "tako_explore_knowledge_graph"
+    description: str = (
+        "Use this when you need to discover what data is available before searching. "
+        "Helps find entities (companies, countries), metrics (revenue, GDP), cohorts "
+        "(S&P 500, G7), and time periods. Use to disambiguate queries or understand "
+        "what data Tako has before calling tako_search."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(
+        self,
+        query: str,
+        node_types: Optional[list[str]] = None,
+        limit: int = 20,
+    ) -> str:
+        try:
+            with httpx.Client(timeout=60.0, follow_redirects=True) as client:
+                resp = client.post(
+                    f"{self.api_url.rstrip('/')}/api/v1/explore/",
+                    json={
+                        "query": query,
+                        "node_types": node_types,
+                        "limit": limit,
+                    },
+                    headers=_headers(self.api_token),
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                return json.dumps(
+                    {
+                        "query": data.get("query"),
+                        "total_matches": data.get("total_matches", 0),
+                        "entities": data.get("entities", []),
+                        "metrics": data.get("metrics", []),
+                        "cohorts": data.get("cohorts", []),
+                        "time_periods": data.get("time_periods", []),
+                    },
+                    indent=2,
+                )
+        except httpx.TimeoutException:
+            return _error_response(
+                "Request timed out",
+                "The exploration request took too long.",
+                "Try a more specific query or filter by node_types.",
+            )
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: Get Chart Image
+# ---------------------------------------------------------------------------
+
+class TakoGetChartImageTool(BaseTool):
+    """Get a static PNG preview image URL for a Tako chart."""
+
+    name: str = "tako_get_chart_image"
+    description: str = (
+        "Use this when you need a static PNG preview image of a chart to display or "
+        "embed. Returns a direct URL to a PNG image of the chart."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(
+        self,
+        pub_id: str,
+        dark_mode: bool = True,
+    ) -> str:
+        try:
+            with httpx.Client(timeout=60.0) as client:
+                resp = client.get(
+                    f"{self.api_url.rstrip('/')}/api/v1/image/{pub_id}/",
+                    params={"dark_mode": str(dark_mode).lower()},
+                    headers=_headers(self.api_token),
+                )
+                if resp.status_code == 200:
+                    image_url = (
+                        f"{self.api_url.rstrip('/')}/api/v1/image/{pub_id}/"
+                        f"?dark_mode={str(dark_mode).lower()}"
+                    )
+                    return json.dumps(
+                        {"image_url": image_url, "pub_id": pub_id, "dark_mode": dark_mode},
+                        indent=2,
+                    )
+                elif resp.status_code == 404:
+                    return json.dumps({
+                        "error": "Chart image not found",
+                        "pub_id": pub_id,
+                        "suggestion": "Verify the pub_id/card_id is correct.",
+                    })
+                else:
+                    resp.raise_for_status()
+                    return json.dumps({"error": "Unexpected error"})
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token and try again.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: Get Chart Schema
+# ---------------------------------------------------------------------------
+
+class TakoGetSchemaTool(BaseTool):
+    """Get the detailed schema definition for a specific chart type."""
+
+    name: str = "tako_get_schema"
+    description: str = (
+        "Use this when you need to understand the exact data format required for a "
+        "specific chart type. Returns the schema definition including required fields "
+        "and configuration options. Always call this before tako_create_chart."
+    )
+
+    api_token: str
+    api_url: str = DEFAULT_API_URL
+
+    def _run(self, schema_name: str) -> str:
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                resp = client.get(
+                    f"{self.api_url.rstrip('/')}/api/v1/thin_viz/default_schema/{schema_name}/",
+                    headers=_headers(self.api_token),
+                )
+                if resp.status_code == 404:
+                    return json.dumps({
+                        "error": f"Schema '{schema_name}' not found",
+                        "suggestion": "Use tako_list_schemas to see available schema names.",
+                    })
+                resp.raise_for_status()
+                schema = resp.json()
+                return json.dumps(
+                    {
+                        "name": schema.get("name"),
+                        "description": schema.get("description"),
+                        "components": schema.get("components", []),
+                        "template": schema.get("template"),
+                    },
+                    indent=2,
+                )
+        except httpx.HTTPStatusError as exc:
+            return _error_response(
+                f"HTTP {exc.response.status_code}",
+                str(exc),
+                "Check your API token is valid and try again.",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tool: Open Chart UI
+# ---------------------------------------------------------------------------
+
+class TakoOpenChartUITool(BaseTool):
+    """Generate an interactive embed URL for a Tako chart."""
+
+    name: str = "tako_open_chart_ui"
+    description: str = (
+        "Use this when you want to display a fully interactive chart to the user. "
+        "Returns an embed URL for the chart with zooming, panning, and hover "
+        "interactions. No API call is made — the URL is constructed locally."
+    )
+
+    api_token: str = ""
+    api_url: str = DEFAULT_API_URL
+
+    def _run(
+        self,
+        pub_id: str,
+        dark_mode: bool = True,
+    ) -> str:
+        theme = "dark" if dark_mode else "light"
+        embed_url = f"https://tako.com/embed/{pub_id}/?theme={theme}"
+        return json.dumps(
+            {"pub_id": pub_id, "embed_url": embed_url, "dark_mode": dark_mode},
+            indent=2,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Convenience factory
 # ---------------------------------------------------------------------------
 
@@ -391,7 +585,11 @@ def create_tako_tools(
     kwargs = {"api_token": api_token, "api_url": api_url}
     return [
         TakoSearchTool(**kwargs),
-        TakoCreateChartTool(**kwargs),
-        TakoListSchemasTool(**kwargs),
+        TakoExploreKnowledgeGraphTool(**kwargs),
+        TakoGetChartImageTool(**kwargs),
         TakoGetInsightsTool(**kwargs),
+        TakoListSchemasTool(**kwargs),
+        TakoGetSchemaTool(**kwargs),
+        TakoCreateChartTool(**kwargs),
+        TakoOpenChartUITool(**kwargs),
     ]

--- a/integrations/langchain_tako.py
+++ b/integrations/langchain_tako.py
@@ -1,0 +1,830 @@
+"""
+LangChain / LangGraph integration for Tako's REST API.
+
+Provides a ``TakoToolkit`` that exposes all eight Tako tools as LangChain-
+compatible ``BaseTool`` instances.  Each tool communicates directly with
+Tako's REST API (no MCP layer required), making this suitable for use in
+LangChain agents, LangGraph workflows, or any framework that consumes
+``BaseTool`` objects.
+
+Quick start
+-----------
+::
+
+    from langchain_tako import create_tako_tools
+
+    tools = create_tako_tools(api_token="tak_...")
+    # Pass *tools* to your LangChain agent or LangGraph node.
+
+The only hard runtime dependency beyond the standard library is **httpx**.
+LangChain classes (``BaseTool``, ``BaseToolkit``, ``BaseModel``) are imported
+lazily so that the module can be installed without pulling in the full
+``langchain-core`` package -- an ``ImportError`` with install instructions
+is raised the first time a LangChain symbol is actually needed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, Type
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Lazy / optional LangChain imports
+# ---------------------------------------------------------------------------
+
+try:
+    from langchain_core.tools import BaseTool, BaseToolkit
+    from pydantic import BaseModel, Field
+except ImportError as _exc:  # pragma: no cover
+    raise ImportError(
+        "The Tako LangChain integration requires 'langchain-core' and 'pydantic'. "
+        "Install them with:\n\n"
+        "  pip install langchain-core pydantic\n"
+    ) from _exc
+
+
+# ---------------------------------------------------------------------------
+# Pydantic v2 input schemas
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeSearchInput(BaseModel):
+    """Input schema for the Tako knowledge search tool."""
+
+    query: str = Field(
+        ...,
+        description=(
+            "Natural language search query for charts and data "
+            "(e.g. 'US GDP growth', 'Intel vs Nvidia revenue')."
+        ),
+    )
+    count: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Number of results to return (1-20).",
+    )
+    search_effort: str = Field(
+        default="deep",
+        description="Search depth -- 'fast' for quick results, 'deep' for comprehensive search.",
+    )
+    country_code: str = Field(
+        default="US",
+        description="ISO country code for localized results (e.g. 'US', 'GB').",
+    )
+    locale: str = Field(
+        default="en-US",
+        description="Locale for results (e.g. 'en-US', 'en-GB').",
+    )
+
+
+class ExploreKnowledgeGraphInput(BaseModel):
+    """Input schema for the Tako knowledge graph exploration tool."""
+
+    query: str = Field(
+        ...,
+        description=(
+            "Natural language query to explore "
+            "(e.g. 'tech companies', 'GDP metrics', 'automotive industry')."
+        ),
+    )
+    node_types: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Optional filter for specific node types. Accepted values: "
+            "'entity', 'metric', 'cohort', 'db', 'units', 'time_period', 'property'."
+        ),
+    )
+    limit: int = Field(
+        default=20,
+        ge=1,
+        le=50,
+        description="Maximum number of results per type (1-50).",
+    )
+
+
+class GetChartImageInput(BaseModel):
+    """Input schema for retrieving a chart's static image URL."""
+
+    pub_id: str = Field(
+        ...,
+        description="The unique identifier (pub_id / card_id) of the chart.",
+    )
+    dark_mode: bool = Field(
+        default=True,
+        description="Whether to return the dark-mode version of the image.",
+    )
+
+
+class GetInsightsInput(BaseModel):
+    """Input schema for retrieving AI-generated chart insights."""
+
+    pub_id: str = Field(
+        ...,
+        description="The unique identifier (pub_id / card_id) of the chart.",
+    )
+    effort: str = Field(
+        default="medium",
+        description=(
+            "Reasoning effort level -- 'low' for a quick summary, "
+            "'medium' for balanced analysis, 'high' for deep analysis."
+        ),
+    )
+
+
+class ListSchemasInput(BaseModel):
+    """Input schema for listing available chart schemas (no parameters required)."""
+
+    pass
+
+
+class GetSchemaInput(BaseModel):
+    """Input schema for retrieving a specific chart schema definition."""
+
+    schema_name: str = Field(
+        ...,
+        description=(
+            "Name of the schema (e.g. 'bar_chart', 'pie_chart', "
+            "'timeseries_card', 'scatter_chart', 'choropleth')."
+        ),
+    )
+
+
+class CreateChartInput(BaseModel):
+    """Input schema for creating a new chart from raw data."""
+
+    schema_name: str = Field(
+        ...,
+        description=(
+            "Name of the chart schema to use (e.g. 'bar_chart', "
+            "'grouped_bar_chart', 'pie_chart', 'scatter_chart')."
+        ),
+    )
+    components: list[dict[str, Any]] = Field(
+        ...,
+        description=(
+            "List of component configurations matching the schema requirements. "
+            "Each component needs 'component_type' and 'config' fields."
+        ),
+    )
+    source: Optional[str] = Field(
+        default=None,
+        description="Optional attribution text (e.g. 'Yahoo Finance', 'Company Reports').",
+    )
+
+
+class OpenChartUIInput(BaseModel):
+    """Input schema for generating an interactive chart embed URL."""
+
+    pub_id: str = Field(
+        ...,
+        description="The unique identifier (pub_id / card_id) of the chart.",
+    )
+    dark_mode: bool = Field(
+        default=True,
+        description="Whether to use dark-mode theme.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper: shared HTTP client logic
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(api_token: str) -> dict[str, str]:
+    """Return default request headers including the API key."""
+    return {
+        "Content-Type": "application/json",
+        "X-API-Key": api_token,
+    }
+
+
+async def _make_request(
+    method: str,
+    url: str,
+    api_token: str,
+    *,
+    json_body: dict[str, Any] | None = None,
+    params: dict[str, str] | None = None,
+    timeout: float = 60.0,
+) -> dict[str, Any] | str:
+    """Execute an HTTP request and return the parsed JSON response.
+
+    Raises a descriptive error string on failure so that the LLM receives
+    actionable feedback rather than a raw traceback.
+    """
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        response = await client.request(
+            method,
+            url,
+            headers=_auth_headers(api_token),
+            json=json_body,
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+
+class TakoSearchTool(BaseTool):
+    """Search Tako's curated knowledge base of charts and data visualizations."""
+
+    name: str = "tako_search"
+    description: str = (
+        "Use this when you need to find existing charts and data visualizations on "
+        "any topic. Searches Tako's knowledge base covering economics, finance, "
+        "demographics, technology, and more. Start here when a user asks about data "
+        "trends, comparisons, or statistics."
+    )
+    args_schema: Type[BaseModel] = KnowledgeSearchInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(
+        self,
+        query: str,
+        count: int = 5,
+        search_effort: str = "deep",
+        country_code: str = "US",
+        locale: str = "en-US",
+        **kwargs: Any,
+    ) -> str:
+        """Execute an async knowledge search against the Tako API."""
+        try:
+            data = await _make_request(
+                "POST",
+                f"{self.api_url}/api/v1/knowledge_search",
+                self.api_token,
+                json_body={
+                    "inputs": {"text": query, "count": count},
+                    "source_indexes": ["tako"],
+                    "search_effort": search_effort,
+                    "country_code": country_code,
+                    "locale": locale,
+                },
+            )
+            cards = data.get("outputs", {}).get("knowledge_cards", [])
+            results = []
+            for card in cards:
+                card_id = card.get("card_id")
+                result: dict[str, Any] = {
+                    "card_id": card_id,
+                    "title": card.get("title"),
+                    "description": card.get("description"),
+                    "url": card.get("url"),
+                    "source": card.get("source"),
+                }
+                if card_id:
+                    result["embed_url"] = f"https://tako.com/embed/{card_id}/?theme=dark"
+                results.append(result)
+            return json.dumps({"results": results, "count": len(results)}, indent=2)
+        except httpx.HTTPStatusError as exc:
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+        except httpx.TimeoutException:
+            return json.dumps(
+                {
+                    "error": "Request timed out",
+                    "suggestion": "Try search_effort='fast' or a more specific query.",
+                }
+            )
+
+    def _run(
+        self,
+        query: str,
+        count: int = 5,
+        search_effort: str = "deep",
+        country_code: str = "US",
+        locale: str = "en-US",
+        **kwargs: Any,
+    ) -> str:
+        """Synchronous fallback -- delegates to the async implementation."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(
+                query=query,
+                count=count,
+                search_effort=search_effort,
+                country_code=country_code,
+                locale=locale,
+            )
+        )
+
+
+class TakoExploreKnowledgeGraphTool(BaseTool):
+    """Explore Tako's knowledge graph to discover available data."""
+
+    name: str = "tako_explore_knowledge_graph"
+    description: str = (
+        "Use this when you need to discover what data is available before searching. "
+        "Helps find entities (companies, countries), metrics (revenue, GDP), cohorts "
+        "(S&P 500, G7), and time periods. Use to disambiguate queries or understand "
+        "what data Tako has before calling tako_search."
+    )
+    args_schema: Type[BaseModel] = ExploreKnowledgeGraphInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(
+        self,
+        query: str,
+        node_types: Optional[list[str]] = None,
+        limit: int = 20,
+        **kwargs: Any,
+    ) -> str:
+        """Execute an async knowledge graph exploration."""
+        try:
+            data = await _make_request(
+                "POST",
+                f"{self.api_url}/api/v1/explore/",
+                self.api_token,
+                json_body={
+                    "query": query,
+                    "node_types": node_types,
+                    "limit": limit,
+                },
+            )
+            return json.dumps(
+                {
+                    "query": data.get("query"),
+                    "total_matches": data.get("total_matches", 0),
+                    "entities": data.get("entities", []),
+                    "metrics": data.get("metrics", []),
+                    "cohorts": data.get("cohorts", []),
+                    "time_periods": data.get("time_periods", []),
+                },
+                indent=2,
+            )
+        except httpx.HTTPStatusError as exc:
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+        except httpx.TimeoutException:
+            return json.dumps(
+                {
+                    "error": "Request timed out",
+                    "suggestion": "Try a more specific query or filter by node_types.",
+                }
+            )
+
+    def _run(
+        self,
+        query: str,
+        node_types: Optional[list[str]] = None,
+        limit: int = 20,
+        **kwargs: Any,
+    ) -> str:
+        """Synchronous fallback."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(query=query, node_types=node_types, limit=limit)
+        )
+
+
+class TakoGetChartImageTool(BaseTool):
+    """Retrieve a static preview image URL for a Tako chart."""
+
+    name: str = "tako_get_chart_image"
+    description: str = (
+        "Use this when you need a static PNG preview image of a chart to display or "
+        "embed. Returns a direct URL to a PNG image of the chart."
+    )
+    args_schema: Type[BaseModel] = GetChartImageInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(
+        self,
+        pub_id: str,
+        dark_mode: bool = True,
+        **kwargs: Any,
+    ) -> str:
+        """Fetch the chart image endpoint and return the public image URL."""
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                resp = await client.get(
+                    f"{self.api_url}/api/v1/image/{pub_id}/",
+                    params={"dark_mode": str(dark_mode).lower()},
+                    headers=_auth_headers(self.api_token),
+                )
+                if resp.status_code == 200:
+                    image_url = (
+                        f"{self.api_url}/api/v1/image/{pub_id}/"
+                        f"?dark_mode={str(dark_mode).lower()}"
+                    )
+                    return json.dumps(
+                        {
+                            "image_url": image_url,
+                            "pub_id": pub_id,
+                            "dark_mode": dark_mode,
+                        },
+                        indent=2,
+                    )
+                elif resp.status_code == 404:
+                    return json.dumps(
+                        {
+                            "error": "Chart image not found",
+                            "pub_id": pub_id,
+                            "suggestion": "Verify the pub_id is correct. Use tako_search to find valid chart IDs.",
+                        }
+                    )
+                else:
+                    resp.raise_for_status()
+                    return json.dumps({"error": "Unexpected response"})
+        except httpx.HTTPStatusError as exc:
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+
+    def _run(self, pub_id: str, dark_mode: bool = True, **kwargs: Any) -> str:
+        """Synchronous fallback."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(pub_id=pub_id, dark_mode=dark_mode)
+        )
+
+
+class TakoGetInsightsTool(BaseTool):
+    """Get AI-generated insights and analysis for a Tako chart."""
+
+    name: str = "tako_get_insights"
+    description: str = (
+        "Use this when you want AI-generated analysis of a chart's data. Returns "
+        "bullet-point insights and a natural language description summarizing trends, "
+        "outliers, and key takeaways from the chart."
+    )
+    args_schema: Type[BaseModel] = GetInsightsInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(
+        self,
+        pub_id: str,
+        effort: str = "medium",
+        **kwargs: Any,
+    ) -> str:
+        """Fetch AI-generated insights for a chart."""
+        try:
+            data = await _make_request(
+                "GET",
+                f"{self.api_url}/api/v1/internal/chart-configs/{pub_id}/chart-insights/",
+                self.api_token,
+                params={"effort": effort},
+                timeout=90.0,
+            )
+            return json.dumps(
+                {
+                    "pub_id": pub_id,
+                    "insights": data.get("insights", ""),
+                    "description": data.get("description", ""),
+                },
+                indent=2,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return json.dumps(
+                    {
+                        "error": "Chart not found",
+                        "pub_id": pub_id,
+                        "suggestion": "Verify the pub_id is correct. Use tako_search to find valid chart IDs.",
+                    }
+                )
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+
+    def _run(self, pub_id: str, effort: str = "medium", **kwargs: Any) -> str:
+        """Synchronous fallback."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(pub_id=pub_id, effort=effort)
+        )
+
+
+class TakoListSchemasTool(BaseTool):
+    """List all available chart schemas (templates) for creating custom visualizations."""
+
+    name: str = "tako_list_schemas"
+    description: str = (
+        "Use this when you want to see all available chart templates before creating "
+        "a custom chart. Returns the full list of ThinViz schemas including timeseries, "
+        "bar charts, pie charts, scatter plots, maps, and more."
+    )
+    args_schema: Type[BaseModel] = ListSchemasInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(self, **kwargs: Any) -> str:
+        """Fetch the list of available chart schemas."""
+        try:
+            schemas = await _make_request(
+                "GET",
+                f"{self.api_url}/api/v1/thin_viz/default_schema/",
+                self.api_token,
+                timeout=30.0,
+            )
+            result = []
+            for schema in schemas:
+                result.append(
+                    {
+                        "name": schema.get("name"),
+                        "description": schema.get("description"),
+                        "components": schema.get("components", []),
+                    }
+                )
+            return json.dumps({"schemas": result, "count": len(result)}, indent=2)
+        except httpx.HTTPStatusError as exc:
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+
+    def _run(self, **kwargs: Any) -> str:
+        """Synchronous fallback."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(self._arun())
+
+
+class TakoGetSchemaTool(BaseTool):
+    """Get the detailed schema definition for a specific chart type."""
+
+    name: str = "tako_get_schema"
+    description: str = (
+        "Use this when you need to understand the exact data format required for a "
+        "specific chart type. Returns the schema definition including required fields, "
+        "data structure, and configuration options. Always call this before "
+        "tako_create_chart to understand what data is needed."
+    )
+    args_schema: Type[BaseModel] = GetSchemaInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(self, schema_name: str, **kwargs: Any) -> str:
+        """Fetch the detailed schema for a given chart type."""
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.get(
+                    f"{self.api_url}/api/v1/thin_viz/default_schema/{schema_name}/",
+                    headers=_auth_headers(self.api_token),
+                )
+                if resp.status_code == 404:
+                    return json.dumps(
+                        {
+                            "error": f"Schema '{schema_name}' not found",
+                            "suggestion": "Use tako_list_schemas to see all available schema names.",
+                        }
+                    )
+                resp.raise_for_status()
+                schema = resp.json()
+                return json.dumps(
+                    {
+                        "name": schema.get("name"),
+                        "description": schema.get("description"),
+                        "components": schema.get("components", []),
+                        "template": schema.get("template"),
+                    },
+                    indent=2,
+                )
+        except httpx.HTTPStatusError as exc:
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+
+    def _run(self, schema_name: str, **kwargs: Any) -> str:
+        """Synchronous fallback."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(schema_name=schema_name)
+        )
+
+
+class TakoCreateChartTool(BaseTool):
+    """Create a new interactive Tako chart from raw data."""
+
+    name: str = "tako_create_chart"
+    description: str = (
+        "Use this when you need to create a new chart from raw data. Pass a schema "
+        "name and your data components to generate an interactive Tako visualization. "
+        "Supports 15+ chart types including timeseries, bar charts, scatter plots, "
+        "maps, and more. Call tako_list_schemas and tako_get_schema first to understand "
+        "the required data format."
+    )
+    args_schema: Type[BaseModel] = CreateChartInput
+
+    api_token: str
+    api_url: str = "https://api.tako.com"
+
+    async def _arun(
+        self,
+        schema_name: str,
+        components: list[dict[str, Any]],
+        source: Optional[str] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Create a chart via the ThinViz API."""
+        try:
+            payload: dict[str, Any] = {"components": components}
+            if source:
+                payload["source"] = source
+
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                resp = await client.post(
+                    f"{self.api_url}/api/v1/thin_viz/default_schema/{schema_name}/create/",
+                    json=payload,
+                    headers=_auth_headers(self.api_token),
+                )
+                if resp.status_code == 404:
+                    return json.dumps(
+                        {
+                            "error": f"Schema '{schema_name}' not found",
+                            "suggestion": "Use tako_list_schemas to see available schema names.",
+                        }
+                    )
+                if resp.status_code == 400:
+                    return json.dumps(
+                        {
+                            "error": "Invalid component configuration",
+                            "details": resp.json(),
+                            "suggestion": "Use tako_get_schema to see the required data format.",
+                        }
+                    )
+                resp.raise_for_status()
+                data = resp.json()
+
+                card_id = data.get("card_id")
+                result: dict[str, Any] = {
+                    "card_id": card_id,
+                    "title": data.get("title"),
+                    "description": data.get("description"),
+                    "webpage_url": data.get("webpage_url"),
+                    "embed_url": data.get("embed_url"),
+                    "image_url": data.get("image_url"),
+                }
+                if card_id:
+                    result["interactive_url"] = (
+                        f"https://tako.com/embed/{card_id}/?theme=dark"
+                    )
+                return json.dumps(result, indent=2)
+
+        except httpx.HTTPStatusError as exc:
+            return json.dumps(
+                {"error": f"HTTP {exc.response.status_code}", "message": str(exc)}
+            )
+
+    def _run(
+        self,
+        schema_name: str,
+        components: list[dict[str, Any]],
+        source: Optional[str] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Synchronous fallback."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(schema_name=schema_name, components=components, source=source)
+        )
+
+
+class TakoOpenChartUITool(BaseTool):
+    """Generate an interactive embed URL for a Tako chart (no API call needed)."""
+
+    name: str = "tako_open_chart_ui"
+    description: str = (
+        "Use this when you want to display a fully interactive chart to the user. "
+        "Returns an embed URL for the chart with zooming, panning, and hover "
+        "interactions. No API call is made -- the URL is constructed locally."
+    )
+    args_schema: Type[BaseModel] = OpenChartUIInput
+
+    api_token: str = ""  # Not required -- no API call is made.
+    api_url: str = "https://api.tako.com"  # Unused, kept for interface consistency.
+
+    async def _arun(
+        self,
+        pub_id: str,
+        dark_mode: bool = True,
+        **kwargs: Any,
+    ) -> str:
+        """Return the Tako embed URL for the given chart."""
+        theme = "dark" if dark_mode else "light"
+        embed_url = f"https://tako.com/embed/{pub_id}/?theme={theme}"
+        return json.dumps(
+            {
+                "pub_id": pub_id,
+                "embed_url": embed_url,
+                "dark_mode": dark_mode,
+            },
+            indent=2,
+        )
+
+    def _run(
+        self,
+        pub_id: str,
+        dark_mode: bool = True,
+        **kwargs: Any,
+    ) -> str:
+        """Synchronous implementation (no I/O required)."""
+        theme = "dark" if dark_mode else "light"
+        embed_url = f"https://tako.com/embed/{pub_id}/?theme={theme}"
+        return json.dumps(
+            {
+                "pub_id": pub_id,
+                "embed_url": embed_url,
+                "dark_mode": dark_mode,
+            },
+            indent=2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# TakoToolkit -- aggregates all eight tools
+# ---------------------------------------------------------------------------
+
+
+class TakoToolkit(BaseToolkit):
+    """LangChain-compatible toolkit that provides all eight Tako tools.
+
+    Parameters
+    ----------
+    api_token : str
+        Tako API token used for authentication (sent as ``X-API-Key`` header).
+    api_url : str, optional
+        Base URL for the Tako REST API.  Defaults to ``https://api.tako.com``.
+
+    Usage
+    -----
+    ::
+
+        from langchain_tako import TakoToolkit
+
+        toolkit = TakoToolkit(api_token="tak_...")
+        tools = toolkit.get_tools()
+    """
+
+    api_token: str = Field(..., description="Tako API token for authentication.")
+    api_url: str = Field(
+        default="https://api.tako.com",
+        description="Base URL for the Tako REST API.",
+    )
+
+    def get_tools(self) -> list[BaseTool]:
+        """Return all eight Tako tools configured with the toolkit's credentials."""
+        common = {"api_token": self.api_token, "api_url": self.api_url}
+        return [
+            TakoSearchTool(**common),
+            TakoExploreKnowledgeGraphTool(**common),
+            TakoGetChartImageTool(**common),
+            TakoGetInsightsTool(**common),
+            TakoListSchemasTool(**common),
+            TakoGetSchemaTool(**common),
+            TakoCreateChartTool(**common),
+            TakoOpenChartUITool(**common),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Convenience factory function
+# ---------------------------------------------------------------------------
+
+
+def create_tako_tools(
+    api_token: str,
+    api_url: str = "https://api.tako.com",
+) -> list[BaseTool]:
+    """Create and return all eight Tako LangChain tools.
+
+    This is a shorthand for ``TakoToolkit(api_token=...).get_tools()``.
+
+    Parameters
+    ----------
+    api_token : str
+        Tako API token (sent as the ``X-API-Key`` header on every request).
+    api_url : str, optional
+        Base URL for the Tako REST API.  Defaults to ``https://api.tako.com``.
+
+    Returns
+    -------
+    list[BaseTool]
+        A list of eight ``BaseTool`` instances -- one for each Tako capability.
+    """
+    toolkit = TakoToolkit(api_token=api_token, api_url=api_url)
+    return toolkit.get_tools()

--- a/integrations/langchain_tako.py
+++ b/integrations/langchain_tako.py
@@ -309,7 +309,7 @@ class TakoSearchTool(BaseTool):
         """Synchronous fallback -- delegates to the async implementation."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self._arun(
                 query=query,
                 count=count,
@@ -387,7 +387,7 @@ class TakoExploreKnowledgeGraphTool(BaseTool):
         """Synchronous fallback."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self._arun(query=query, node_types=node_types, limit=limit)
         )
 
@@ -452,7 +452,7 @@ class TakoGetChartImageTool(BaseTool):
         """Synchronous fallback."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self._arun(pub_id=pub_id, dark_mode=dark_mode)
         )
 
@@ -511,7 +511,7 @@ class TakoGetInsightsTool(BaseTool):
         """Synchronous fallback."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self._arun(pub_id=pub_id, effort=effort)
         )
 
@@ -558,7 +558,7 @@ class TakoListSchemasTool(BaseTool):
         """Synchronous fallback."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(self._arun())
+        return asyncio.run(self._arun())
 
 
 class TakoGetSchemaTool(BaseTool):
@@ -611,7 +611,7 @@ class TakoGetSchemaTool(BaseTool):
         """Synchronous fallback."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self._arun(schema_name=schema_name)
         )
 
@@ -699,7 +699,7 @@ class TakoCreateChartTool(BaseTool):
         """Synchronous fallback."""
         import asyncio
 
-        return asyncio.get_event_loop().run_until_complete(
+        return asyncio.run(
             self._arun(schema_name=schema_name, components=components, source=source)
         )
 

--- a/integrations/openai_actions.yaml
+++ b/integrations/openai_actions.yaml
@@ -1,0 +1,672 @@
+openapi: 3.1.0
+info:
+  title: Tako Data Visualization API
+  description: >
+    Tako is an AI-native data visualization platform that helps users find, explore,
+    and create data-driven charts and visualizations. Use this API to search for
+    existing charts and knowledge cards across Tako's index, explore the knowledge
+    graph for entities and metrics, retrieve chart images and insights, and create
+    new custom charts from schema templates.
+  version: 1.0.0
+  contact:
+    name: Tako Support
+    email: hello@tako.com
+    url: https://tako.com
+
+servers:
+  - url: https://api.tako.com
+    description: Tako Production API
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: >
+        API key for authenticating requests to the Tako API.
+        Include this key in the X-API-Key header of every request.
+
+  schemas:
+    KnowledgeCard:
+      type: object
+      properties:
+        card_id:
+          type: string
+          description: Unique identifier for the knowledge card.
+        title:
+          type: string
+          description: Human-readable title of the chart or knowledge card.
+        description:
+          type: string
+          description: Brief summary of what the chart shows.
+        url:
+          type: string
+          format: uri
+          description: URL to view the chart on Tako.
+        source:
+          type: string
+          description: The data source or publisher behind this chart.
+
+    SearchRequest:
+      type: object
+      required:
+        - inputs
+      properties:
+        inputs:
+          type: object
+          required:
+            - text
+          properties:
+            text:
+              type: string
+              description: The natural-language search query describing the data or chart you are looking for.
+            count:
+              type: integer
+              minimum: 1
+              maximum: 20
+              default: 5
+              description: Number of results to return (1-20).
+        source_indexes:
+          type: array
+          items:
+            type: string
+          default:
+            - tako
+          description: Which indexes to search. Use ["tako"] for Tako's own chart index.
+        search_effort:
+          type: string
+          enum:
+            - fast
+            - deep
+          default: deep
+          description: >
+            Controls the thoroughness of the search. Use "fast" for quick lookups
+            and "deep" for more comprehensive results.
+        country_code:
+          type: string
+          default: US
+          description: ISO 3166-1 alpha-2 country code to localize results.
+        locale:
+          type: string
+          default: en-US
+          description: BCP 47 locale tag for language and region preferences.
+
+    SearchResponse:
+      type: object
+      properties:
+        outputs:
+          type: object
+          properties:
+            knowledge_cards:
+              type: array
+              items:
+                $ref: "#/components/schemas/KnowledgeCard"
+              description: List of matching knowledge cards / charts.
+
+    ExploreRequest:
+      type: object
+      required:
+        - query
+      properties:
+        query:
+          type: string
+          description: >
+            Natural-language query describing the entity, metric, or topic
+            you want to explore in Tako's knowledge graph.
+        node_types:
+          type: array
+          items:
+            type: string
+          description: >
+            Optional list of node types to filter results (e.g., "entity", "metric",
+            "cohort"). Omit to search all types.
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 20
+          description: Maximum number of results to return (1-50).
+
+    ExploreResponse:
+      type: object
+      properties:
+        query:
+          type: string
+          description: The original query that was submitted.
+        total_matches:
+          type: integer
+          description: Total number of matching nodes found in the knowledge graph.
+        entities:
+          type: array
+          items:
+            type: object
+          description: Matching entity nodes (companies, people, places, etc.).
+        metrics:
+          type: array
+          items:
+            type: object
+          description: Matching metric nodes (revenue, population, rates, etc.).
+        cohorts:
+          type: array
+          items:
+            type: object
+          description: Matching cohort nodes (demographic groups, market segments, etc.).
+        time_periods:
+          type: array
+          items:
+            type: object
+          description: Matching time period nodes (quarters, years, date ranges, etc.).
+
+    ChartInsightsResponse:
+      type: object
+      properties:
+        insights:
+          type: string
+          description: AI-generated analytical insights about the chart data.
+        description:
+          type: string
+          description: A natural-language description of what the chart shows.
+
+    ChartSchemaListItem:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Machine-readable name of the chart schema (used in URLs).
+        description:
+          type: string
+          description: Human-readable description of what this chart type is for.
+        components:
+          type: array
+          items:
+            type: object
+          description: List of component slots this schema accepts.
+
+    ChartSchemaDetail:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Machine-readable name of the chart schema.
+        description:
+          type: string
+          description: Human-readable description of the chart type.
+        components:
+          type: array
+          items:
+            type: object
+          description: Detailed list of component definitions with their configuration options.
+        template:
+          type: object
+          description: The default template configuration for this chart schema.
+
+    CreateChartRequest:
+      type: object
+      required:
+        - components
+      properties:
+        components:
+          type: array
+          items:
+            type: object
+            required:
+              - component_type
+              - config
+            properties:
+              component_type:
+                type: string
+                description: >
+                  The type of component to configure (e.g., "title", "data_series",
+                  "x_axis", "y_axis"). Must match one of the component types
+                  defined in the chosen schema.
+              config:
+                type: object
+                description: >
+                  Configuration object for this component. The shape depends on
+                  the component_type. Refer to the schema detail endpoint for
+                  the expected fields.
+          description: >
+            Array of component configurations that populate the chart.
+            Each component fills a slot defined by the chart schema.
+        source:
+          type: string
+          description: >
+            Optional attribution string for the data source
+            (e.g., "World Bank", "US Census Bureau").
+
+    CreateChartResponse:
+      type: object
+      properties:
+        card_id:
+          type: string
+          description: Unique identifier for the newly created chart card.
+        title:
+          type: string
+          description: The resolved title of the chart.
+        description:
+          type: string
+          description: Auto-generated description of the chart.
+        webpage_url:
+          type: string
+          format: uri
+          description: URL to the chart's dedicated page on Tako.
+        embed_url:
+          type: string
+          format: uri
+          description: URL for embedding the chart in an iframe.
+        image_url:
+          type: string
+          format: uri
+          description: Direct URL to a PNG image of the chart.
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /api/v1/knowledge_search:
+    post:
+      operationId: searchCharts
+      x-openai-isConsequential: false
+      summary: Search for charts and knowledge cards
+      description: >
+        Search Tako's index of data visualizations and knowledge cards using
+        natural language. Use this endpoint when the user is looking for an
+        existing chart, dataset, or statistic. Returns a ranked list of matching
+        knowledge cards with titles, descriptions, and URLs.
+
+
+        Typical use cases:
+
+        - "Find charts about US GDP growth"
+
+        - "Show me data on global smartphone shipments"
+
+        - "What are the latest unemployment statistics?"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchRequest"
+            example:
+              inputs:
+                text: "US GDP growth rate 2020-2024"
+                count: 5
+              source_indexes:
+                - tako
+              search_effort: deep
+              country_code: US
+              locale: en-US
+      responses:
+        "200":
+          description: Successful search returning matching knowledge cards.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchResponse"
+              example:
+                outputs:
+                  knowledge_cards:
+                    - card_id: "abc123"
+                      title: "US GDP Growth Rate (2020-2024)"
+                      description: "Quarterly GDP growth rate for the United States from 2020 through 2024, sourced from the Bureau of Economic Analysis."
+                      url: "https://tako.com/chart/abc123"
+                      source: "Bureau of Economic Analysis"
+                    - card_id: "def456"
+                      title: "US Real GDP Annual Change"
+                      description: "Year-over-year percentage change in real GDP for the United States."
+                      url: "https://tako.com/chart/def456"
+                      source: "World Bank"
+        "400":
+          description: Invalid request parameters.
+        "401":
+          description: Missing or invalid API key.
+
+  /api/v1/explore/:
+    post:
+      operationId: exploreKnowledgeGraph
+      x-openai-isConsequential: false
+      summary: Explore the Tako knowledge graph
+      description: >
+        Query Tako's knowledge graph to discover entities, metrics, cohorts, and
+        time periods related to a topic. Use this endpoint when the user wants to
+        understand what data is available about a subject before searching for or
+        creating a specific chart.
+
+
+        This is useful for:
+
+        - Discovering which metrics are tracked for a company or country
+
+        - Finding related entities or cohorts
+
+        - Understanding the time periods for which data exists
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExploreRequest"
+            example:
+              query: "Apple Inc revenue"
+              node_types:
+                - entity
+                - metric
+              limit: 10
+      responses:
+        "200":
+          description: Successful exploration returning matching graph nodes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExploreResponse"
+              example:
+                query: "Apple Inc revenue"
+                total_matches: 42
+                entities:
+                  - name: "Apple Inc"
+                    type: "company"
+                    id: "apple-inc"
+                metrics:
+                  - name: "Total Revenue"
+                    unit: "USD"
+                    id: "total-revenue"
+                  - name: "Services Revenue"
+                    unit: "USD"
+                    id: "services-revenue"
+                cohorts: []
+                time_periods:
+                  - label: "FY2024"
+                    start: "2023-10-01"
+                    end: "2024-09-30"
+        "400":
+          description: Invalid request parameters.
+        "401":
+          description: Missing or invalid API key.
+
+  /api/v1/image/{pub_id}/:
+    get:
+      operationId: getChartImage
+      x-openai-isConsequential: false
+      summary: Get a chart as a PNG image
+      description: >
+        Retrieve a rendered PNG image of a specific chart by its publication ID.
+        Use this endpoint when the user wants to see or display a chart visually.
+        The image can be rendered in light or dark mode.
+      parameters:
+        - name: pub_id
+          in: path
+          required: true
+          description: The publication ID of the chart to render.
+          schema:
+            type: string
+          example: "abc123"
+        - name: dark_mode
+          in: query
+          required: false
+          description: >
+            Whether to render the chart with a dark background.
+            Defaults to true.
+          schema:
+            type: boolean
+            default: true
+          example: true
+      responses:
+        "200":
+          description: PNG image of the chart.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Chart not found for the given pub_id.
+        "401":
+          description: Missing or invalid API key.
+
+  /api/v1/internal/chart-configs/{pub_id}/chart-insights/:
+    get:
+      operationId: getChartInsights
+      x-openai-isConsequential: false
+      summary: Get AI-generated insights for a chart
+      description: >
+        Retrieve AI-generated analytical insights and a natural-language
+        description for a specific chart. Use this endpoint after finding a chart
+        (via search or explore) to get a deeper understanding of the data it
+        presents. The effort parameter controls how thorough the analysis is.
+      parameters:
+        - name: pub_id
+          in: path
+          required: true
+          description: The publication ID of the chart to analyze.
+          schema:
+            type: string
+          example: "abc123"
+        - name: effort
+          in: query
+          required: false
+          description: >
+            Controls the depth of the insight generation.
+            "low" returns a quick summary, "medium" provides balanced analysis,
+            and "high" performs a thorough deep-dive.
+          schema:
+            type: string
+            enum:
+              - low
+              - medium
+              - high
+            default: medium
+          example: medium
+      responses:
+        "200":
+          description: AI-generated insights for the chart.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChartInsightsResponse"
+              example:
+                insights: >
+                  US GDP grew at an annualized rate of 2.8% in Q3 2024,
+                  exceeding expectations of 2.1%. The growth was primarily
+                  driven by consumer spending and government expenditure.
+                  This marks the eighth consecutive quarter of positive growth.
+                description: >
+                  This line chart shows the quarterly US GDP growth rate
+                  from Q1 2020 through Q3 2024, with values ranging from
+                  -31.2% during the pandemic trough to +33.8% in the
+                  subsequent recovery.
+        "404":
+          description: Chart not found for the given pub_id.
+        "401":
+          description: Missing or invalid API key.
+
+  /api/v1/thin_viz/default_schema/:
+    get:
+      operationId: listChartSchemas
+      x-openai-isConsequential: false
+      summary: List all available chart schemas
+      description: >
+        Retrieve a list of all available chart schemas (chart types) that can be
+        used to create new visualizations. Each schema defines a chart type
+        (e.g., bar chart, line chart, pie chart) and the components it accepts.
+        Use this endpoint to discover which chart types are available before
+        creating a new chart.
+      responses:
+        "200":
+          description: List of available chart schemas.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ChartSchemaListItem"
+              example:
+                - name: "bar_chart"
+                  description: "A vertical or horizontal bar chart for comparing values across categories."
+                  components:
+                    - component_type: "title"
+                    - component_type: "data_series"
+                    - component_type: "x_axis"
+                    - component_type: "y_axis"
+                - name: "line_chart"
+                  description: "A line chart for showing trends over time or continuous data."
+                  components:
+                    - component_type: "title"
+                    - component_type: "data_series"
+                    - component_type: "x_axis"
+                    - component_type: "y_axis"
+                - name: "pie_chart"
+                  description: "A pie or donut chart for showing proportions of a whole."
+                  components:
+                    - component_type: "title"
+                    - component_type: "data_series"
+        "401":
+          description: Missing or invalid API key.
+
+  /api/v1/thin_viz/default_schema/{schema_name}/:
+    get:
+      operationId: getChartSchema
+      x-openai-isConsequential: false
+      summary: Get detailed schema for a specific chart type
+      description: >
+        Retrieve the full schema definition for a specific chart type, including
+        all component definitions with their configuration options and a default
+        template. Use this endpoint after listing schemas to understand exactly
+        what data and configuration a particular chart type requires before
+        calling the create endpoint.
+      parameters:
+        - name: schema_name
+          in: path
+          required: true
+          description: >
+            The machine-readable name of the chart schema
+            (e.g., "bar_chart", "line_chart"). Obtain this from the
+            listChartSchemas endpoint.
+          schema:
+            type: string
+          example: "bar_chart"
+      responses:
+        "200":
+          description: Full schema definition for the requested chart type.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChartSchemaDetail"
+              example:
+                name: "bar_chart"
+                description: "A vertical or horizontal bar chart for comparing values across categories."
+                components:
+                  - component_type: "title"
+                    required: true
+                    config:
+                      text:
+                        type: "string"
+                        description: "The chart title text."
+                  - component_type: "data_series"
+                    required: true
+                    config:
+                      labels:
+                        type: "array"
+                        description: "Category labels for each bar."
+                      values:
+                        type: "array"
+                        description: "Numeric values for each bar."
+                  - component_type: "x_axis"
+                    required: false
+                    config:
+                      label:
+                        type: "string"
+                        description: "Label for the x-axis."
+                  - component_type: "y_axis"
+                    required: false
+                    config:
+                      label:
+                        type: "string"
+                        description: "Label for the y-axis."
+                template:
+                  orientation: "vertical"
+                  show_legend: true
+                  color_scheme: "default"
+        "404":
+          description: Schema not found for the given name.
+        "401":
+          description: Missing or invalid API key.
+
+  /api/v1/thin_viz/default_schema/{schema_name}/create/:
+    post:
+      operationId: createChart
+      x-openai-isConsequential: true
+      summary: Create a new chart from a schema
+      description: >
+        Create a new data visualization by populating a chart schema with
+        component data. Use this endpoint when the user wants to build a custom
+        chart from scratch. First call listChartSchemas to discover available
+        types, then getChartSchema to understand the required components, and
+        finally this endpoint to create the chart.
+
+
+        The response includes URLs for viewing, embedding, and downloading the
+        created chart.
+      parameters:
+        - name: schema_name
+          in: path
+          required: true
+          description: >
+            The chart schema to use for creation (e.g., "bar_chart", "line_chart").
+            Must be a valid schema name from the listChartSchemas endpoint.
+          schema:
+            type: string
+          example: "bar_chart"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateChartRequest"
+            example:
+              components:
+                - component_type: "title"
+                  config:
+                    text: "Top 5 Programming Languages by Popularity (2024)"
+                - component_type: "data_series"
+                  config:
+                    labels:
+                      - "Python"
+                      - "JavaScript"
+                      - "Java"
+                      - "TypeScript"
+                      - "C++"
+                    values:
+                      - 28.11
+                      - 15.71
+                      - 8.33
+                      - 7.72
+                      - 6.98
+                - component_type: "x_axis"
+                  config:
+                    label: "Language"
+                - component_type: "y_axis"
+                  config:
+                    label: "Popularity (%)"
+              source: "TIOBE Index"
+      responses:
+        "201":
+          description: Chart successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateChartResponse"
+              example:
+                card_id: "xyz789"
+                title: "Top 5 Programming Languages by Popularity (2024)"
+                description: "A bar chart comparing the popularity of the top 5 programming languages in 2024 according to the TIOBE Index."
+                webpage_url: "https://tako.com/chart/xyz789"
+                embed_url: "https://tako.com/embed/xyz789"
+                image_url: "https://api.tako.com/api/v1/image/xyz789/"
+        "400":
+          description: Invalid component configuration or missing required components.
+        "404":
+          description: Schema not found for the given name.
+        "401":
+          description: Missing or invalid API key.

--- a/integrations/vercel_ai_tako.ts
+++ b/integrations/vercel_ai_tako.ts
@@ -467,12 +467,147 @@ export function createTakoTools(
     },
   });
 
+  // -----------------------------------------------------------------------
+  // exploreKnowledgeGraph
+  // -----------------------------------------------------------------------
+  const exploreKnowledgeGraph = tool({
+    description:
+      "Use this when you need to discover what data is available before searching. " +
+      "Helps find entities (companies, countries), metrics (revenue, GDP), cohorts " +
+      "(S&P 500, G7), and time periods in Tako's knowledge graph.",
+    parameters: z.object({
+      query: z
+        .string()
+        .describe(
+          'Natural language query to explore (e.g. "tech companies", "GDP metrics").',
+        ),
+      nodeTypes: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Filter by node types: entity, metric, cohort, db, units, time_period, property.",
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(50)
+        .optional()
+        .default(20)
+        .describe("Maximum results per type (1-50)."),
+    }),
+    execute: async ({ query, nodeTypes, limit }) => {
+      try {
+        const data = await takoFetch<Record<string, unknown>>(
+          `${baseUrl}/api/v1/explore/`,
+          apiToken,
+          {
+            method: "POST",
+            body: JSON.stringify({
+              query,
+              node_types: nodeTypes,
+              limit,
+            }),
+          },
+        );
+
+        return {
+          query: data.query as string,
+          total_matches: (data.total_matches as number) ?? 0,
+          entities: (data.entities as unknown[]) ?? [],
+          metrics: (data.metrics as unknown[]) ?? [],
+          cohorts: (data.cohorts as unknown[]) ?? [],
+          time_periods: (data.time_periods as unknown[]) ?? [],
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Exploration failed",
+          message,
+          suggestion:
+            "Try a more specific query or filter by nodeTypes.",
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // getChartSchema
+  // -----------------------------------------------------------------------
+  const getChartSchema = tool({
+    description:
+      "Use this when you need the exact data format for a specific chart type. " +
+      "Returns schema details including required fields and configuration. " +
+      "Always call this before createChart.",
+    parameters: z.object({
+      schemaName: z
+        .string()
+        .describe(
+          'Schema name (e.g. "bar_chart", "timeseries_card", "pie_chart").',
+        ),
+    }),
+    execute: async ({ schemaName }) => {
+      try {
+        const data = await takoFetch<Record<string, unknown>>(
+          `${baseUrl}/api/v1/thin_viz/default_schema/${encodeURIComponent(schemaName)}/`,
+          apiToken,
+        );
+
+        return {
+          name: (data.name as string) ?? null,
+          description: (data.description as string) ?? null,
+          components: (data.components as unknown[]) ?? [],
+          template: data.template ?? null,
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Failed to get schema",
+          message,
+          suggestion:
+            "Use listChartSchemas to see available schema names.",
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // openChartUi
+  // -----------------------------------------------------------------------
+  const openChartUi = tool({
+    description:
+      "Use this when you want to display a fully interactive chart. Returns an " +
+      "embed URL with zooming, panning, and hover interactions. No API call needed.",
+    parameters: z.object({
+      pubId: z
+        .string()
+        .describe("The chart's unique identifier (pub_id / card_id)."),
+      darkMode: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Whether to use dark mode (default: true)."),
+    }),
+    execute: async ({ pubId, darkMode }) => {
+      const theme = darkMode ? "dark" : "light";
+      const embedUrl = `https://tako.com/embed/${pubId}/?theme=${theme}`;
+      return {
+        pub_id: pubId,
+        embed_url: embedUrl,
+        dark_mode: darkMode,
+      };
+    },
+  });
+
   return {
     searchCharts,
+    exploreKnowledgeGraph,
     createChart,
     listChartSchemas,
+    getChartSchema,
     getChartInsights,
     getChartImage,
+    openChartUi,
   } as const;
 }
 

--- a/integrations/vercel_ai_tako.ts
+++ b/integrations/vercel_ai_tako.ts
@@ -1,0 +1,480 @@
+/**
+ * Tako integration for the Vercel AI SDK.
+ *
+ * Provides Vercel AI SDK-compatible tool definitions that wrap the Tako API,
+ * enabling AI applications built with the Vercel AI SDK to search for charts,
+ * create visualisations, list chart schemas, retrieve AI-generated insights,
+ * and fetch chart images.
+ *
+ * @example
+ * ```ts
+ * import { generateText } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ * import { createTakoTools } from "./integrations/vercel_ai_tako";
+ *
+ * const takoTools = createTakoTools("your-tako-api-token");
+ *
+ * const result = await generateText({
+ *   model: openai("gpt-4o"),
+ *   tools: takoTools,
+ *   prompt: "Find charts about US GDP growth",
+ * });
+ * ```
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options accepted by {@link createTakoTools}. */
+export interface TakoToolsOptions {
+  /** Tako API token (from https://tako.com account settings). */
+  apiToken: string;
+  /** Base URL for the Tako API. Defaults to "https://api.tako.com". */
+  apiUrl?: string;
+}
+
+/** A single chart search result. */
+export interface TakoSearchResult {
+  card_id: string | null;
+  title: string | null;
+  description: string | null;
+  url: string | null;
+  source: string | null;
+}
+
+/** Response from the knowledge search endpoint. */
+export interface TakoSearchResponse {
+  results: TakoSearchResult[];
+  count: number;
+}
+
+/** Response from the create chart endpoint. */
+export interface TakoCreateChartResponse {
+  card_id: string | null;
+  title: string | null;
+  description: string | null;
+  webpage_url: string | null;
+  embed_url: string | null;
+  image_url: string | null;
+}
+
+/** A single schema entry returned by list schemas. */
+export interface TakoSchema {
+  name: string | null;
+  description: string | null;
+  components: unknown[];
+}
+
+/** Response from the list schemas endpoint. */
+export interface TakoListSchemasResponse {
+  schemas: TakoSchema[];
+  count: number;
+}
+
+/** Response from the chart insights endpoint. */
+export interface TakoInsightsResponse {
+  pub_id: string;
+  insights: string;
+  description: string;
+}
+
+/** Response from the chart image endpoint. */
+export interface TakoChartImageResponse {
+  image_url: string;
+  pub_id: string;
+  dark_mode: boolean;
+}
+
+/** Error response shape. */
+export interface TakoErrorResponse {
+  error: string;
+  message?: string;
+  suggestion?: string;
+  details?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_API_URL = "https://api.tako.com";
+
+function buildHeaders(apiToken: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "X-API-Key": apiToken,
+  };
+}
+
+async function takoFetch<T>(
+  url: string,
+  apiToken: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      ...buildHeaders(apiToken),
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => "");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(errorBody);
+    } catch {
+      parsed = { raw: errorBody };
+    }
+    throw Object.assign(
+      new Error(`Tako API error: HTTP ${response.status}`),
+      { status: response.status, body: parsed },
+    );
+  }
+
+  return (await response.json()) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create Tako tools for the Vercel AI SDK.
+ *
+ * @param apiToken - Your Tako API token.
+ * @param apiUrl   - Base URL for the Tako API. Defaults to `https://api.tako.com`.
+ * @returns An object of named Vercel AI SDK tools.
+ *
+ * @example
+ * ```ts
+ * import { generateText } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ * import { createTakoTools } from "./integrations/vercel_ai_tako";
+ *
+ * const tools = createTakoTools("tak_...");
+ *
+ * const { text } = await generateText({
+ *   model: openai("gpt-4o"),
+ *   tools,
+ *   prompt: "Find charts about global temperature trends",
+ * });
+ * ```
+ */
+export function createTakoTools(
+  apiToken: string,
+  apiUrl: string = DEFAULT_API_URL,
+) {
+  const baseUrl = apiUrl.replace(/\/+$/, "");
+
+  // -----------------------------------------------------------------------
+  // searchCharts
+  // -----------------------------------------------------------------------
+  const searchCharts = tool({
+    description:
+      "Use this when you need to find existing charts and data visualizations " +
+      "on any topic. Searches Tako's curated knowledge base of charts covering " +
+      "economics, finance, demographics, technology, and more. Returns matching " +
+      "charts with titles, descriptions, URLs, and source information.",
+    parameters: z.object({
+      query: z
+        .string()
+        .describe(
+          'Natural language search query (e.g. "US GDP growth", "Intel vs Nvidia revenue").',
+        ),
+      count: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .optional()
+        .default(5)
+        .describe("Number of results to return (1-20)."),
+      searchEffort: z
+        .enum(["fast", "deep"])
+        .optional()
+        .default("deep")
+        .describe('Search depth: "fast" or "deep".'),
+      countryCode: z
+        .string()
+        .optional()
+        .default("US")
+        .describe('ISO country code (e.g. "US", "GB").'),
+      locale: z
+        .string()
+        .optional()
+        .default("en-US")
+        .describe('Locale string (e.g. "en-US").'),
+    }),
+    execute: async ({
+      query,
+      count,
+      searchEffort,
+      countryCode,
+      locale,
+    }): Promise<TakoSearchResponse | TakoErrorResponse> => {
+      try {
+        const data = await takoFetch<{
+          outputs?: { knowledge_cards?: Record<string, unknown>[] };
+        }>(`${baseUrl}/api/v1/knowledge_search`, apiToken, {
+          method: "POST",
+          body: JSON.stringify({
+            inputs: { text: query, count },
+            source_indexes: ["tako"],
+            search_effort: searchEffort,
+            country_code: countryCode,
+            locale,
+          }),
+        });
+
+        const cards = data.outputs?.knowledge_cards ?? [];
+        const results: TakoSearchResult[] = cards.map((card) => ({
+          card_id: (card.card_id as string) ?? null,
+          title: (card.title as string) ?? null,
+          description: (card.description as string) ?? null,
+          url: (card.url as string) ?? null,
+          source: (card.source as string) ?? null,
+        }));
+
+        return { results, count: results.length };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Search failed",
+          message,
+          suggestion:
+            'Try search_effort "fast" or a more specific query. Check your API token.',
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // createChart
+  // -----------------------------------------------------------------------
+  const createChart = tool({
+    description:
+      "Use this when you need to create a new chart from raw data. Pass a " +
+      "schema name and component configurations to generate an interactive Tako " +
+      "visualisation. Supports 15+ chart types. Call listChartSchemas first to " +
+      "see available chart types.",
+    parameters: z.object({
+      schemaName: z
+        .string()
+        .describe(
+          'Chart schema name (e.g. "bar_chart", "timeseries_card", "pie_chart").',
+        ),
+      components: z
+        .array(z.record(z.unknown()))
+        .describe(
+          'Component configurations. Each object needs "component_type" and "config".',
+        ),
+      source: z
+        .string()
+        .optional()
+        .describe('Optional attribution text (e.g. "Yahoo Finance").'),
+    }),
+    execute: async ({
+      schemaName,
+      components,
+      source,
+    }): Promise<TakoCreateChartResponse | TakoErrorResponse> => {
+      try {
+        const payload: Record<string, unknown> = { components };
+        if (source) {
+          payload.source = source;
+        }
+
+        const data = await takoFetch<Record<string, unknown>>(
+          `${baseUrl}/api/v1/thin_viz/default_schema/${encodeURIComponent(schemaName)}/create/`,
+          apiToken,
+          {
+            method: "POST",
+            body: JSON.stringify(payload),
+          },
+        );
+
+        return {
+          card_id: (data.card_id as string) ?? null,
+          title: (data.title as string) ?? null,
+          description: (data.description as string) ?? null,
+          webpage_url: (data.webpage_url as string) ?? null,
+          embed_url: (data.embed_url as string) ?? null,
+          image_url: (data.image_url as string) ?? null,
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Chart creation failed",
+          message,
+          suggestion:
+            "Verify the schema name and component structure. Use listChartSchemas to see valid names.",
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // listChartSchemas
+  // -----------------------------------------------------------------------
+  const listChartSchemas = tool({
+    description:
+      "Use this when you want to see all available chart templates before " +
+      "creating a custom chart. Returns the full list of Tako chart schemas " +
+      "including timeseries, bar charts, pie charts, scatter plots, maps, and more.",
+    parameters: z.object({}),
+    execute: async (): Promise<
+      TakoListSchemasResponse | TakoErrorResponse
+    > => {
+      try {
+        const schemas = await takoFetch<Record<string, unknown>[]>(
+          `${baseUrl}/api/v1/thin_viz/default_schema/`,
+          apiToken,
+        );
+
+        const result: TakoSchema[] = schemas.map((s) => ({
+          name: (s.name as string) ?? null,
+          description: (s.description as string) ?? null,
+          components: (s.components as unknown[]) ?? [],
+        }));
+
+        return { schemas: result, count: result.length };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Failed to list schemas",
+          message,
+          suggestion: "Check your API token is valid and try again.",
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // getChartInsights
+  // -----------------------------------------------------------------------
+  const getChartInsights = tool({
+    description:
+      "Use this when you want AI-generated analysis of a chart's data. Returns " +
+      "bullet-point insights and a natural language description summarising " +
+      "trends, outliers, and key takeaways from the chart.",
+    parameters: z.object({
+      pubId: z
+        .string()
+        .describe("The chart's unique identifier (pub_id / card_id)."),
+      effort: z
+        .enum(["low", "medium", "high"])
+        .optional()
+        .default("medium")
+        .describe('Reasoning depth: "low", "medium", or "high".'),
+    }),
+    execute: async ({
+      pubId,
+      effort,
+    }): Promise<TakoInsightsResponse | TakoErrorResponse> => {
+      try {
+        const params = new URLSearchParams({ effort });
+        const data = await takoFetch<Record<string, unknown>>(
+          `${baseUrl}/api/v1/internal/chart-configs/${encodeURIComponent(pubId)}/chart-insights/?${params.toString()}`,
+          apiToken,
+        );
+
+        return {
+          pub_id: pubId,
+          insights: (data.insights as string) ?? "",
+          description: (data.description as string) ?? "",
+        };
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Failed to get insights",
+          message,
+          suggestion: "Verify the pub_id/card_id is correct.",
+        };
+      }
+    },
+  });
+
+  // -----------------------------------------------------------------------
+  // getChartImage
+  // -----------------------------------------------------------------------
+  const getChartImage = tool({
+    description:
+      "Use this when you need a static preview image of a chart to display or " +
+      "embed. Returns a direct URL to a PNG image of the chart.",
+    parameters: z.object({
+      pubId: z
+        .string()
+        .describe("The chart's unique identifier (pub_id / card_id)."),
+      darkMode: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Whether to return the dark-mode version (default: true)."),
+    }),
+    execute: async ({
+      pubId,
+      darkMode,
+    }): Promise<TakoChartImageResponse | TakoErrorResponse> => {
+      try {
+        const params = new URLSearchParams({
+          dark_mode: String(darkMode),
+        });
+        const url = `${baseUrl}/api/v1/image/${encodeURIComponent(pubId)}/?${params.toString()}`;
+
+        // We only need to verify the endpoint is reachable; the image URL
+        // itself is what we return.
+        const response = await fetch(url, {
+          method: "GET",
+          headers: buildHeaders(apiToken),
+        });
+
+        if (response.status === 200) {
+          return {
+            image_url: url,
+            pub_id: pubId,
+            dark_mode: darkMode,
+          };
+        } else if (response.status === 404) {
+          return {
+            error: "Chart image not found",
+            suggestion: "Verify the pub_id/card_id is correct.",
+          };
+        } else if (response.status === 408) {
+          return {
+            error: "Image generation timed out",
+            suggestion: "Wait a few seconds and try again.",
+          };
+        } else {
+          return {
+            error: `Unexpected HTTP ${response.status}`,
+            suggestion: "Check your API token and try again.",
+          };
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          error: "Failed to get chart image",
+          message,
+          suggestion: "Check your API token and try again.",
+        };
+      }
+    },
+  });
+
+  return {
+    searchCharts,
+    createChart,
+    listChartSchemas,
+    getChartInsights,
+    getChartImage,
+  } as const;
+}
+
+/** The return type of {@link createTakoTools}. */
+export type TakoTools = ReturnType<typeof createTakoTools>;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,2434 @@
+openapi: 3.1.0
+
+info:
+  title: Tako MCP Server
+  version: 0.1.0
+  summary: Data visualization agent — create, discover, and analyze interactive charts via MCP
+  description: |
+    ## Overview
+
+    The Tako MCP Server exposes Tako's knowledge base and interactive chart creation
+    capabilities through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/).
+    It allows AI agents to search 100,000+ curated charts covering economics, finance,
+    demographics, technology, and more, as well as create custom visualizations from
+    raw data using 15+ chart types.
+
+    ## Transports
+
+    The server supports two MCP transport mechanisms:
+
+    | Transport        | Endpoint       | Description                                      |
+    |------------------|----------------|--------------------------------------------------|
+    | Streamable HTTP  | `POST /mcp`    | Preferred. Single-endpoint bidirectional JSON-RPC |
+    | SSE              | `GET /sse`     | Legacy. Server-Sent Events with `/messages/` POST |
+
+    Agents should prefer the **Streamable HTTP** transport (`POST /mcp`). The SSE
+    transport is provided for backward compatibility with older MCP clients.
+
+    ## MCP Tools
+
+    The server registers **8 MCP tools** that agents invoke through the MCP protocol
+    (not as REST endpoints). They are documented in this spec under the
+    `x-mcp-tools` extension and also as virtual paths under `/x-mcp/tools/*` for
+    agent-readable reference.
+
+    ### Tool Categories
+
+    - **Discovery** — `knowledge_search`, `explore_knowledge_graph`
+    - **Retrieval** — `get_chart_image`, `get_card_insights`
+    - **Schema** — `list_chart_schemas`, `get_chart_schema`
+    - **Creation** — `create_chart`
+    - **Rendering** — `open_chart_ui`
+
+    ## Authentication
+
+    All MCP tool calls require a Tako API token passed as the `api_token` parameter.
+    REST endpoints accept either the `X-API-Key` header or a Bearer token in the
+    `Authorization` header. Obtain a token at [tako.com](https://tako.com).
+
+    ## Chart Types
+
+    Available chart schemas for `create_chart`:
+
+    `timeseries_card` | `stock_card` | `bar_chart` | `grouped_bar_chart` |
+    `pie_chart` | `scatter_chart` | `bubble_chart` | `histogram` | `boxplot` |
+    `choropleth` | `treemap` | `heatmap` | `waterfall` | `financial_boxes` |
+    `table` | `data_table_chart` | `header`
+
+  contact:
+    name: Tako
+    url: https://tako.com
+    email: hello@tako.com
+  license:
+    name: MIT
+    identifier: MIT
+    url: https://opensource.org/licenses/MIT
+  x-logo:
+    url: https://tako.com/favicon.ico
+    altText: Tako Logo
+
+servers:
+  - url: https://mcp.tako.com
+    description: Tako MCP Server — Production
+    x-agent-hints:
+      transport: streamable-http
+      preferred_endpoint: /mcp
+
+tags:
+  - name: Health
+    description: Service health and readiness checks
+  - name: Discovery
+    description: MCP server discovery and capability negotiation
+  - name: MCP Transport
+    description: Model Context Protocol transport endpoints
+  - name: MCP Tools — Search
+    description: Tools for searching and exploring Tako's knowledge base
+    x-semantic-tags:
+      - search
+      - discovery
+      - knowledge-base
+  - name: MCP Tools — Retrieval
+    description: Tools for retrieving chart images and AI-generated insights
+    x-semantic-tags:
+      - retrieval
+      - image
+      - insights
+      - analysis
+  - name: MCP Tools — Schema
+    description: Tools for listing and inspecting chart creation templates
+    x-semantic-tags:
+      - schema
+      - template
+      - chart-types
+  - name: MCP Tools — Creation
+    description: Tools for creating new charts from raw data
+    x-semantic-tags:
+      - create
+      - chart
+      - visualization
+  - name: MCP Tools — Rendering
+    description: Tools for rendering interactive chart UIs via MCP-UI
+    x-semantic-tags:
+      - render
+      - interactive
+      - mcp-ui
+      - embed
+
+paths:
+  # ---------------------------------------------------------------------------
+  # REST Endpoints
+  # ---------------------------------------------------------------------------
+
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Basic health check
+      description: |
+        Returns a plain-text `"ok"` response when the server is running.
+        Use this for simple liveness probes.
+      tags:
+        - Health
+      x-agent-hints:
+        usage: Use for liveness checks. A 200 response means the server process is alive.
+        caching: Safe to cache for 30 seconds.
+      x-semantic-tags:
+        - health
+        - liveness
+        - probe
+      responses:
+        "200":
+          description: Server is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+                const: ok
+              examples:
+                healthy:
+                  summary: Healthy response
+                  value: ok
+
+  /health/detailed:
+    get:
+      operationId: healthCheckDetailed
+      summary: Detailed health check
+      description: |
+        Returns a JSON object with service status, name, version, and current
+        server timestamp. Use this for readiness probes and monitoring dashboards.
+      tags:
+        - Health
+      x-agent-hints:
+        usage: Use for readiness checks and monitoring. Includes version and timestamp for diagnostics.
+        caching: Safe to cache for 10 seconds.
+      x-semantic-tags:
+        - health
+        - readiness
+        - monitoring
+        - version
+      responses:
+        "200":
+          description: Detailed health information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DetailedHealth"
+              examples:
+                healthy:
+                  summary: Healthy detailed response
+                  value:
+                    status: ok
+                    service: tako-mcp-server
+                    version: "0.1.0"
+                    timestamp: 1708790400.123
+
+  /.well-known/mcp:
+    get:
+      operationId: getMcpServerCard
+      summary: MCP Server Card
+      description: |
+        Returns the MCP Server Card (per the MCP discovery specification). This
+        describes the server's capabilities, available transports, authentication
+        requirements, and a summary of registered tools.
+
+        Agents and MCP clients use this endpoint for automatic server discovery
+        and capability negotiation.
+      tags:
+        - Discovery
+      x-agent-hints:
+        usage: >
+          Fetch this first when connecting to the Tako MCP server.
+          It tells you which transports are available, what tools are registered,
+          and how to authenticate.
+        caching: Safe to cache for 5 minutes. Tool list changes infrequently.
+      x-semantic-tags:
+        - discovery
+        - server-card
+        - capabilities
+        - mcp
+      responses:
+        "200":
+          description: MCP Server Card
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/McpServerCard"
+              examples:
+                serverCard:
+                  summary: Full server card
+                  value:
+                    protocolVersion: "2025-06-18"
+                    serverInfo:
+                      name: tako-mcp
+                      title: Tako MCP Server
+                      version: "0.1.0"
+                      description: >-
+                        Create and discover data visualizations. Search Tako's
+                        knowledge base of charts covering economics, finance,
+                        demographics, technology, and more. Create custom charts
+                        from raw data using 15+ chart types.
+                      iconUrl: https://tako.com/favicon.ico
+                      documentationUrl: https://github.com/TakoData/tako-mcp
+                    transport:
+                      - type: streamable-http
+                        endpoint: /mcp
+                      - type: sse
+                        endpoint: /sse
+                    capabilities:
+                      tools:
+                        listChanged: true
+                    authentication:
+                      required: true
+                      schemes:
+                        - bearer
+                    tools:
+                      - name: knowledge_search
+                        description: Search Tako's knowledge base for charts and data visualizations on any topic.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: false
+                      - name: explore_knowledge_graph
+                        description: Discover available entities, metrics, cohorts, and time periods.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: false
+                      - name: get_chart_image
+                        description: Get a static PNG preview image URL for a chart.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: false
+                      - name: get_card_insights
+                        description: Get AI-generated analysis and insights for a chart.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: false
+                      - name: list_chart_schemas
+                        description: List all available chart templates for creating custom visualizations.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: false
+                      - name: get_chart_schema
+                        description: Get the detailed schema and data format for a specific chart type.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: false
+                      - name: create_chart
+                        description: Create a new interactive chart from raw data using 15+ chart types.
+                        annotations:
+                          readOnlyHint: false
+                          destructiveHint: false
+                          openWorldHint: true
+                      - name: open_chart_ui
+                        description: Open a fully interactive chart with zooming, panning, and hover interactions.
+                        annotations:
+                          readOnlyHint: true
+                          destructiveHint: false
+                          openWorldHint: true
+
+  /mcp:
+    post:
+      operationId: mcpStreamableHttp
+      summary: Streamable HTTP transport for MCP
+      description: |
+        Primary MCP transport endpoint. Accepts JSON-RPC 2.0 messages and returns
+        responses via streaming HTTP. Supports all MCP protocol methods including
+        `tools/list`, `tools/call`, `initialize`, and `ping`.
+
+        This is the **preferred** transport. Use this endpoint for new integrations.
+      tags:
+        - MCP Transport
+      x-agent-hints:
+        usage: >
+          Send MCP JSON-RPC messages here. Supports initialize, tools/list,
+          tools/call, and other MCP methods. Responses are streamed.
+          Prefer this over the SSE transport for new integrations.
+        content_type: application/json
+        response_streaming: true
+      x-semantic-tags:
+        - mcp
+        - transport
+        - json-rpc
+        - streamable-http
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JsonRpcRequest"
+            examples:
+              initialize:
+                summary: Initialize MCP session
+                value:
+                  jsonrpc: "2.0"
+                  id: 1
+                  method: initialize
+                  params:
+                    protocolVersion: "2025-06-18"
+                    capabilities: {}
+                    clientInfo:
+                      name: my-agent
+                      version: "1.0.0"
+              listTools:
+                summary: List available tools
+                value:
+                  jsonrpc: "2.0"
+                  id: 2
+                  method: tools/list
+                  params: {}
+              callKnowledgeSearch:
+                summary: Call the knowledge_search tool
+                value:
+                  jsonrpc: "2.0"
+                  id: 3
+                  method: tools/call
+                  params:
+                    name: knowledge_search
+                    arguments:
+                      query: US GDP growth rate
+                      api_token: tak_your_api_token_here
+                      count: 5
+                      search_effort: deep
+      responses:
+        "200":
+          description: JSON-RPC response (may be streamed)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonRpcResponse"
+              examples:
+                initializeResponse:
+                  summary: Successful initialization
+                  value:
+                    jsonrpc: "2.0"
+                    id: 1
+                    result:
+                      protocolVersion: "2025-06-18"
+                      capabilities:
+                        tools:
+                          listChanged: true
+                      serverInfo:
+                        name: tako-knowledge
+                        version: "0.1.0"
+        "400":
+          description: Malformed JSON-RPC request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonRpcError"
+        "410":
+          description: Session expired or not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionExpiredError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonRpcError"
+
+  /sse:
+    get:
+      operationId: mcpSseConnect
+      summary: SSE transport — establish connection
+      description: |
+        Opens a Server-Sent Events stream for the legacy MCP SSE transport.
+        The server sends a `session_id` in the initial event. Subsequent
+        JSON-RPC messages must be POSTed to `/messages/?session_id={id}`.
+
+        **Note:** Prefer the Streamable HTTP transport (`POST /mcp`) for new
+        integrations. The SSE transport is maintained for backward compatibility.
+      tags:
+        - MCP Transport
+      x-agent-hints:
+        usage: >
+          Legacy transport. Connect here to receive an SSE stream with a session_id,
+          then POST JSON-RPC messages to /messages/?session_id=<id>.
+          Prefer POST /mcp for new integrations.
+        deprecated_in_favor_of: POST /mcp
+      x-semantic-tags:
+        - mcp
+        - transport
+        - sse
+        - legacy
+      responses:
+        "200":
+          description: SSE stream established
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: Server-Sent Events stream carrying JSON-RPC messages
+              examples:
+                sseConnection:
+                  summary: Initial SSE connection event
+                  value: "event: endpoint\ndata: /messages/?session_id=abc-123-def\n\n"
+
+  /messages/:
+    post:
+      operationId: mcpSseMessage
+      summary: SSE transport — send JSON-RPC message
+      description: |
+        Sends a JSON-RPC 2.0 message to an active SSE session. The `session_id`
+        query parameter must match a session established via `GET /sse`.
+
+        Responses are delivered through the SSE stream, not in the HTTP response body.
+      tags:
+        - MCP Transport
+      x-agent-hints:
+        usage: >
+          POST JSON-RPC messages here with a session_id from GET /sse.
+          Responses arrive via the SSE stream, not in the HTTP response.
+      x-semantic-tags:
+        - mcp
+        - transport
+        - sse
+        - json-rpc
+      parameters:
+        - name: session_id
+          in: query
+          required: true
+          description: Session ID obtained from the SSE endpoint
+          schema:
+            type: string
+            format: uuid
+          example: 550e8400-e29b-41d4-a716-446655440000
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JsonRpcRequest"
+            examples:
+              toolCall:
+                summary: Call knowledge_search via SSE transport
+                value:
+                  jsonrpc: "2.0"
+                  id: 1
+                  method: tools/call
+                  params:
+                    name: knowledge_search
+                    arguments:
+                      query: "S&P 500 performance"
+                      api_token: tak_your_api_token_here
+      responses:
+        "202":
+          description: Message accepted — response will arrive on the SSE stream
+        "404":
+          description: Session not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionExpiredError"
+              examples:
+                sessionNotFound:
+                  summary: Session not found
+                  value:
+                    error: Session expired or not found
+                    code: -32001
+                    message: Please reconnect to /sse to establish a new session
+                    reconnect: true
+        "410":
+          description: Session expired
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionExpiredError"
+
+  # ---------------------------------------------------------------------------
+  # Virtual paths documenting MCP Tools for agent consumption
+  # ---------------------------------------------------------------------------
+
+  /x-mcp/tools/knowledge_search:
+    post:
+      operationId: mcpTool_knowledgeSearch
+      summary: "MCP Tool: knowledge_search"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Search Tako's curated knowledge base of 100,000+ charts covering economics,
+        finance, demographics, technology, and more. Use when a user asks about data
+        trends, comparisons, or statistics — Tako likely already has a relevant
+        visualization.
+
+        Each result includes `open_ui_args` with the `pub_id` needed to render the
+        chart interactively via `open_chart_ui`.
+      tags:
+        - MCP Tools — Search
+      x-agent-hints:
+        usage: >
+          Start here when a user asks about data trends, comparisons, or statistics.
+          Use search_effort="deep" for comprehensive results or "fast" for speed.
+          Each result includes a card_id you can pass to get_chart_image,
+          get_card_insights, or open_chart_ui.
+        when_to_use:
+          - User asks about data trends or statistics
+          - User wants to find existing charts on a topic
+          - User asks to compare metrics across entities
+        when_not_to_use:
+          - User wants to create a chart from their own data (use create_chart)
+          - User wants to explore what data is available (use explore_knowledge_graph)
+        workflow: >
+          knowledge_search -> (optional) get_card_insights -> open_chart_ui
+      x-semantic-tags:
+        - search
+        - charts
+        - knowledge-base
+        - discovery
+        - data
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/KnowledgeSearchParams"
+            examples:
+              gdpSearch:
+                summary: Search for GDP charts
+                value:
+                  query: US GDP growth rate over the last 10 years
+                  api_token: tak_your_api_token_here
+                  count: 5
+                  search_effort: deep
+                  country_code: US
+                  locale: en-US
+              stockComparison:
+                summary: Compare tech stocks
+                value:
+                  query: Intel vs Nvidia revenue comparison
+                  api_token: tak_your_api_token_here
+                  count: 10
+                  search_effort: deep
+              climateData:
+                summary: Climate data search
+                value:
+                  query: global temperature change since 1900
+                  api_token: tak_your_api_token_here
+                  count: 3
+                  search_effort: fast
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnowledgeSearchResponse"
+              examples:
+                success:
+                  summary: Successful search with results
+                  value:
+                    results:
+                      - card_id: abc123
+                        title: "US GDP Growth Rate (2014-2024)"
+                        description: "Annual GDP growth rate of the United States over the last decade"
+                        url: https://tako.com/c/abc123
+                        source: World Bank
+                        open_ui_tool: open_chart_ui
+                        open_ui_args:
+                          pub_id: abc123
+                      - card_id: def456
+                        title: "US Real GDP Quarterly"
+                        description: "Quarterly real GDP data for the United States"
+                        url: https://tako.com/c/def456
+                        source: Bureau of Economic Analysis
+                        open_ui_tool: open_chart_ui
+                        open_ui_args:
+                          pub_id: def456
+                    count: 2
+                noResults:
+                  summary: No matching charts
+                  value:
+                    results: []
+                    count: 0
+
+  /x-mcp/tools/explore_knowledge_graph:
+    post:
+      operationId: mcpTool_exploreKnowledgeGraph
+      summary: "MCP Tool: explore_knowledge_graph"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Discover available entities (companies, countries), metrics (revenue, GDP),
+        cohorts (S&P 500, G7), and time periods in Tako's knowledge graph. Use this
+        to understand what data is available before searching, or to disambiguate
+        vague queries.
+      tags:
+        - MCP Tools — Search
+      x-agent-hints:
+        usage: >
+          Use before knowledge_search when the user's query is vague or you need
+          to understand what entities, metrics, or cohorts are available. Filter by
+          node_types to narrow results. Good for discovery and disambiguation.
+        when_to_use:
+          - User asks what data is available on a topic
+          - You need to disambiguate between similar entities
+          - You want to discover related metrics or cohorts
+        when_not_to_use:
+          - User already knows what chart they want (use knowledge_search)
+          - User wants to create a chart (use create_chart)
+        workflow: >
+          explore_knowledge_graph -> knowledge_search -> open_chart_ui
+      x-semantic-tags:
+        - explore
+        - knowledge-graph
+        - entities
+        - metrics
+        - cohorts
+        - discovery
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExploreKnowledgeGraphParams"
+            examples:
+              techCompanies:
+                summary: Explore tech company data
+                value:
+                  query: technology companies
+                  api_token: tak_your_api_token_here
+                  node_types:
+                    - entity
+                    - metric
+                  limit: 20
+              gdpMetrics:
+                summary: Explore GDP-related metrics
+                value:
+                  query: GDP
+                  api_token: tak_your_api_token_here
+                  node_types:
+                    - metric
+                    - cohort
+                  limit: 10
+      responses:
+        "200":
+          description: Knowledge graph exploration results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExploreKnowledgeGraphResponse"
+              examples:
+                success:
+                  summary: Successful exploration
+                  value:
+                    query: technology companies
+                    total_matches: 45
+                    entities:
+                      - name: Apple Inc.
+                        type: company
+                        description: American multinational technology company
+                        aliases:
+                          - AAPL
+                          - Apple
+                        available_tables:
+                          - financial_data
+                          - stock_prices
+                        node_id: entity_apple
+                      - name: NVIDIA Corporation
+                        type: company
+                        description: American multinational technology company specializing in GPUs
+                        aliases:
+                          - NVDA
+                          - Nvidia
+                        available_tables:
+                          - financial_data
+                          - stock_prices
+                        node_id: entity_nvidia
+                    metrics:
+                      - name: Revenue
+                        description: Total revenue / net sales
+                        units:
+                          - USD
+                          - EUR
+                        time_periods:
+                          - yearly
+                          - quarterly
+                        compatible_tables:
+                          - financial_data
+                        node_id: metric_revenue
+                    cohorts:
+                      - name: Magnificent 7
+                        description: Seven largest US technology companies by market cap
+                        member_count: 7
+                        sample_members:
+                          - Apple
+                          - Microsoft
+                          - Google
+                        node_id: cohort_mag7
+                    time_periods:
+                      - yearly
+                      - quarterly
+                      - monthly
+                    execution_time_ms: 142
+
+  /x-mcp/tools/get_chart_image:
+    post:
+      operationId: mcpTool_getChartImage
+      summary: "MCP Tool: get_chart_image"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Get a direct URL to a static PNG preview image of a chart. Useful for
+        embedding chart previews in responses, documents, or messages where
+        interactive rendering is not available.
+      tags:
+        - MCP Tools — Retrieval
+      x-agent-hints:
+        usage: >
+          Use when you need a static image URL for a chart (e.g., to embed in
+          a message or document). The URL points to a public PNG image. For
+          interactive rendering, prefer open_chart_ui instead.
+        when_to_use:
+          - You need a static image URL for embedding
+          - The client does not support MCP-UI interactive rendering
+          - You want a thumbnail preview
+        when_not_to_use:
+          - User wants interactive chart exploration (use open_chart_ui)
+        workflow: >
+          knowledge_search -> get_chart_image (for static preview)
+      x-semantic-tags:
+        - image
+        - preview
+        - png
+        - static
+        - embed
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetChartImageParams"
+            examples:
+              darkMode:
+                summary: Get dark mode chart image
+                value:
+                  pub_id: abc123
+                  api_token: tak_your_api_token_here
+                  dark_mode: true
+              lightMode:
+                summary: Get light mode chart image
+                value:
+                  pub_id: abc123
+                  api_token: tak_your_api_token_here
+                  dark_mode: false
+      responses:
+        "200":
+          description: Chart image URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetChartImageResponse"
+              examples:
+                success:
+                  summary: Image URL returned
+                  value:
+                    image_url: https://api.tako.com/api/v1/image/abc123/?dark_mode=true
+                    pub_id: abc123
+                    dark_mode: true
+
+  /x-mcp/tools/get_card_insights:
+    post:
+      operationId: mcpTool_getCardInsights
+      summary: "MCP Tool: get_card_insights"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Get AI-generated analysis of a chart's data. Returns bullet-point insights
+        identifying trends, outliers, and key takeaways, plus a natural language
+        description summarizing the chart.
+      tags:
+        - MCP Tools — Retrieval
+      x-agent-hints:
+        usage: >
+          Use after knowledge_search or create_chart to get AI-generated analysis
+          of a chart. The "medium" effort level balances speed and depth. Use "high"
+          for detailed analysis of complex charts.
+        when_to_use:
+          - User asks what a chart shows or means
+          - You need to summarize chart data in text
+          - User asks for trends or key takeaways
+        when_not_to_use:
+          - You just need the chart image (use get_chart_image)
+          - You need raw data (not available via this tool)
+        workflow: >
+          knowledge_search -> get_card_insights -> present summary to user
+      x-semantic-tags:
+        - insights
+        - analysis
+        - ai
+        - trends
+        - summary
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetCardInsightsParams"
+            examples:
+              medium:
+                summary: Medium-effort analysis
+                value:
+                  pub_id: abc123
+                  api_token: tak_your_api_token_here
+                  effort: medium
+              deep:
+                summary: Deep analysis
+                value:
+                  pub_id: abc123
+                  api_token: tak_your_api_token_here
+                  effort: high
+      responses:
+        "200":
+          description: AI-generated insights
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetCardInsightsResponse"
+              examples:
+                success:
+                  summary: Insights for a GDP chart
+                  value:
+                    pub_id: abc123
+                    insights: |
+                      - US GDP grew at an average rate of 2.3% annually over the last decade
+                      - The sharpest decline occurred in Q2 2020 (-31.2%) due to COVID-19
+                      - Recovery was rapid, with 33.8% growth in Q3 2020
+                      - Growth has normalized to 2-3% range since 2022
+                    description: >-
+                      This chart shows the annual GDP growth rate of the United States
+                      from 2014 to 2024. The data reveals a generally stable growth
+                      pattern interrupted by the COVID-19 pandemic, with a strong
+                      V-shaped recovery.
+
+  /x-mcp/tools/list_chart_schemas:
+    post:
+      operationId: mcpTool_listChartSchemas
+      summary: "MCP Tool: list_chart_schemas"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        List all available chart templates (schemas) for creating custom
+        visualizations. Returns schema names, descriptions, use cases, and
+        component structures. Call this first when the user wants to create
+        a new chart to understand what options are available.
+      tags:
+        - MCP Tools — Schema
+      x-agent-hints:
+        usage: >
+          Call this first when the user wants to create a chart. It returns all
+          available chart types with descriptions and use cases. Then call
+          get_chart_schema for the specific schema you want to use.
+        when_to_use:
+          - User wants to create a new chart
+          - You need to pick the right chart type for the user's data
+        when_not_to_use:
+          - You already know which chart type to use (go straight to get_chart_schema)
+        workflow: >
+          list_chart_schemas -> get_chart_schema -> create_chart -> open_chart_ui
+      x-semantic-tags:
+        - schema
+        - templates
+        - chart-types
+        - list
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListChartSchemasParams"
+            examples:
+              listAll:
+                summary: List all chart schemas
+                value:
+                  api_token: tak_your_api_token_here
+      responses:
+        "200":
+          description: Available chart schemas
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListChartSchemasResponse"
+              examples:
+                success:
+                  summary: Chart schemas list
+                  value:
+                    schemas:
+                      - name: bar_chart
+                        description: Simple categorical bar chart
+                        use_case: "Single-series categorical comparisons — revenue by region, top 10 lists"
+                        components:
+                          - header
+                          - categorical_bar
+                      - name: timeseries_card
+                        description: Time series line or area chart
+                        use_case: "Any time-based data — trends, growth rates, historical comparisons"
+                        components:
+                          - header
+                          - generic_timeseries
+                      - name: pie_chart
+                        description: Pie or donut chart
+                        use_case: "Proportional/percentage data — market share, budget allocation"
+                        components:
+                          - header
+                          - pie
+                      - name: choropleth
+                        description: Geographic map with shaded regions
+                        use_case: "Geographic map data — by US state or world country"
+                        components:
+                          - header
+                          - choropleth_map
+                    count: 4
+
+  /x-mcp/tools/get_chart_schema:
+    post:
+      operationId: mcpTool_getChartSchema
+      summary: "MCP Tool: get_chart_schema"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Get the detailed schema definition for a specific chart type. Returns
+        the required fields, data structure, component configuration, and
+        template details. Always call this before `create_chart` to understand
+        the exact data format needed.
+      tags:
+        - MCP Tools — Schema
+      x-agent-hints:
+        usage: >
+          Call this after list_chart_schemas to get the exact data format for a
+          chart type. The response tells you what components are needed and
+          their configuration schema. Use this to build the components array
+          for create_chart.
+        when_to_use:
+          - You've chosen a chart type and need to know the data format
+          - You need to validate data before calling create_chart
+        when_not_to_use:
+          - You don't know which chart type to use yet (use list_chart_schemas first)
+        workflow: >
+          list_chart_schemas -> get_chart_schema -> create_chart
+      x-semantic-tags:
+        - schema
+        - template
+        - data-format
+        - components
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: false
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GetChartSchemaParams"
+            examples:
+              barChart:
+                summary: Get bar chart schema
+                value:
+                  schema_name: bar_chart
+                  api_token: tak_your_api_token_here
+              timeseries:
+                summary: Get timeseries schema
+                value:
+                  schema_name: timeseries_card
+                  api_token: tak_your_api_token_here
+      responses:
+        "200":
+          description: Chart schema details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GetChartSchemaResponse"
+              examples:
+                barChartSchema:
+                  summary: Bar chart schema
+                  value:
+                    name: bar_chart
+                    description: Simple categorical bar chart
+                    components:
+                      - component_type: header
+                        required: true
+                        config:
+                          title:
+                            type: string
+                            required: true
+                          subtitle:
+                            type: string
+                            required: false
+                      - component_type: categorical_bar
+                        required: true
+                        config:
+                          datasets:
+                            type: array
+                            required: true
+                            items:
+                              label:
+                                type: string
+                              data:
+                                type: array
+                                items:
+                                  x:
+                                    type: string
+                                    description: Category label
+                                  "y":
+                                    type: number
+                                    description: Value
+                              units:
+                                type: string
+                          title:
+                            type: string
+                    template: {}
+
+  /x-mcp/tools/create_chart:
+    post:
+      operationId: mcpTool_createChart
+      summary: "MCP Tool: create_chart"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Create a new interactive chart from raw data. This is the primary chart
+        creation tool. Pass a schema name and your data as component configurations
+        to generate a hosted, shareable Tako visualization. Supports 15+ chart types.
+
+        **Recommended workflow:** `list_chart_schemas` -> `get_chart_schema` -> `create_chart`
+
+        The created chart gets a permanent URL and can be rendered interactively
+        via `open_chart_ui`.
+      tags:
+        - MCP Tools — Creation
+      x-agent-hints:
+        usage: >
+          Use this to create a new chart from user-provided or computed data.
+          Always call get_chart_schema first to understand the required data format.
+          The response includes a card_id, webpage_url (for sharing), image_url
+          (for preview), and open_ui_args (for interactive rendering).
+        when_to_use:
+          - User provides data and wants a visualization
+          - You have computed data that should be charted
+          - User asks to create, build, or make a chart
+        when_not_to_use:
+          - User is looking for an existing chart (use knowledge_search)
+          - You don't know the data format yet (use get_chart_schema first)
+        workflow: >
+          list_chart_schemas -> get_chart_schema -> create_chart -> open_chart_ui
+        important_notes:
+          - Always call get_chart_schema before create_chart to know the data format
+          - The components array must match the schema's expected structure
+          - Include a source attribution when the data origin is known
+      x-semantic-tags:
+        - create
+        - chart
+        - visualization
+        - data
+        - thinviz
+      x-tool-annotations:
+        readOnlyHint: false
+        destructiveHint: false
+        openWorldHint: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateChartParams"
+            examples:
+              barChart:
+                summary: Create a bar chart
+                value:
+                  schema_name: bar_chart
+                  components:
+                    - component_type: header
+                      config:
+                        title: Revenue by Region
+                        subtitle: Q4 2024
+                    - component_type: categorical_bar
+                      config:
+                        datasets:
+                          - label: Revenue
+                            data:
+                              - x: North America
+                                "y": 120
+                              - x: Europe
+                                "y": 98
+                              - x: Asia
+                                "y": 156
+                            units: "$M"
+                        title: Revenue by Region
+                  api_token: tak_your_api_token_here
+                  source: Company Reports
+              stockChart:
+                summary: Create a stock price chart
+                value:
+                  schema_name: stock_card
+                  components:
+                    - component_type: stock_boxes
+                      config:
+                        items:
+                          - labelPrimary: AAPL
+                            labelSecondary: NASDAQ
+                            valuePrimary: "$195.20"
+                            valueSecondary: USD
+                            subValue: "+$9.70 (+5.24%)"
+                    - component_type: generic_timeseries
+                      config:
+                        datasets:
+                          - label: AAPL
+                            data:
+                              - x: "2024-01-01"
+                                "y": 185.50
+                              - x: "2024-01-02"
+                                "y": 190.25
+                              - x: "2024-01-03"
+                                "y": 195.20
+                            type: line
+                            units: "$"
+                        chart_type: line
+                        title: AAPL Stock Price
+                  api_token: tak_your_api_token_here
+                  source: Yahoo Finance
+      responses:
+        "200":
+          description: Created chart
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateChartResponse"
+              examples:
+                success:
+                  summary: Chart created successfully
+                  value:
+                    card_id: xyz789
+                    title: Revenue by Region
+                    description: Q4 2024 revenue comparison across regions
+                    webpage_url: https://tako.com/c/xyz789
+                    embed_url: https://tako.com/embed/xyz789/
+                    image_url: https://api.tako.com/api/v1/image/xyz789/?dark_mode=true
+                    open_ui_tool: open_chart_ui
+                    open_ui_args:
+                      pub_id: xyz789
+
+  /x-mcp/tools/open_chart_ui:
+    post:
+      operationId: mcpTool_openChartUi
+      summary: "MCP Tool: open_chart_ui"
+      description: |
+        **Invoked via MCP protocol, not as a REST endpoint.**
+
+        Render a fully interactive chart with zooming, panning, hover interactions,
+        and responsive resizing via MCP-UI. Returns a `UIResource` containing an
+        HTML/iframe embed that MCP-UI-compatible clients can display inline.
+
+        Prefer this over `get_chart_image` when the client supports MCP-UI, as it
+        provides a much richer experience.
+      tags:
+        - MCP Tools — Rendering
+      x-agent-hints:
+        usage: >
+          Use this to show a chart interactively. The response is a UIResource
+          (not a URL) that MCP-UI-capable clients render as an embedded iframe.
+          Falls back gracefully — if the client doesn't support MCP-UI, suggest
+          using get_chart_image instead.
+        when_to_use:
+          - You want to display a chart to the user interactively
+          - After knowledge_search or create_chart, to show the result
+          - User asks to see, view, or open a chart
+        when_not_to_use:
+          - You need a static image URL (use get_chart_image)
+          - The client does not support MCP-UI rendering
+        workflow: >
+          knowledge_search -> open_chart_ui
+          create_chart -> open_chart_ui
+        note: >
+          This tool does NOT require an api_token since it generates a client-side
+          embed URL. The pub_id must reference a valid chart.
+      x-semantic-tags:
+        - render
+        - interactive
+        - mcp-ui
+        - embed
+        - iframe
+        - chart
+      x-tool-annotations:
+        readOnlyHint: true
+        destructiveHint: false
+        openWorldHint: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OpenChartUiParams"
+            examples:
+              default:
+                summary: Open chart with defaults
+                value:
+                  pub_id: abc123
+                  dark_mode: true
+                  width: 900
+                  height: 600
+              lightWide:
+                summary: Open chart in light mode, wider
+                value:
+                  pub_id: abc123
+                  dark_mode: false
+                  width: 1200
+                  height: 800
+      responses:
+        "200":
+          description: MCP-UI resource for interactive chart rendering
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OpenChartUiResponse"
+              examples:
+                success:
+                  summary: UIResource for chart embed
+                  value:
+                    uri: ui://tako/embed/abc123
+                    content:
+                      type: rawHtml
+                      htmlString: "<html><!-- interactive Tako chart embed --></html>"
+                    encoding: text
+                    uiMetadata:
+                      preferredFrameSize:
+                        - 900px
+                        - 600px
+
+# =============================================================================
+# Component Schemas
+# =============================================================================
+
+components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: Tako API token passed in the X-API-Key request header
+    ApiKeyParam:
+      type: apiKey
+      in: query
+      name: api_token
+      description: Tako API token passed as a query/body parameter (used in MCP tool calls)
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Tako API token passed as a Bearer token
+
+  schemas:
+    # -------------------------------------------------------------------------
+    # REST endpoint schemas
+    # -------------------------------------------------------------------------
+
+    DetailedHealth:
+      type: object
+      description: Detailed health check response
+      required:
+        - status
+        - service
+        - version
+        - timestamp
+      properties:
+        status:
+          type: string
+          description: Service status
+          enum:
+            - ok
+          example: ok
+        service:
+          type: string
+          description: Service name
+          example: tako-mcp-server
+        version:
+          type: string
+          description: Server version (semver)
+          pattern: "^\\d+\\.\\d+\\.\\d+$"
+          example: "0.1.0"
+        timestamp:
+          type: number
+          format: double
+          description: Unix timestamp (seconds since epoch)
+          example: 1708790400.123
+
+    McpServerCard:
+      type: object
+      description: MCP Server Card for discovery (per MCP specification)
+      required:
+        - protocolVersion
+        - serverInfo
+        - transport
+        - capabilities
+      properties:
+        protocolVersion:
+          type: string
+          description: MCP protocol version
+          example: "2025-06-18"
+        serverInfo:
+          $ref: "#/components/schemas/McpServerInfo"
+        transport:
+          type: array
+          description: Available MCP transports
+          items:
+            $ref: "#/components/schemas/McpTransport"
+        capabilities:
+          type: object
+          description: Server capabilities
+          properties:
+            tools:
+              type: object
+              properties:
+                listChanged:
+                  type: boolean
+                  description: Whether the server supports tools/listChanged notifications
+        authentication:
+          type: object
+          description: Authentication requirements
+          properties:
+            required:
+              type: boolean
+            schemes:
+              type: array
+              items:
+                type: string
+        tools:
+          type: array
+          description: Summary of registered tools
+          items:
+            $ref: "#/components/schemas/McpToolSummary"
+
+    McpServerInfo:
+      type: object
+      description: Server identification information
+      required:
+        - name
+        - version
+      properties:
+        name:
+          type: string
+          example: tako-mcp
+        title:
+          type: string
+          example: Tako MCP Server
+        version:
+          type: string
+          example: "0.1.0"
+        description:
+          type: string
+        iconUrl:
+          type: string
+          format: uri
+          example: https://tako.com/favicon.ico
+        documentationUrl:
+          type: string
+          format: uri
+          example: https://github.com/TakoData/tako-mcp
+
+    McpTransport:
+      type: object
+      description: MCP transport endpoint description
+      required:
+        - type
+        - endpoint
+      properties:
+        type:
+          type: string
+          enum:
+            - streamable-http
+            - sse
+          description: Transport type
+        endpoint:
+          type: string
+          description: URL path for this transport
+          example: /mcp
+
+    McpToolSummary:
+      type: object
+      description: Summary of an MCP tool (as listed in the server card)
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          description: Tool name
+        description:
+          type: string
+          description: Brief tool description
+        annotations:
+          $ref: "#/components/schemas/ToolAnnotations"
+
+    ToolAnnotations:
+      type: object
+      description: MCP tool behavior annotations
+      properties:
+        readOnlyHint:
+          type: boolean
+          description: Whether the tool only reads data (no side effects)
+        destructiveHint:
+          type: boolean
+          description: Whether the tool may destructively modify data
+        openWorldHint:
+          type: boolean
+          description: Whether the tool interacts with the open world (network, UI)
+
+    # -------------------------------------------------------------------------
+    # JSON-RPC schemas
+    # -------------------------------------------------------------------------
+
+    JsonRpcRequest:
+      type: object
+      description: JSON-RPC 2.0 request
+      required:
+        - jsonrpc
+        - method
+      properties:
+        jsonrpc:
+          type: string
+          const: "2.0"
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Request ID (omit for notifications)
+        method:
+          type: string
+          description: MCP method name
+          examples:
+            - initialize
+            - tools/list
+            - tools/call
+            - ping
+        params:
+          type: object
+          description: Method parameters
+
+    JsonRpcResponse:
+      type: object
+      description: JSON-RPC 2.0 success response
+      required:
+        - jsonrpc
+        - id
+      properties:
+        jsonrpc:
+          type: string
+          const: "2.0"
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+        result:
+          description: Result payload (varies by method)
+
+    JsonRpcError:
+      type: object
+      description: JSON-RPC 2.0 error response
+      required:
+        - jsonrpc
+        - id
+        - error
+      properties:
+        jsonrpc:
+          type: string
+          const: "2.0"
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+            - type: "null"
+        error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: integer
+              description: JSON-RPC error code
+            message:
+              type: string
+              description: Error message
+            data:
+              description: Additional error data
+
+    SessionExpiredError:
+      type: object
+      description: Session expired or not found error
+      properties:
+        error:
+          type: string
+          example: Session expired or not found
+        code:
+          type: integer
+          example: -32001
+        message:
+          type: string
+          example: Please reconnect to /sse to establish a new session
+        reconnect:
+          type: boolean
+          example: true
+
+    # -------------------------------------------------------------------------
+    # MCP Tool parameter schemas
+    # -------------------------------------------------------------------------
+
+    KnowledgeSearchParams:
+      type: object
+      description: Parameters for the knowledge_search MCP tool
+      required:
+        - query
+        - api_token
+      properties:
+        query:
+          type: string
+          description: |
+            Natural language search query for charts and data.
+            Examples: "US GDP growth", "Intel vs Nvidia revenue", "climate change temperature data"
+          minLength: 1
+          maxLength: 1000
+          examples:
+            - US GDP growth rate
+            - Intel vs Nvidia revenue comparison
+            - global temperature change
+        api_token:
+          type: string
+          description: Tako API token for authentication. Obtain at https://tako.com
+        count:
+          type: integer
+          description: Number of results to return
+          minimum: 1
+          maximum: 20
+          default: 5
+        search_effort:
+          type: string
+          description: |
+            Search depth. "fast" returns quick results with lower latency.
+            "deep" performs a comprehensive search for better relevance.
+          enum:
+            - fast
+            - deep
+          default: deep
+        country_code:
+          type: string
+          description: ISO 3166-1 alpha-2 country code for localized results
+          pattern: "^[A-Z]{2}$"
+          default: US
+          examples:
+            - US
+            - GB
+            - DE
+            - JP
+        locale:
+          type: string
+          description: BCP 47 locale code for result language and formatting
+          pattern: "^[a-z]{2}-[A-Z]{2}$"
+          default: en-US
+          examples:
+            - en-US
+            - en-GB
+            - de-DE
+
+    KnowledgeSearchResponse:
+      type: object
+      description: Results from the knowledge_search tool
+      required:
+        - results
+        - count
+      properties:
+        results:
+          type: array
+          description: Matching charts from Tako's knowledge base
+          items:
+            $ref: "#/components/schemas/KnowledgeSearchResult"
+        count:
+          type: integer
+          description: Number of results returned
+          minimum: 0
+
+    KnowledgeSearchResult:
+      type: object
+      description: A single chart result from knowledge search
+      properties:
+        card_id:
+          type: string
+          description: Unique chart identifier (pub_id). Use with other tools.
+          example: abc123
+        title:
+          type: string
+          description: Chart title
+          example: "US GDP Growth Rate (2014-2024)"
+        description:
+          type: string
+          description: Brief description of the chart content
+        url:
+          type: string
+          format: uri
+          description: Public URL to view the chart on tako.com
+          example: https://tako.com/c/abc123
+        source:
+          type: string
+          description: Data source attribution
+          example: World Bank
+        open_ui_tool:
+          type: string
+          description: Name of the tool to call for interactive rendering
+          const: open_chart_ui
+        open_ui_args:
+          type: object
+          description: Arguments to pass to open_chart_ui
+          properties:
+            pub_id:
+              type: string
+
+    ExploreKnowledgeGraphParams:
+      type: object
+      description: Parameters for the explore_knowledge_graph MCP tool
+      required:
+        - query
+        - api_token
+      properties:
+        query:
+          type: string
+          description: |
+            Natural language query to explore. Examples: "tech companies",
+            "GDP metrics", "automotive industry"
+          minLength: 1
+          maxLength: 500
+        api_token:
+          type: string
+          description: Tako API token for authentication
+        node_types:
+          type: array
+          description: |
+            Filter results to specific node types. If omitted, all types are returned.
+          items:
+            type: string
+            enum:
+              - entity
+              - metric
+              - cohort
+              - db
+              - units
+              - time_period
+              - property
+          examples:
+            - - entity
+              - metric
+        limit:
+          type: integer
+          description: Maximum number of results per node type
+          minimum: 1
+          maximum: 50
+          default: 20
+
+    ExploreKnowledgeGraphResponse:
+      type: object
+      description: Results from the explore_knowledge_graph tool
+      required:
+        - query
+        - total_matches
+      properties:
+        query:
+          type: string
+          description: The original query
+        total_matches:
+          type: integer
+          description: Total number of matching nodes across all types
+          minimum: 0
+        entities:
+          type: array
+          description: Matching entities (companies, countries, people, organizations)
+          items:
+            $ref: "#/components/schemas/KnowledgeGraphEntity"
+        metrics:
+          type: array
+          description: Matching metrics (measurements like revenue, GDP, temperature)
+          items:
+            $ref: "#/components/schemas/KnowledgeGraphMetric"
+        cohorts:
+          type: array
+          description: Matching cohorts (groups like S&P 500, BRICS, G7)
+          items:
+            $ref: "#/components/schemas/KnowledgeGraphCohort"
+        time_periods:
+          type: array
+          description: Available time granularities
+          items:
+            type: string
+          examples:
+            - - yearly
+              - quarterly
+              - monthly
+        execution_time_ms:
+          type: number
+          description: Query execution time in milliseconds
+          minimum: 0
+
+    KnowledgeGraphEntity:
+      type: object
+      description: An entity node in the knowledge graph
+      properties:
+        name:
+          type: string
+          description: Entity name
+          example: Apple Inc.
+        type:
+          type: string
+          description: Entity type (e.g., company, country, person)
+          example: company
+        description:
+          type: string
+          description: Brief description of the entity
+        aliases:
+          type: array
+          description: Alternative names or ticker symbols
+          items:
+            type: string
+          maxItems: 3
+          examples:
+            - - AAPL
+              - Apple
+        available_tables:
+          type: array
+          description: Data tables containing this entity
+          items:
+            type: string
+          maxItems: 3
+        node_id:
+          type: string
+          description: Unique node identifier in the knowledge graph
+
+    KnowledgeGraphMetric:
+      type: object
+      description: A metric node in the knowledge graph
+      properties:
+        name:
+          type: string
+          description: Metric name
+          example: Revenue
+        description:
+          type: string
+          description: What this metric measures
+        units:
+          type: array
+          description: Available measurement units
+          items:
+            type: string
+          maxItems: 3
+          examples:
+            - - USD
+              - EUR
+        time_periods:
+          type: array
+          description: Available time granularities for this metric
+          items:
+            type: string
+          maxItems: 3
+        compatible_tables:
+          type: array
+          description: Data tables containing this metric
+          items:
+            type: string
+          maxItems: 3
+        node_id:
+          type: string
+          description: Unique node identifier in the knowledge graph
+
+    KnowledgeGraphCohort:
+      type: object
+      description: A cohort node in the knowledge graph
+      properties:
+        name:
+          type: string
+          description: Cohort name
+          example: S&P 500
+        description:
+          type: string
+          description: What this cohort represents
+        member_count:
+          type: integer
+          description: Number of members in the cohort
+        sample_members:
+          type: array
+          description: Example members of the cohort
+          items:
+            type: string
+        node_id:
+          type: string
+          description: Unique node identifier in the knowledge graph
+
+    GetChartImageParams:
+      type: object
+      description: Parameters for the get_chart_image MCP tool
+      required:
+        - pub_id
+        - api_token
+      properties:
+        pub_id:
+          type: string
+          description: Unique chart identifier (card_id from knowledge_search or create_chart)
+        api_token:
+          type: string
+          description: Tako API token for authentication
+        dark_mode:
+          type: boolean
+          description: Whether to return the dark mode version of the image
+          default: true
+
+    GetChartImageResponse:
+      type: object
+      description: Response from the get_chart_image tool
+      required:
+        - image_url
+        - pub_id
+        - dark_mode
+      properties:
+        image_url:
+          type: string
+          format: uri
+          description: Direct URL to the PNG chart image
+          example: https://api.tako.com/api/v1/image/abc123/?dark_mode=true
+        pub_id:
+          type: string
+          description: The chart identifier
+        dark_mode:
+          type: boolean
+          description: Whether dark mode was applied
+
+    GetCardInsightsParams:
+      type: object
+      description: Parameters for the get_card_insights MCP tool
+      required:
+        - pub_id
+        - api_token
+      properties:
+        pub_id:
+          type: string
+          description: Unique chart identifier (card_id from knowledge_search or create_chart)
+        api_token:
+          type: string
+          description: Tako API token for authentication
+        effort:
+          type: string
+          description: |
+            Reasoning effort level for the AI analysis.
+            "low" gives a quick summary, "medium" provides balanced analysis,
+            "high" does deep analysis with more detail.
+          enum:
+            - low
+            - medium
+            - high
+          default: medium
+
+    GetCardInsightsResponse:
+      type: object
+      description: Response from the get_card_insights tool
+      required:
+        - pub_id
+        - insights
+        - description
+      properties:
+        pub_id:
+          type: string
+          description: The chart identifier
+        insights:
+          type: string
+          description: |
+            Bullet-point AI analysis of the chart data. Identifies trends,
+            outliers, comparisons, and key takeaways.
+        description:
+          type: string
+          description: |
+            Natural language narrative summary of the chart content and
+            its significance.
+
+    ListChartSchemasParams:
+      type: object
+      description: Parameters for the list_chart_schemas MCP tool
+      required:
+        - api_token
+      properties:
+        api_token:
+          type: string
+          description: Tako API token for authentication
+
+    ListChartSchemasResponse:
+      type: object
+      description: Response from the list_chart_schemas tool
+      required:
+        - schemas
+        - count
+      properties:
+        schemas:
+          type: array
+          description: Available chart schemas
+          items:
+            $ref: "#/components/schemas/ChartSchemaSummary"
+        count:
+          type: integer
+          description: Total number of available schemas
+          minimum: 0
+
+    ChartSchemaSummary:
+      type: object
+      description: Summary of a chart schema (template)
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: |
+            Schema name — pass this to get_chart_schema or create_chart.
+            Available values: timeseries_card, stock_card, bar_chart,
+            grouped_bar_chart, pie_chart, scatter_chart, bubble_chart,
+            histogram, boxplot, choropleth, treemap, heatmap, waterfall,
+            financial_boxes, table, data_table_chart, header
+          enum:
+            - timeseries_card
+            - stock_card
+            - bar_chart
+            - grouped_bar_chart
+            - pie_chart
+            - scatter_chart
+            - bubble_chart
+            - histogram
+            - boxplot
+            - choropleth
+            - treemap
+            - heatmap
+            - waterfall
+            - financial_boxes
+            - table
+            - data_table_chart
+            - header
+        description:
+          type: string
+          description: Brief description of the chart type
+        use_case:
+          type: string
+          description: When to use this chart type (guidance for agents)
+        components:
+          type: array
+          description: Component types required by this schema
+          items:
+            type: string
+
+    GetChartSchemaParams:
+      type: object
+      description: Parameters for the get_chart_schema MCP tool
+      required:
+        - schema_name
+        - api_token
+      properties:
+        schema_name:
+          type: string
+          description: Name of the chart schema to retrieve
+          enum:
+            - timeseries_card
+            - stock_card
+            - bar_chart
+            - grouped_bar_chart
+            - pie_chart
+            - scatter_chart
+            - bubble_chart
+            - histogram
+            - boxplot
+            - choropleth
+            - treemap
+            - heatmap
+            - waterfall
+            - financial_boxes
+            - table
+            - data_table_chart
+            - header
+        api_token:
+          type: string
+          description: Tako API token for authentication
+
+    GetChartSchemaResponse:
+      type: object
+      description: Response from the get_chart_schema tool
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Schema name
+        description:
+          type: string
+          description: Schema description
+        components:
+          type: array
+          description: Component definitions with their configuration schemas
+          items:
+            type: object
+            description: Component definition
+            properties:
+              component_type:
+                type: string
+                description: Component type name
+              required:
+                type: boolean
+                description: Whether this component is required
+              config:
+                type: object
+                description: Configuration schema for this component
+        template:
+          type: object
+          description: Template metadata and defaults
+
+    CreateChartParams:
+      type: object
+      description: Parameters for the create_chart MCP tool
+      required:
+        - schema_name
+        - components
+        - api_token
+      properties:
+        schema_name:
+          type: string
+          description: Name of the chart schema to use
+          enum:
+            - timeseries_card
+            - stock_card
+            - bar_chart
+            - grouped_bar_chart
+            - pie_chart
+            - scatter_chart
+            - bubble_chart
+            - histogram
+            - boxplot
+            - choropleth
+            - treemap
+            - heatmap
+            - waterfall
+            - financial_boxes
+            - table
+            - data_table_chart
+            - header
+        components:
+          type: array
+          description: |
+            List of component configurations matching the schema requirements.
+            Each component needs a "component_type" and "config" field.
+            Use get_chart_schema to see the expected structure.
+          items:
+            $ref: "#/components/schemas/ChartComponent"
+          minItems: 1
+        api_token:
+          type: string
+          description: Tako API token for authentication
+        source:
+          type: string
+          description: |
+            Data source attribution (e.g., "Yahoo Finance", "Company Reports",
+            "World Bank"). Displayed on the chart for transparency.
+
+    ChartComponent:
+      type: object
+      description: |
+        A single component in a chart. Components are the building blocks of
+        Tako charts — each schema requires specific component types.
+      required:
+        - component_type
+        - config
+      properties:
+        component_type:
+          type: string
+          description: |
+            The type of component. Common types include: header, categorical_bar,
+            generic_timeseries, pie, scatter, choropleth_map, stock_boxes,
+            grouped_bar, bubble, histogram, boxplot, treemap, heatmap,
+            waterfall, financial_boxes, table, data_table
+        config:
+          type: object
+          description: |
+            Component configuration. Structure varies by component_type.
+            Use get_chart_schema to see the exact format.
+          additionalProperties: true
+
+    CreateChartResponse:
+      type: object
+      description: Response from the create_chart tool
+      required:
+        - card_id
+      properties:
+        card_id:
+          type: string
+          description: Unique identifier for the created chart
+          example: xyz789
+        title:
+          type: string
+          description: Generated chart title
+        description:
+          type: string
+          description: Generated chart description
+        webpage_url:
+          type: string
+          format: uri
+          description: Public URL to view the chart on tako.com
+          example: https://tako.com/c/xyz789
+        embed_url:
+          type: string
+          format: uri
+          description: Embeddable URL for iframes
+          example: https://tako.com/embed/xyz789/
+        image_url:
+          type: string
+          format: uri
+          description: Direct URL to a PNG preview of the chart
+          example: https://api.tako.com/api/v1/image/xyz789/?dark_mode=true
+        open_ui_tool:
+          type: string
+          description: Name of the tool to call for interactive rendering
+          const: open_chart_ui
+        open_ui_args:
+          type: object
+          description: Arguments to pass to open_chart_ui
+          properties:
+            pub_id:
+              type: string
+
+    OpenChartUiParams:
+      type: object
+      description: Parameters for the open_chart_ui MCP tool
+      required:
+        - pub_id
+      properties:
+        pub_id:
+          type: string
+          description: Unique chart identifier (card_id from knowledge_search or create_chart)
+        dark_mode:
+          type: boolean
+          description: Whether to use dark mode theme
+          default: true
+        width:
+          type: integer
+          description: Initial width of the chart embed in pixels
+          default: 900
+          minimum: 200
+          maximum: 2000
+        height:
+          type: integer
+          description: Initial height of the chart embed in pixels
+          default: 600
+          minimum: 200
+          maximum: 2000
+
+    OpenChartUiResponse:
+      type: object
+      description: |
+        MCP-UI resource for interactive chart rendering. This is a UIResource
+        object that MCP-UI-compatible clients can render inline.
+      required:
+        - uri
+        - content
+        - encoding
+      properties:
+        uri:
+          type: string
+          description: MCP-UI resource URI
+          pattern: "^ui://tako/embed/.+"
+          example: ui://tako/embed/abc123
+        content:
+          type: object
+          description: Content payload
+          required:
+            - type
+            - htmlString
+          properties:
+            type:
+              type: string
+              const: rawHtml
+              description: Content type — always "rawHtml" for chart embeds
+            htmlString:
+              type: string
+              description: |
+                Complete HTML document containing an iframe embed of the
+                interactive Tako chart. Includes responsive resize handling.
+        encoding:
+          type: string
+          const: text
+          description: Content encoding
+        uiMetadata:
+          type: object
+          description: UI rendering hints
+          properties:
+            preferredFrameSize:
+              type: array
+              description: "Preferred [width, height] as CSS values"
+              items:
+                type: string
+              minItems: 2
+              maxItems: 2
+              examples:
+                - - 900px
+                  - 600px
+
+    # -------------------------------------------------------------------------
+    # Error schemas
+    # -------------------------------------------------------------------------
+
+    ToolError:
+      type: object
+      description: Error response from an MCP tool call
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Error type or HTTP status code
+        message:
+          type: string
+          description: Human-readable error message
+        pub_id:
+          type: string
+          description: Chart ID (if applicable)
+        details:
+          type: object
+          description: Additional error details (e.g., validation errors)
+        suggestion:
+          type: string
+          description: Suggested action to resolve the error
+
+# =============================================================================
+# x-mcp-tools extension — Canonical MCP tool definitions for agent consumption
+# =============================================================================
+
+x-mcp-tools:
+  - name: knowledge_search
+    title: "Tako: Search Charts"
+    description: >
+      Search Tako's curated knowledge base of 100,000+ charts covering economics,
+      finance, demographics, technology, and more. Use when a user asks about data
+      trends, comparisons, or statistics.
+    inputSchema:
+      $ref: "#/components/schemas/KnowledgeSearchParams"
+    outputSchema:
+      $ref: "#/components/schemas/KnowledgeSearchResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    x-agent-hints:
+      category: search
+      typical_latency_ms: 2000-8000
+      workflow_position: entry_point
+
+  - name: explore_knowledge_graph
+    title: "Tako: Explore Knowledge Graph"
+    description: >
+      Discover available entities, metrics, cohorts, and time periods in Tako's
+      knowledge graph. Use to disambiguate queries or understand what data is available.
+    inputSchema:
+      $ref: "#/components/schemas/ExploreKnowledgeGraphParams"
+    outputSchema:
+      $ref: "#/components/schemas/ExploreKnowledgeGraphResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    x-agent-hints:
+      category: search
+      typical_latency_ms: 1000-5000
+      workflow_position: entry_point
+
+  - name: get_chart_image
+    title: "Tako: Get Chart Image"
+    description: >
+      Get a direct URL to a static PNG preview image of a chart. Useful for
+      embedding in responses or documents.
+    inputSchema:
+      $ref: "#/components/schemas/GetChartImageParams"
+    outputSchema:
+      $ref: "#/components/schemas/GetChartImageResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    x-agent-hints:
+      category: retrieval
+      typical_latency_ms: 500-3000
+      workflow_position: after_search
+
+  - name: get_card_insights
+    title: "Tako: Get AI Insights"
+    description: >
+      Get AI-generated bullet-point analysis and natural language description
+      for a chart. Identifies trends, outliers, and key takeaways.
+    inputSchema:
+      $ref: "#/components/schemas/GetCardInsightsParams"
+    outputSchema:
+      $ref: "#/components/schemas/GetCardInsightsResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    x-agent-hints:
+      category: retrieval
+      typical_latency_ms: 3000-15000
+      workflow_position: after_search
+
+  - name: list_chart_schemas
+    title: "Tako: List Chart Types"
+    description: >
+      List all available chart templates for creating custom visualizations.
+      Returns schema names, descriptions, use cases, and component structures.
+    inputSchema:
+      $ref: "#/components/schemas/ListChartSchemasParams"
+    outputSchema:
+      $ref: "#/components/schemas/ListChartSchemasResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    x-agent-hints:
+      category: schema
+      typical_latency_ms: 200-1000
+      workflow_position: before_create
+
+  - name: get_chart_schema
+    title: "Tako: Get Chart Schema"
+    description: >
+      Get the detailed schema definition for a specific chart type including
+      required fields, data structure, and configuration options.
+    inputSchema:
+      $ref: "#/components/schemas/GetChartSchemaParams"
+    outputSchema:
+      $ref: "#/components/schemas/GetChartSchemaResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: false
+    x-agent-hints:
+      category: schema
+      typical_latency_ms: 200-1000
+      workflow_position: before_create
+
+  - name: create_chart
+    title: "Tako: Create Chart"
+    description: >
+      Create a new interactive chart from raw data. Supports 15+ chart types
+      including timeseries, bar charts, scatter plots, pie charts, maps, and more.
+      The chart is hosted and shareable.
+    inputSchema:
+      $ref: "#/components/schemas/CreateChartParams"
+    outputSchema:
+      $ref: "#/components/schemas/CreateChartResponse"
+    annotations:
+      readOnlyHint: false
+      destructiveHint: false
+      openWorldHint: true
+    x-agent-hints:
+      category: creation
+      typical_latency_ms: 3000-10000
+      workflow_position: create
+      prerequisite_tools:
+        - get_chart_schema
+
+  - name: open_chart_ui
+    title: "Tako: Open Interactive Chart"
+    description: >
+      Render a fully interactive chart with zooming, panning, hover interactions,
+      and responsive resizing via MCP-UI. Returns a UIResource for inline rendering.
+    inputSchema:
+      $ref: "#/components/schemas/OpenChartUiParams"
+    outputSchema:
+      $ref: "#/components/schemas/OpenChartUiResponse"
+    annotations:
+      readOnlyHint: true
+      destructiveHint: false
+      openWorldHint: true
+    x-agent-hints:
+      category: rendering
+      typical_latency_ms: 100-500
+      workflow_position: final
+      note: Does not require api_token — generates a client-side embed URL.
+
+security:
+  - ApiKeyHeader: []
+  - BearerAuth: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [
-    { name = "Tako", email = "hello@trytako.com" }
+    { name = "Tako", email = "hello@tako.com" }
 ]
 keywords = ["mcp", "model-context-protocol", "data-visualization", "charts", "knowledge-base"]
 classifiers = [

--- a/registry/awesome-mcp-servers.md
+++ b/registry/awesome-mcp-servers.md
@@ -1,0 +1,31 @@
+### [Tako MCP Server](https://github.com/TakoData/tako-mcp)
+
+Data visualization and chart discovery MCP server. Search Tako's knowledge base of 100K+ professionally curated charts and create custom interactive visualizations from raw data.
+
+**Features:**
+
+- **Knowledge Search** -- Search 100K+ charts covering economics, finance, demographics, technology, and more
+- **Knowledge Graph Exploration** -- Discover available entities, metrics, cohorts, and time periods across datasets
+- **AI-Generated Insights** -- Get automated analysis and key takeaways for any chart
+- **Custom Chart Creation** -- Build interactive charts from raw data using 15+ chart types
+- **Interactive MCP-UI Rendering** -- View charts with full zoom, pan, and hover interactions directly in the client
+- **Static PNG Previews** -- Get chart preview images for embedding in conversations
+
+**Chart Types Supported:**
+
+- Timeseries (line, area, stacked area)
+- Bar charts (vertical, horizontal, grouped, stacked)
+- Scatter plots
+- Pie and donut charts
+- Geographic maps (choropleth, bubble)
+- Heatmaps
+- Treemaps
+- Sankey diagrams
+- And more (15+ total)
+
+**Connection:**
+
+- **Hosted server:** `https://mcp.tako.com/sse` (SSE and Streamable HTTP)
+- **Install via pip:** `pip install tako-mcp`
+- **Docker:** `ghcr.io/takodata/tako-mcp:latest`
+- **Homepage:** [tako.com](https://tako.com)

--- a/registry/docker-mcp.yaml
+++ b/registry/docker-mcp.yaml
@@ -1,0 +1,81 @@
+# Docker MCP Catalog Configuration for Tako MCP Server
+# https://docker.com/mcp
+
+image: ghcr.io/takodata/tako-mcp:latest
+name: tako-mcp
+
+description: |
+  Tako MCP Server for data visualization. Search a knowledge base of 100K+
+  charts covering economics, finance, demographics, and technology. Create
+  custom interactive charts from raw data using 15+ chart types including
+  timeseries, bar charts, scatter plots, pie charts, maps, heatmaps,
+  treemaps, and more.
+
+ports:
+  - 8001
+
+environment:
+  PUBLIC_BASE_URL:
+    description: Base URL for the Tako platform
+    default: "https://tako.com"
+    required: true
+  TAKO_API_URL:
+    description: Tako API endpoint URL (override for custom deployments)
+    required: false
+  PORT:
+    description: Port the server listens on
+    default: "8001"
+    required: false
+  HOST:
+    description: Host address the server binds to
+    default: "0.0.0.0"
+    required: false
+
+health_check:
+  endpoint: /health
+  interval: 30s
+  timeout: 10s
+  retries: 3
+
+labels:
+  com.docker.mcp.name: tako-mcp
+  com.docker.mcp.display-name: Tako MCP Server
+  com.docker.mcp.description: >
+    Create and discover data visualizations with Tako's knowledge base
+    of 100K+ charts. Build custom charts from raw data.
+  com.docker.mcp.version: "0.1.0"
+  com.docker.mcp.license: MIT
+  com.docker.mcp.author: Tako
+  com.docker.mcp.repository: https://github.com/TakoData/tako-mcp
+  com.docker.mcp.homepage: https://tako.com
+  com.docker.mcp.transport: sse
+  com.docker.mcp.categories: data-visualization,charts,analytics,knowledge-base
+
+tags:
+  - latest
+  - "0.1.0"
+
+# Docker run example
+run:
+  command: >
+    docker run -d
+    --name tako-mcp
+    -p 8001:8001
+    -e PUBLIC_BASE_URL=https://tako.com
+    ghcr.io/takodata/tako-mcp:latest
+
+# Docker compose snippet
+compose:
+  services:
+    tako-mcp:
+      image: ghcr.io/takodata/tako-mcp:latest
+      ports:
+        - "8001:8001"
+      environment:
+        PUBLIC_BASE_URL: https://tako.com
+      healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+        interval: 30s
+        timeout: 10s
+        retries: 3
+      restart: unless-stopped

--- a/registry/glama.yaml
+++ b/registry/glama.yaml
@@ -1,0 +1,110 @@
+# Glama MCP Marketplace Configuration for Tako MCP Server
+# https://glama.ai/mcp/servers
+
+name: tako-mcp
+display_name: Tako MCP Server
+
+description: |
+  Tako MCP Server lets AI assistants create and discover data visualizations.
+  Search Tako's curated knowledge base of 100K+ charts spanning economics,
+  finance, demographics, technology, and more. Create custom interactive charts
+  from raw data using 15+ chart types including timeseries, bar charts, scatter
+  plots, pie charts, geographic maps, heatmaps, treemaps, and sankey diagrams.
+
+  Key capabilities:
+  - Knowledge search across 100K+ professionally curated charts
+  - Knowledge graph exploration for entities, metrics, cohorts, and time periods
+  - AI-generated insights and analysis for any chart
+  - Custom chart creation from raw data with 15+ chart types
+  - Interactive chart rendering via MCP-UI (zoom, pan, hover)
+  - Static PNG chart previews for embedding
+
+version: "0.1.0"
+
+author:
+  name: Tako
+  email: hello@tako.com
+  url: https://tako.com
+
+repository: https://github.com/TakoData/tako-mcp
+license: MIT
+
+categories:
+  - data-visualization
+  - charts
+  - analytics
+  - knowledge-base
+
+tags:
+  - charts
+  - data-visualization
+  - thinviz
+  - interactive-charts
+  - mcp-ui
+  - knowledge-base
+  - analytics
+
+tools:
+  - name: knowledge_search
+    description: >
+      Search Tako's knowledge base for charts and data visualizations on any topic.
+      Use when a user asks about data trends, comparisons, or statistics.
+  - name: explore_knowledge_graph
+    description: >
+      Discover available entities, metrics, cohorts, and time periods. Use to
+      understand what data is available before searching.
+  - name: get_chart_image
+    description: >
+      Get a static PNG preview image URL for a chart.
+  - name: get_card_insights
+    description: >
+      Get AI-generated insights and analysis for a chart.
+  - name: list_chart_schemas
+    description: >
+      List all available chart templates for creating custom visualizations.
+  - name: get_chart_schema
+    description: >
+      Get the detailed schema and data format for a specific chart type.
+  - name: create_chart
+    description: >
+      Create a new interactive chart from raw data using 15+ chart types
+      including timeseries, bar charts, scatter plots, pie charts, maps, and more.
+  - name: open_chart_ui
+    description: >
+      Open a fully interactive chart with zooming, panning, and hover
+      interactions via MCP-UI.
+
+installation:
+  pip:
+    command: pip install tako-mcp
+    entrypoint: tako-mcp
+  docker:
+    image: ghcr.io/takodata/tako-mcp:latest
+    ports:
+      - "8001:8001"
+    environment:
+      PUBLIC_BASE_URL: https://tako.com
+
+hosted_server:
+  url: https://mcp.tako.com/sse
+  transport:
+    - sse
+    - streamable-http
+
+transport:
+  - sse
+  - streamable-http
+
+authentication:
+  type: api_key
+  description: >
+    Tako API token. Sign up at tako.com and create a token in your
+    account settings.
+  setup_url: https://tako.com
+
+links:
+  homepage: https://tako.com
+  documentation: https://github.com/TakoData/tako-mcp#readme
+  repository: https://github.com/TakoData/tako-mcp
+  issues: https://github.com/TakoData/tako-mcp/issues
+  mcp_server: https://mcp.tako.com

--- a/registry/mcp-index.json
+++ b/registry/mcp-index.json
@@ -1,0 +1,99 @@
+{
+  "name": "tako-mcp",
+  "title": "Tako MCP Server",
+  "description": "Create and discover data visualizations. Search Tako's knowledge base of 100K+ charts covering economics, finance, demographics, and technology. Create custom charts from raw data using 15+ chart types including timeseries, bar charts, scatter plots, pie charts, maps, heatmaps, treemaps, and more.",
+  "version": "0.1.0",
+  "repository": "https://github.com/TakoData/tako-mcp",
+  "homepage": "https://tako.com",
+  "license": "MIT",
+  "author": {
+    "name": "Tako",
+    "email": "hello@tako.com",
+    "url": "https://tako.com"
+  },
+  "categories": [
+    "Data Visualization",
+    "Charts",
+    "Analytics",
+    "Knowledge Base"
+  ],
+  "tags": [
+    "charts",
+    "data-visualization",
+    "thinviz",
+    "interactive-charts",
+    "mcp-ui",
+    "knowledge-base",
+    "analytics"
+  ],
+  "tools": [
+    {
+      "name": "knowledge_search",
+      "description": "Search Tako's knowledge base for charts and data visualizations on any topic. Use when a user asks about data trends, comparisons, or statistics."
+    },
+    {
+      "name": "explore_knowledge_graph",
+      "description": "Discover available entities, metrics, cohorts, and time periods. Use to understand what data is available before searching."
+    },
+    {
+      "name": "get_chart_image",
+      "description": "Get a static PNG preview image URL for a chart."
+    },
+    {
+      "name": "get_card_insights",
+      "description": "Get AI-generated insights and analysis for a chart."
+    },
+    {
+      "name": "list_chart_schemas",
+      "description": "List all available chart templates for creating custom visualizations."
+    },
+    {
+      "name": "get_chart_schema",
+      "description": "Get the detailed schema and data format for a specific chart type."
+    },
+    {
+      "name": "create_chart",
+      "description": "Create a new interactive chart from raw data using 15+ chart types including timeseries, bar charts, scatter plots, pie charts, maps, and more."
+    },
+    {
+      "name": "open_chart_ui",
+      "description": "Open a fully interactive chart with zooming, panning, and hover interactions via MCP-UI."
+    }
+  ],
+  "installation": {
+    "pip": {
+      "command": "pip install tako-mcp",
+      "entrypoint": "tako-mcp"
+    },
+    "docker": {
+      "image": "ghcr.io/takodata/tako-mcp:latest",
+      "ports": ["8001:8001"],
+      "environment": {
+        "PUBLIC_BASE_URL": "https://tako.com"
+      }
+    },
+    "hosted": {
+      "url": "https://mcp.tako.com/sse",
+      "description": "Connect directly to Tako's hosted MCP server without local installation."
+    }
+  },
+  "transport": {
+    "supported": ["sse", "streamable-http"],
+    "default": "sse",
+    "endpoint": "/sse",
+    "port": 8001
+  },
+  "authentication": {
+    "type": "api_key",
+    "description": "Tako API token. Sign up at tako.com and create a token in your account settings.",
+    "setup_url": "https://tako.com"
+  },
+  "links": {
+    "homepage": "https://tako.com",
+    "documentation": "https://github.com/TakoData/tako-mcp#readme",
+    "repository": "https://github.com/TakoData/tako-mcp",
+    "issues": "https://github.com/TakoData/tako-mcp/issues",
+    "changelog": "https://github.com/TakoData/tako-mcp/releases",
+    "mcp_server": "https://mcp.tako.com"
+  }
+}

--- a/src/tako_mcp/main.py
+++ b/src/tako_mcp/main.py
@@ -16,7 +16,7 @@ from tako.types.knowledge_search.types import KnowledgeSearchSourceIndex, Knowle
 from tako.types.visualize.types import TakoDataFormatDataset
 
 TAKO_API_KEY = os.getenv("TAKO_API_KEY")
-X_TAKO_URL = os.getenv("X_TAKO_URL", "https://trytako.com/")
+X_TAKO_URL = os.getenv("X_TAKO_URL", "https://tako.com/")
 ENVIRONMENT = os.getenv("ENVIRONMENT")
 PORT = os.getenv("PORT", 8001)
 HOST = os.getenv("HOST", "0.0.0.0")

--- a/src/tako_mcp/server.py
+++ b/src/tako_mcp/server.py
@@ -18,6 +18,7 @@ import re
 import sys
 import time
 import urllib.parse
+from typing import Any
 
 import httpx
 from anyio import ClosedResourceError
@@ -25,6 +26,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp_ui_server import UIMetadataKey, create_ui_resource
 from mcp_ui_server.core import UIResource
+from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse, PlainTextResponse
 
 # Suppress noisy logs from dependencies
@@ -68,6 +70,172 @@ mcp = FastMCP(
 )
 
 
+# =============================================================================
+# Structured output models (MCP structuredContent)
+# =============================================================================
+
+
+class SearchResultItem(BaseModel):
+    """A single chart result from a knowledge search."""
+
+    card_id: str | None = Field(default=None, description="Unique chart identifier")
+    title: str | None = Field(default=None, description="Chart title")
+    description: str | None = Field(default=None, description="Chart description")
+    url: str | None = Field(default=None, description="Chart URL on Tako")
+    source: str | None = Field(default=None, description="Data source attribution")
+    open_ui_tool: str | None = Field(
+        default=None, description="Tool name to open interactive chart"
+    )
+    open_ui_args: dict[str, Any] | None = Field(
+        default=None, description="Arguments for open_chart_ui tool"
+    )
+
+
+class SearchResults(BaseModel):
+    """Results from a knowledge search query."""
+
+    results: list[SearchResultItem] = Field(description="List of matching charts")
+    count: int = Field(description="Number of results returned")
+
+
+class ChartImageResult(BaseModel):
+    """Result from getting a chart preview image."""
+
+    image_url: str = Field(description="Public URL to the PNG chart image")
+    pub_id: str = Field(description="Chart identifier")
+    dark_mode: bool = Field(description="Whether dark mode was used")
+
+
+class ChartInsightsResult(BaseModel):
+    """AI-generated insights for a chart."""
+
+    pub_id: str = Field(description="Chart identifier")
+    insights: str = Field(description="Bullet-point analysis of chart data")
+    description: str = Field(description="Narrative summary of the chart")
+
+
+class EntityResult(BaseModel):
+    """An entity from the knowledge graph."""
+
+    name: str | None = Field(default=None, description="Entity name")
+    type: str | None = Field(default=None, description="Entity type")
+    description: str | None = Field(default=None, description="Entity description")
+    aliases: list[str] = Field(default_factory=list, description="Alternative names")
+    available_tables: list[str] = Field(
+        default_factory=list, description="Related data tables"
+    )
+    node_id: str | None = Field(default=None, description="Knowledge graph node ID")
+
+
+class MetricResult(BaseModel):
+    """A metric from the knowledge graph."""
+
+    name: str | None = Field(default=None, description="Metric name")
+    description: str | None = Field(default=None, description="Metric description")
+    units: list[str] = Field(default_factory=list, description="Measurement units")
+    time_periods: list[str] = Field(
+        default_factory=list, description="Available time granularities"
+    )
+    compatible_tables: list[str] = Field(
+        default_factory=list, description="Compatible data tables"
+    )
+    node_id: str | None = Field(default=None, description="Knowledge graph node ID")
+
+
+class CohortResult(BaseModel):
+    """A cohort/group from the knowledge graph."""
+
+    name: str | None = Field(default=None, description="Cohort name")
+    description: str | None = Field(default=None, description="Cohort description")
+    member_count: int | None = Field(
+        default=None, description="Number of members in the cohort"
+    )
+    sample_members: list[str] = Field(
+        default_factory=list, description="Example members"
+    )
+    node_id: str | None = Field(default=None, description="Knowledge graph node ID")
+
+
+class KnowledgeGraphResult(BaseModel):
+    """Results from exploring the knowledge graph."""
+
+    query: str | None = Field(default=None, description="Original query")
+    total_matches: int = Field(default=0, description="Total number of matches")
+    entities: list[EntityResult] = Field(
+        default_factory=list, description="Matching entities"
+    )
+    metrics: list[MetricResult] = Field(
+        default_factory=list, description="Matching metrics"
+    )
+    cohorts: list[CohortResult] = Field(
+        default_factory=list, description="Matching cohorts"
+    )
+    time_periods: list[Any] = Field(
+        default_factory=list, description="Available time periods"
+    )
+    execution_time_ms: int = Field(default=0, description="Query execution time in ms")
+
+
+class SchemaEntry(BaseModel):
+    """A chart schema/template entry."""
+
+    name: str | None = Field(default=None, description="Schema name identifier")
+    description: str | None = Field(default=None, description="Schema description")
+    use_case: str = Field(default="", description="Recommended use case for this chart type")
+    components: list[dict[str, Any]] = Field(
+        default_factory=list, description="Component definitions"
+    )
+
+
+class ChartSchemaList(BaseModel):
+    """List of available chart schemas."""
+
+    schemas: list[SchemaEntry] = Field(description="Available chart templates")
+    count: int = Field(description="Number of schemas")
+
+
+class ChartSchemaDetail(BaseModel):
+    """Detailed schema for a specific chart type."""
+
+    name: str | None = Field(default=None, description="Schema name")
+    description: str | None = Field(default=None, description="Schema description")
+    components: list[dict[str, Any]] = Field(
+        default_factory=list, description="Component definitions with configs"
+    )
+    template: dict[str, Any] | None = Field(
+        default=None, description="Template configuration"
+    )
+
+
+class ChartCreateResult(BaseModel):
+    """Result from creating a new chart."""
+
+    card_id: str | None = Field(default=None, description="New chart's unique identifier")
+    title: str | None = Field(default=None, description="Chart title")
+    description: str | None = Field(default=None, description="Chart description")
+    webpage_url: str | None = Field(
+        default=None, description="URL to view the chart on Tako"
+    )
+    embed_url: str | None = Field(
+        default=None, description="URL to embed the chart"
+    )
+    image_url: str | None = Field(
+        default=None, description="URL to a static PNG preview"
+    )
+    open_ui_tool: str | None = Field(
+        default=None, description="Tool name to open interactive chart"
+    )
+    open_ui_args: dict[str, Any] | None = Field(
+        default=None, description="Arguments for open_chart_ui tool"
+    )
+
+
+class TakoToolError(Exception):
+    """Error raised by Tako tools to signal failure to the MCP client."""
+
+    pass
+
+
 def _get_auth_header(api_token: str | None) -> dict:
     """Build request headers with authentication."""
     headers = {"Content-Type": "application/json"}
@@ -89,7 +257,7 @@ async def knowledge_search(
     search_effort: str = "deep",
     country_code: str = "US",
     locale: str = "en-US",
-) -> str:
+) -> SearchResults:
     """
     Use this when you need to find existing charts and data visualizations on any topic.
     This searches Tako's curated knowledge base of charts covering economics, finance,
@@ -106,8 +274,8 @@ async def knowledge_search(
         locale: Locale for results (e.g., "en-US", "en-GB")
 
     Returns:
-        JSON with matching charts including card_id, title, description, url, and source.
-        Each result includes open_ui_args for rendering the chart interactively.
+        SearchResults with matching charts including card_id, title, description, url, source,
+        and open_ui_args for rendering charts interactively.
     """
     start_time = time.time()
     try:
@@ -134,46 +302,36 @@ async def knowledge_search(
             results = []
             for card in cards:
                 card_id = card.get("card_id")
-                result = {
-                    "card_id": card_id,
-                    "title": card.get("title"),
-                    "description": card.get("description"),
-                    "url": card.get("url"),
-                    "source": card.get("source"),
-                }
-                if card_id:
-                    result["open_ui_tool"] = "open_chart_ui"
-                    result["open_ui_args"] = {"pub_id": card_id}
-                results.append(result)
+                item = SearchResultItem(
+                    card_id=card_id,
+                    title=card.get("title"),
+                    description=card.get("description"),
+                    url=card.get("url"),
+                    source=card.get("source"),
+                    open_ui_tool="open_chart_ui" if card_id else None,
+                    open_ui_args={"pub_id": card_id} if card_id else None,
+                )
+                results.append(item)
 
             elapsed_time = time.time() - start_time
             logging.debug(
                 f"knowledge_search completed in {elapsed_time:.2f}s: "
                 f"query={query[:50]}, count={len(results)}, effort={search_effort}"
             )
-            return json.dumps({"results": results, "count": len(results)}, indent=2)
+            return SearchResults(results=results, count=len(results))
     except httpx.TimeoutException:
         elapsed_time = time.time() - start_time
         logging.warning(
             f"knowledge_search timed out after {elapsed_time:.2f}s: "
             f"query={query[:50]}, effort={search_effort}"
         )
-        return json.dumps(
-            {
-                "error": "Request timed out",
-                "message": "The search request took too long.",
-                "suggestion": "Try using search_effort='fast' for quicker results, or use a more specific query.",
-            },
-            indent=2,
+        raise TakoToolError(
+            "Request timed out. Try using search_effort='fast' for quicker results, "
+            "or use a more specific query."
         )
     except httpx.HTTPStatusError as e:
-        return json.dumps(
-            {
-                "error": f"HTTP {e.response.status_code}",
-                "message": str(e),
-                "suggestion": "Check your API token is valid and try again.",
-            },
-            indent=2,
+        raise TakoToolError(
+            f"HTTP {e.response.status_code}: Check your API token is valid and try again."
         )
 
 
@@ -187,7 +345,7 @@ async def get_chart_image(
     pub_id: str,
     api_token: str,
     dark_mode: bool = True,
-) -> str:
+) -> ChartImageResult:
     """
     Use this when you need a static preview image of a chart to display or embed.
     Returns a direct URL to a PNG image of the chart. Useful for including chart
@@ -199,7 +357,7 @@ async def get_chart_image(
         dark_mode: Whether to return dark mode version of the image (default: True)
 
     Returns:
-        JSON with image_url (public PNG URL), pub_id, and dark_mode setting
+        ChartImageResult with image_url (public PNG URL), pub_id, and dark_mode setting.
     """
     async with httpx.AsyncClient(timeout=60.0) as client:
         resp = await client.get(
@@ -210,32 +368,24 @@ async def get_chart_image(
 
         if resp.status_code == 200:
             image_url = f"{PUBLIC_API_URL}/api/v1/image/{pub_id}/?dark_mode={str(dark_mode).lower()}"
-            return json.dumps(
-                {
-                    "image_url": image_url,
-                    "pub_id": pub_id,
-                    "dark_mode": dark_mode,
-                },
-                indent=2,
+            return ChartImageResult(
+                image_url=image_url, pub_id=pub_id, dark_mode=dark_mode
             )
         elif resp.status_code == 404:
-            return json.dumps({
-                "error": "Chart image not found",
-                "pub_id": pub_id,
-                "suggestion": "Verify the pub_id/card_id is correct. Use knowledge_search to find valid chart IDs.",
-            })
+            raise TakoToolError(
+                f"Chart image not found for pub_id '{pub_id}'. "
+                "Use knowledge_search to find valid chart IDs."
+            )
         elif resp.status_code == 408:
-            return json.dumps({
-                "error": "Image generation timed out",
-                "pub_id": pub_id,
-                "suggestion": "The image is still rendering. Wait a few seconds and try again.",
-            })
+            raise TakoToolError(
+                "Image generation timed out. The image is still rendering. "
+                "Wait a few seconds and try again."
+            )
         else:
             resp.raise_for_status()
-            return json.dumps({
-                "error": "Unexpected error",
-                "suggestion": "Check your API token and try again. If the issue persists, the Tako API may be temporarily unavailable.",
-            })
+            raise TakoToolError(
+                "Unexpected error. Check your API token and try again."
+            )
 
 
 @mcp.tool(annotations={
@@ -248,7 +398,7 @@ async def get_card_insights(
     pub_id: str,
     api_token: str,
     effort: str = "medium",
-) -> str:
+) -> ChartInsightsResult:
     """
     Use this when you want AI-generated analysis of a chart's data. Returns bullet-point
     insights and a natural language description that summarizes trends, outliers, and key
@@ -261,7 +411,8 @@ async def get_card_insights(
             analysis, "high" for deep analysis (default: "medium")
 
     Returns:
-        JSON with pub_id, insights (bullet-point analysis), and description (narrative summary)
+        ChartInsightsResult with pub_id, insights (bullet-point analysis), and
+        description (narrative summary).
     """
     async with httpx.AsyncClient(timeout=90.0) as client:
         resp = await client.get(
@@ -271,22 +422,18 @@ async def get_card_insights(
         )
 
         if resp.status_code == 404:
-            return json.dumps({
-                "error": "Chart not found",
-                "pub_id": pub_id,
-                "suggestion": "Verify the pub_id/card_id is correct. Use knowledge_search to find valid chart IDs.",
-            })
+            raise TakoToolError(
+                f"Chart not found for pub_id '{pub_id}'. "
+                "Use knowledge_search to find valid chart IDs."
+            )
 
         resp.raise_for_status()
         data = resp.json()
 
-        return json.dumps(
-            {
-                "pub_id": pub_id,
-                "insights": data.get("insights", ""),
-                "description": data.get("description", ""),
-            },
-            indent=2,
+        return ChartInsightsResult(
+            pub_id=pub_id,
+            insights=data.get("insights", ""),
+            description=data.get("description", ""),
         )
 
 
@@ -301,7 +448,7 @@ async def explore_knowledge_graph(
     api_token: str,
     node_types: list[str] | None = None,
     limit: int = 20,
-) -> str:
+) -> KnowledgeGraphResult:
     """
     Use this when you need to discover what data is available before searching.
     Helps find entities (companies, countries), metrics (revenue, GDP), cohorts
@@ -323,7 +470,7 @@ async def explore_knowledge_graph(
         limit: Maximum number of results per type (1-50), defaults to 20
 
     Returns:
-        JSON with entities, metrics, cohorts, time_periods, and total_matches
+        KnowledgeGraphResult with entities, metrics, cohorts, time_periods, and total_matches.
     """
     start_time = time.time()
     try:
@@ -341,83 +488,72 @@ async def explore_knowledge_graph(
 
             data = resp.json()
 
-            result = {
-                "query": data.get("query"),
-                "total_matches": data.get("total_matches", 0),
-                "entities": [
-                    {
-                        "name": e.get("name"),
-                        "type": e.get("type"),
-                        "description": e.get("description"),
-                        "aliases": e.get("aliases", [])[:3],
-                        "available_tables": e.get("available_tables", [])[:3],
-                        "node_id": e.get("node_id"),
-                    }
+            result = KnowledgeGraphResult(
+                query=data.get("query"),
+                total_matches=data.get("total_matches", 0),
+                entities=[
+                    EntityResult(
+                        name=e.get("name"),
+                        type=e.get("type"),
+                        description=e.get("description"),
+                        aliases=e.get("aliases", [])[:3],
+                        available_tables=e.get("available_tables", [])[:3],
+                        node_id=e.get("node_id"),
+                    )
                     for e in data.get("entities", [])
                 ],
-                "metrics": [
-                    {
-                        "name": m.get("name"),
-                        "description": m.get("description"),
-                        "units": m.get("units", [])[:3],
-                        "time_periods": m.get("time_periods", [])[:3],
-                        "compatible_tables": m.get("compatible_tables", [])[:3],
-                        "node_id": m.get("node_id"),
-                    }
+                metrics=[
+                    MetricResult(
+                        name=m.get("name"),
+                        description=m.get("description"),
+                        units=m.get("units", [])[:3],
+                        time_periods=m.get("time_periods", [])[:3],
+                        compatible_tables=m.get("compatible_tables", [])[:3],
+                        node_id=m.get("node_id"),
+                    )
                     for m in data.get("metrics", [])
                 ],
-                "cohorts": [
-                    {
-                        "name": c.get("name"),
-                        "description": c.get("description"),
-                        "member_count": c.get("member_count"),
-                        "sample_members": c.get("sample_members", []),
-                        "node_id": c.get("node_id"),
-                    }
+                cohorts=[
+                    CohortResult(
+                        name=c.get("name"),
+                        description=c.get("description"),
+                        member_count=c.get("member_count"),
+                        sample_members=c.get("sample_members", []),
+                        node_id=c.get("node_id"),
+                    )
                     for c in data.get("cohorts", [])
                 ],
-                "time_periods": data.get("time_periods", []),
-                "execution_time_ms": data.get("execution_time_ms", 0),
-            }
+                time_periods=data.get("time_periods", []),
+                execution_time_ms=data.get("execution_time_ms", 0),
+            )
 
             elapsed_time = time.time() - start_time
             logging.debug(
                 f"explore_knowledge_graph completed in {elapsed_time:.2f}s: "
-                f"query={query[:50]}, total_matches={result['total_matches']}"
+                f"query={query[:50]}, total_matches={result.total_matches}"
             )
-            return json.dumps(result, indent=2)
+            return result
 
     except httpx.TimeoutException:
         elapsed_time = time.time() - start_time
         logging.warning(
             f"explore_knowledge_graph timed out after {elapsed_time:.2f}s: query={query[:50]}"
         )
-        return json.dumps(
-            {
-                "error": "Request timed out",
-                "message": "The explore request took too long.",
-                "suggestion": "Try a more specific query or filter by node_types to narrow results.",
-            },
-            indent=2,
+        raise TakoToolError(
+            "Request timed out. Try a more specific query or filter by node_types "
+            "to narrow results."
         )
     except httpx.HTTPStatusError as e:
-        return json.dumps(
-            {
-                "error": f"HTTP {e.response.status_code}",
-                "message": str(e),
-                "suggestion": "Check your API token is valid and try again.",
-            },
-            indent=2,
+        raise TakoToolError(
+            f"HTTP {e.response.status_code}: Check your API token is valid and try again."
         )
+    except TakoToolError:
+        raise
     except Exception as e:
         logging.error(f"explore_knowledge_graph error: {e}", exc_info=True)
-        return json.dumps(
-            {
-                "error": "Unexpected error",
-                "message": str(e),
-                "suggestion": "Check your API token and try again. If the issue persists, the Tako API may be temporarily unavailable.",
-            },
-            indent=2,
+        raise TakoToolError(
+            "Unexpected error. Check your API token and try again. "
+            "If the issue persists, the Tako API may be temporarily unavailable."
         )
 
 
@@ -434,7 +570,7 @@ async def explore_knowledge_graph(
 })
 async def list_chart_schemas(
     api_token: str,
-) -> str:
+) -> ChartSchemaList:
     """
     Use this when you want to see all available chart templates before creating a custom
     chart. Returns the full list of ThinViz schemas including timeseries, bar charts, pie
@@ -449,7 +585,7 @@ async def list_chart_schemas(
         api_token: Your Tako API token for authentication
 
     Returns:
-        JSON with schemas array (name, description, components) and count
+        ChartSchemaList with schemas array (name, description, use_case, components) and count.
     """
     # Recommended use cases for each schema to help agents pick the right chart type
     _schema_use_cases = {
@@ -484,23 +620,18 @@ async def list_chart_schemas(
             result = []
             for schema in schemas:
                 name = schema.get("name")
-                entry = {
-                    "name": name,
-                    "description": schema.get("description"),
-                    "use_case": _schema_use_cases.get(name, ""),
-                    "components": schema.get("components", []),
-                }
+                entry = SchemaEntry(
+                    name=name,
+                    description=schema.get("description"),
+                    use_case=_schema_use_cases.get(name, ""),
+                    components=schema.get("components", []),
+                )
                 result.append(entry)
 
-            return json.dumps({"schemas": result, "count": len(result)}, indent=2)
+            return ChartSchemaList(schemas=result, count=len(result))
     except httpx.HTTPStatusError as e:
-        return json.dumps(
-            {
-                "error": f"HTTP {e.response.status_code}",
-                "message": str(e),
-                "suggestion": "Check your API token is valid and try again.",
-            },
-            indent=2,
+        raise TakoToolError(
+            f"HTTP {e.response.status_code}: Check your API token is valid and try again."
         )
 
 
@@ -513,7 +644,7 @@ async def list_chart_schemas(
 async def get_chart_schema(
     schema_name: str,
     api_token: str,
-) -> str:
+) -> ChartSchemaDetail:
     """
     Use this when you need to understand the exact data format required for a specific
     chart type. Returns the schema definition including required fields, data structure,
@@ -526,7 +657,7 @@ async def get_chart_schema(
         api_token: Your Tako API token for authentication
 
     Returns:
-        JSON with schema name, description, components array, and template details
+        ChartSchemaDetail with schema name, description, components array, and template details.
     """
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.get(
@@ -535,20 +666,20 @@ async def get_chart_schema(
         )
 
         if resp.status_code == 404:
-            return json.dumps({
-                "error": f"Schema '{schema_name}' not found",
-                "suggestion": "Use list_chart_schemas to see all available schema names.",
-            })
+            raise TakoToolError(
+                f"Schema '{schema_name}' not found. "
+                "Use list_chart_schemas to see all available schema names."
+            )
 
         resp.raise_for_status()
         schema = resp.json()
 
-        return json.dumps({
-            "name": schema.get("name"),
-            "description": schema.get("description"),
-            "components": schema.get("components", []),
-            "template": schema.get("template"),
-        }, indent=2)
+        return ChartSchemaDetail(
+            name=schema.get("name"),
+            description=schema.get("description"),
+            components=schema.get("components", []),
+            template=schema.get("template"),
+        )
 
 
 @mcp.tool(annotations={
@@ -562,7 +693,7 @@ async def create_chart(
     components: list[dict],
     api_token: str,
     source: str | None = None,
-) -> str:
+) -> ChartCreateResult:
     """
     Use this when you need to create a new chart from raw data. This is the primary chart
     creation tool — pass a schema name and your data components to generate an interactive
@@ -581,7 +712,7 @@ async def create_chart(
         source: Optional attribution text (e.g., "Yahoo Finance", "Company Reports")
 
     Returns:
-        JSON with card_id, title, description, webpage_url, embed_url, image_url,
+        ChartCreateResult with card_id, title, description, webpage_url, embed_url, image_url,
         and open_ui_args for rendering the chart interactively.
 
     Example components for "bar_chart" schema:
@@ -653,51 +784,45 @@ async def create_chart(
             )
 
             if resp.status_code == 404:
-                return json.dumps({
-                    "error": f"Schema '{schema_name}' not found",
-                    "suggestion": "Use list_chart_schemas to see all available schema names.",
-                })
+                raise TakoToolError(
+                    f"Schema '{schema_name}' not found. "
+                    "Use list_chart_schemas to see all available schema names."
+                )
             if resp.status_code == 400:
                 error_data = resp.json()
-                return json.dumps({
-                    "error": "Invalid component configuration",
-                    "details": error_data,
-                    "suggestion": "Use get_chart_schema to see the required data format for this schema.",
-                })
+                raise TakoToolError(
+                    f"Invalid component configuration: {json.dumps(error_data)}. "
+                    "Use get_chart_schema to see the required data format for this schema."
+                )
 
             resp.raise_for_status()
             data = resp.json()
 
             card_id = data.get("card_id")
-            result = {
-                "card_id": card_id,
-                "title": data.get("title"),
-                "description": data.get("description"),
-                "webpage_url": data.get("webpage_url"),
-                "embed_url": data.get("embed_url"),
-                "image_url": data.get("image_url"),
-            }
-
-            # Add hint about opening the chart UI
-            if card_id:
-                result["open_ui_tool"] = "open_chart_ui"
-                result["open_ui_args"] = {"pub_id": card_id}
-
-            return json.dumps(result, indent=2)
+            return ChartCreateResult(
+                card_id=card_id,
+                title=data.get("title"),
+                description=data.get("description"),
+                webpage_url=data.get("webpage_url"),
+                embed_url=data.get("embed_url"),
+                image_url=data.get("image_url"),
+                open_ui_tool="open_chart_ui" if card_id else None,
+                open_ui_args={"pub_id": card_id} if card_id else None,
+            )
 
     except httpx.HTTPStatusError as e:
-        return json.dumps({
-            "error": f"HTTP {e.response.status_code}",
-            "message": str(e),
-            "suggestion": "Check your API token and component configuration. Use get_chart_schema to verify the expected format.",
-        }, indent=2)
+        raise TakoToolError(
+            f"HTTP {e.response.status_code}: Check your API token and component configuration. "
+            "Use get_chart_schema to verify the expected format."
+        )
+    except TakoToolError:
+        raise
     except Exception as e:
         logging.error(f"create_chart error: {e}", exc_info=True)
-        return json.dumps({
-            "error": "Unexpected error",
-            "message": str(e),
-            "suggestion": "Check your API token and try again. If the issue persists, the Tako API may be temporarily unavailable.",
-        }, indent=2)
+        raise TakoToolError(
+            "Unexpected error. Check your API token and try again. "
+            "If the issue persists, the Tako API may be temporarily unavailable."
+        )
 
 
 # =============================================================================
@@ -817,6 +942,417 @@ async def open_chart_ui(
 _sse_app = mcp.sse_app()
 _streamable_http_app = mcp.streamable_http_app()
 
+
+# =============================================================================
+# OAuth 2.1 Authorization Server (RFC 9728)
+# =============================================================================
+
+# OAuth configuration
+OAUTH_ISSUER = os.environ.get("OAUTH_ISSUER", PUBLIC_BASE_URL)
+OAUTH_REGISTRATION_ENABLED = os.environ.get("OAUTH_REGISTRATION_ENABLED", "true").lower() == "true"
+
+# In-memory stores (replace with persistent storage in production)
+_oauth_clients: dict[str, dict] = {}
+_oauth_codes: dict[str, dict] = {}
+_oauth_tokens: dict[str, dict] = {}
+
+_OAUTH_METADATA = {
+    "issuer": OAUTH_ISSUER,
+    "authorization_endpoint": f"{OAUTH_ISSUER}/oauth/authorize",
+    "token_endpoint": f"{OAUTH_ISSUER}/oauth/token",
+    "registration_endpoint": f"{OAUTH_ISSUER}/oauth/register" if OAUTH_REGISTRATION_ENABLED else None,
+    "response_types_supported": ["code"],
+    "grant_types_supported": ["authorization_code", "refresh_token"],
+    "token_endpoint_auth_methods_supported": ["none"],
+    "code_challenge_methods_supported": ["S256"],
+    "scopes_supported": ["read", "write", "admin"],
+    "service_documentation": "https://github.com/TakoData/tako-mcp",
+}
+
+
+def _generate_token(prefix: str = "tako") -> str:
+    """Generate a cryptographically random token."""
+    import secrets
+    return f"{prefix}_{secrets.token_urlsafe(32)}"
+
+
+async def _handle_oauth_metadata(scope, receive, send):
+    """Serve OAuth 2.1 Authorization Server Metadata (RFC 8414)."""
+    response = JSONResponse(_OAUTH_METADATA)
+    await response(scope, receive, send)
+
+
+async def _handle_oauth_register(scope, receive, send):
+    """Handle dynamic client registration (RFC 7591)."""
+    if scope["method"] != "POST":
+        response = JSONResponse({"error": "method_not_allowed"}, status_code=405)
+        await response(scope, receive, send)
+        return
+
+    if not OAUTH_REGISTRATION_ENABLED:
+        response = JSONResponse({"error": "registration_disabled"}, status_code=403)
+        await response(scope, receive, send)
+        return
+
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+
+    try:
+        client_meta = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        response = JSONResponse({"error": "invalid_request"}, status_code=400)
+        await response(scope, receive, send)
+        return
+
+    client_id = _generate_token("client")
+    client_record = {
+        "client_id": client_id,
+        "client_name": client_meta.get("client_name", "Unknown Client"),
+        "redirect_uris": client_meta.get("redirect_uris", []),
+        "grant_types": client_meta.get("grant_types", ["authorization_code"]),
+        "response_types": client_meta.get("response_types", ["code"]),
+        "scope": client_meta.get("scope", "read"),
+        "token_endpoint_auth_method": "none",
+    }
+    _oauth_clients[client_id] = client_record
+
+    response = JSONResponse(client_record, status_code=201)
+    await response(scope, receive, send)
+
+
+async def _handle_oauth_authorize(scope, receive, send):
+    """Handle authorization requests — issues authorization codes."""
+    query_string = scope.get("query_string", b"").decode()
+    params = urllib.parse.parse_qs(query_string)
+
+    client_id = params.get("client_id", [None])[0]
+    redirect_uri = params.get("redirect_uri", [None])[0]
+    response_type = params.get("response_type", [None])[0]
+    code_challenge = params.get("code_challenge", [None])[0]
+    code_challenge_method = params.get("code_challenge_method", [None])[0]
+    state = params.get("state", [None])[0]
+    requested_scope = params.get("scope", ["read"])[0]
+
+    if response_type != "code":
+        response = JSONResponse(
+            {"error": "unsupported_response_type", "error_description": "Only 'code' is supported"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+        return
+
+    if not code_challenge or code_challenge_method != "S256":
+        response = JSONResponse(
+            {"error": "invalid_request", "error_description": "PKCE with S256 is required (OAuth 2.1)"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+        return
+
+    # Generate authorization code
+    import secrets
+    code = secrets.token_urlsafe(32)
+    _oauth_codes[code] = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": code_challenge_method,
+        "scope": requested_scope,
+        "created_at": time.time(),
+        "expires_at": time.time() + 600,  # 10 minute expiry
+    }
+
+    # Redirect back with code
+    redirect_params = {"code": code}
+    if state:
+        redirect_params["state"] = state
+
+    redirect_url = f"{redirect_uri}?{urllib.parse.urlencode(redirect_params)}"
+    response = JSONResponse(
+        {"redirect_to": redirect_url, "code": code},
+        status_code=200,
+        headers={"Location": redirect_url},
+    )
+    await response(scope, receive, send)
+
+
+async def _handle_oauth_token(scope, receive, send):
+    """Handle token exchange — trades authorization codes for access tokens."""
+    if scope["method"] != "POST":
+        response = JSONResponse({"error": "method_not_allowed"}, status_code=405)
+        await response(scope, receive, send)
+        return
+
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+
+    try:
+        if b"=" in body:
+            params = dict(urllib.parse.parse_qsl(body.decode()))
+        else:
+            params = json.loads(body) if body else {}
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        response = JSONResponse({"error": "invalid_request"}, status_code=400)
+        await response(scope, receive, send)
+        return
+
+    grant_type = params.get("grant_type")
+
+    if grant_type == "authorization_code":
+        code = params.get("code")
+        code_verifier = params.get("code_verifier")
+
+        if not code or code not in _oauth_codes:
+            response = JSONResponse({"error": "invalid_grant"}, status_code=400)
+            await response(scope, receive, send)
+            return
+
+        code_record = _oauth_codes.pop(code)
+
+        if code_record["expires_at"] < time.time():
+            response = JSONResponse({"error": "invalid_grant", "error_description": "Code expired"}, status_code=400)
+            await response(scope, receive, send)
+            return
+
+        # Verify PKCE
+        if code_verifier:
+            import hashlib
+            import base64
+            challenge = base64.urlsafe_b64encode(
+                hashlib.sha256(code_verifier.encode()).digest()
+            ).rstrip(b"=").decode()
+            if challenge != code_record["code_challenge"]:
+                response = JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
+                await response(scope, receive, send)
+                return
+
+        access_token = _generate_token("tak")
+        refresh_token = _generate_token("ref")
+        _oauth_tokens[access_token] = {
+            "client_id": code_record.get("client_id"),
+            "scope": code_record.get("scope", "read"),
+            "created_at": time.time(),
+            "expires_at": time.time() + 3600,  # 1 hour
+            "refresh_token": refresh_token,
+        }
+
+        response = JSONResponse({
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": refresh_token,
+            "scope": code_record.get("scope", "read"),
+        })
+        await response(scope, receive, send)
+
+    elif grant_type == "refresh_token":
+        refresh = params.get("refresh_token")
+
+        # Find the token record by refresh token
+        found = None
+        for token, record in _oauth_tokens.items():
+            if record.get("refresh_token") == refresh:
+                found = (token, record)
+                break
+
+        if not found:
+            response = JSONResponse({"error": "invalid_grant"}, status_code=400)
+            await response(scope, receive, send)
+            return
+
+        old_token, old_record = found
+        del _oauth_tokens[old_token]
+
+        new_access = _generate_token("tak")
+        new_refresh = _generate_token("ref")
+        _oauth_tokens[new_access] = {
+            "client_id": old_record.get("client_id"),
+            "scope": old_record.get("scope", "read"),
+            "created_at": time.time(),
+            "expires_at": time.time() + 3600,
+            "refresh_token": new_refresh,
+        }
+
+        response = JSONResponse({
+            "access_token": new_access,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": new_refresh,
+            "scope": old_record.get("scope", "read"),
+        })
+        await response(scope, receive, send)
+    else:
+        response = JSONResponse(
+            {"error": "unsupported_grant_type"},
+            status_code=400,
+        )
+        await response(scope, receive, send)
+
+# =============================================================================
+# Agent-friendly tools description (served at /v1/tools)
+# =============================================================================
+
+_TOOLS_DESCRIPTION = {
+    "server": {
+        "name": "tako-mcp",
+        "version": SERVER_VERSION,
+        "description": (
+            "Tako MCP Server — create and discover data visualizations. "
+            "Search a curated knowledge base of 100K+ charts or create custom "
+            "charts from raw data using 15+ chart types."
+        ),
+        "homepage": "https://tako.com",
+        "repository": "https://github.com/TakoData/tako-mcp",
+        "connection": "https://mcp.tako.com/sse",
+    },
+    "authentication": {
+        "method": "api_token parameter",
+        "description": "Pass your Tako API token as the api_token parameter in each tool call.",
+        "get_token": "Sign up at tako.com and create a token in your account settings.",
+    },
+    "tools": [
+        {
+            "name": "knowledge_search",
+            "category": "search",
+            "description": (
+                "Search Tako's curated knowledge base of 100K+ charts covering economics, "
+                "finance, demographics, technology, and more. Start here when a user asks "
+                "about data trends, comparisons, or statistics."
+            ),
+            "when_to_use": "When you need to find existing charts and data visualizations on any topic.",
+            "parameters": {
+                "query": {"type": "string", "required": True, "description": "Natural language search query"},
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "count": {"type": "integer", "required": False, "default": 5, "range": "1-20"},
+                "search_effort": {"type": "string", "required": False, "default": "deep", "enum": ["fast", "deep"]},
+                "country_code": {"type": "string", "required": False, "default": "US"},
+                "locale": {"type": "string", "required": False, "default": "en-US"},
+            },
+            "returns": "SearchResults with matching charts (card_id, title, description, url, source)",
+            "example_queries": ["US GDP growth rate", "Intel vs Nvidia revenue", "climate change temperature data"],
+        },
+        {
+            "name": "explore_knowledge_graph",
+            "category": "search",
+            "description": (
+                "Discover available entities (companies, countries), metrics (revenue, GDP), "
+                "cohorts (S&P 500, G7), and time periods in Tako's knowledge graph."
+            ),
+            "when_to_use": "When you need to discover what data is available before searching.",
+            "parameters": {
+                "query": {"type": "string", "required": True, "description": "Natural language query to explore"},
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "node_types": {"type": "array[string]", "required": False, "enum": ["entity", "metric", "cohort", "db", "units", "time_period", "property"]},
+                "limit": {"type": "integer", "required": False, "default": 20, "range": "1-50"},
+            },
+            "returns": "KnowledgeGraphResult with entities, metrics, cohorts, time_periods",
+        },
+        {
+            "name": "get_chart_image",
+            "category": "display",
+            "description": "Get a static PNG preview URL for a chart. Useful for including chart previews in responses.",
+            "when_to_use": "When you need a static image of a chart to display or embed.",
+            "parameters": {
+                "pub_id": {"type": "string", "required": True, "description": "Chart identifier (pub_id/card_id)"},
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "dark_mode": {"type": "boolean", "required": False, "default": True},
+            },
+            "returns": "ChartImageResult with image_url, pub_id, dark_mode",
+        },
+        {
+            "name": "get_card_insights",
+            "category": "analysis",
+            "description": "Get AI-generated analysis with bullet-point insights and a narrative summary of chart data.",
+            "when_to_use": "When you want AI-generated analysis of a chart's data.",
+            "parameters": {
+                "pub_id": {"type": "string", "required": True, "description": "Chart identifier (pub_id/card_id)"},
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "effort": {"type": "string", "required": False, "default": "medium", "enum": ["low", "medium", "high"]},
+            },
+            "returns": "ChartInsightsResult with pub_id, insights, description",
+        },
+        {
+            "name": "list_chart_schemas",
+            "category": "thinviz",
+            "description": (
+                "List all available chart templates (15+ types). Call this first when the user "
+                "wants to create a new visualization."
+            ),
+            "when_to_use": "When you want to see all available chart types before creating a chart.",
+            "parameters": {
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+            },
+            "returns": "ChartSchemaList with schemas (name, description, use_case, components) and count",
+        },
+        {
+            "name": "get_chart_schema",
+            "category": "thinviz",
+            "description": "Get the exact data format for a specific chart type. Always call this before create_chart.",
+            "when_to_use": "When you need to understand the data format for creating a chart.",
+            "parameters": {
+                "schema_name": {"type": "string", "required": True, "description": "Schema name (e.g., 'bar_chart', 'timeseries_card')"},
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+            },
+            "returns": "ChartSchemaDetail with name, description, components, template",
+        },
+        {
+            "name": "create_chart",
+            "category": "thinviz",
+            "description": (
+                "Create a new interactive chart from raw data. Supports 15+ chart types. "
+                "The chart will be hosted and shareable on Tako."
+            ),
+            "when_to_use": "When you need to create a new chart from raw data.",
+            "workflow": "list_chart_schemas → get_chart_schema → create_chart",
+            "parameters": {
+                "schema_name": {"type": "string", "required": True, "description": "Schema name"},
+                "components": {"type": "array[object]", "required": True, "description": "Component configs matching the schema"},
+                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "source": {"type": "string", "required": False, "description": "Data source attribution"},
+            },
+            "returns": "ChartCreateResult with card_id, title, webpage_url, embed_url, image_url",
+        },
+        {
+            "name": "open_chart_ui",
+            "category": "display",
+            "description": "Render a fully interactive chart with zooming, panning, and hover interactions via MCP-UI.",
+            "when_to_use": "When you want to display an interactive chart to the user.",
+            "parameters": {
+                "pub_id": {"type": "string", "required": True, "description": "Chart identifier (pub_id/card_id)"},
+                "dark_mode": {"type": "boolean", "required": False, "default": True},
+                "width": {"type": "integer", "required": False, "default": 900},
+                "height": {"type": "integer", "required": False, "default": 600},
+            },
+            "returns": "UIResource containing an interactive iframe embed",
+        },
+    ],
+    "chart_types": [
+        {"schema": "timeseries_card", "name": "Line/Area Chart", "use_case": "Trends over time"},
+        {"schema": "stock_card", "name": "Stock Chart", "use_case": "Financial data with ticker boxes"},
+        {"schema": "bar_chart", "name": "Bar Chart", "use_case": "Categorical comparisons"},
+        {"schema": "grouped_bar_chart", "name": "Grouped Bar Chart", "use_case": "Multi-series comparisons"},
+        {"schema": "pie_chart", "name": "Pie Chart", "use_case": "Proportional data"},
+        {"schema": "scatter_chart", "name": "Scatter Plot", "use_case": "2-variable correlations"},
+        {"schema": "bubble_chart", "name": "Bubble Chart", "use_case": "3-variable data"},
+        {"schema": "histogram", "name": "Histogram", "use_case": "Frequency distributions"},
+        {"schema": "boxplot", "name": "Box Plot", "use_case": "Statistical distributions"},
+        {"schema": "choropleth", "name": "Map", "use_case": "Geographic data (US/World)"},
+        {"schema": "treemap", "name": "Treemap", "use_case": "Hierarchical data"},
+        {"schema": "heatmap", "name": "Heatmap", "use_case": "2D matrices"},
+        {"schema": "waterfall", "name": "Waterfall Chart", "use_case": "Sequential changes"},
+        {"schema": "financial_boxes", "name": "KPI Boxes", "use_case": "Key metrics display"},
+        {"schema": "table", "name": "Table", "use_case": "Tabular data"},
+    ],
+}
+
 # MCP Server Card (SEP-1649) for /.well-known/mcp
 _SERVER_CARD = {
     "protocolVersion": "2025-06-18",
@@ -849,6 +1385,11 @@ _SERVER_CARD = {
     "authentication": {
         "required": True,
         "schemes": ["bearer"],
+        "oauth": {
+            "authorization_server": "/.well-known/oauth-authorization-server",
+            "scopes": ["read", "write", "admin"],
+            "pkce_required": True,
+        },
     },
     "tools": [
         {
@@ -949,6 +1490,33 @@ async def app(scope, receive, send):
             response = JSONResponse(_SERVER_CARD)
             wrapped_send = _wrap_send(send, response_started)
             await response(scope, receive, wrapped_send)
+            return
+
+        if scope["path"] == "/v1/tools":
+            response = JSONResponse(_TOOLS_DESCRIPTION)
+            wrapped_send = _wrap_send(send, response_started)
+            await response(scope, receive, wrapped_send)
+            return
+
+        # OAuth 2.1 endpoints
+        if scope["path"] == "/.well-known/oauth-authorization-server":
+            wrapped_send = _wrap_send(send, response_started)
+            await _handle_oauth_metadata(scope, receive, wrapped_send)
+            return
+
+        if scope["path"] == "/oauth/register":
+            wrapped_send = _wrap_send(send, response_started)
+            await _handle_oauth_register(scope, receive, wrapped_send)
+            return
+
+        if scope["path"] == "/oauth/authorize":
+            wrapped_send = _wrap_send(send, response_started)
+            await _handle_oauth_authorize(scope, receive, wrapped_send)
+            return
+
+        if scope["path"] == "/oauth/token":
+            wrapped_send = _wrap_send(send, response_started)
+            await _handle_oauth_token(scope, receive, wrapped_send)
             return
 
         # Route /mcp to Streamable HTTP transport
@@ -1098,6 +1666,7 @@ def main():
     logging.info(f"Public Base URL: {PUBLIC_BASE_URL}")
     logging.info(f"DNS rebinding protection: {enable_dns_rebinding}")
     logging.info(f"Transports: SSE (/sse), Streamable HTTP (/mcp)")
+    logging.info(f"Discovery: /v1/tools, /.well-known/mcp, /.well-known/oauth-authorization-server")
     logging.info(f"Listening on {host}:{port}")
     logging.info("=" * 60)
 

--- a/src/tako_mcp/server.py
+++ b/src/tako_mcp/server.py
@@ -451,6 +451,27 @@ async def list_chart_schemas(
     Returns:
         JSON with schemas array (name, description, components) and count
     """
+    # Recommended use cases for each schema to help agents pick the right chart type
+    _schema_use_cases = {
+        "stock_card": "Financial data with ticker info — stock prices, forex, crypto over time",
+        "timeseries_card": "Any time-based data — trends, growth rates, historical comparisons",
+        "bar_chart": "Single-series categorical comparisons — revenue by region, top 10 lists",
+        "grouped_bar_chart": "Multi-series categorical comparisons — side-by-side or stacked bars",
+        "data_table_chart": "Bar chart with a data table below for exact values",
+        "histogram": "Frequency distributions — age distribution, salary ranges, score buckets",
+        "pie_chart": "Proportional/percentage data — market share, budget allocation",
+        "table": "Raw tabular data display — rankings, detailed breakdowns",
+        "header": "Title/subtitle card header (usually combined with other components)",
+        "financial_boxes": "KPI metric boxes — revenue, growth rate, key numbers at a glance",
+        "choropleth": "Geographic map data — by US state or world country",
+        "treemap": "Hierarchical proportional data — org structure, category breakdowns",
+        "heatmap": "2D correlation or intensity matrices — correlation tables, activity grids",
+        "boxplot": "Statistical distributions — comparing spread across categories",
+        "waterfall": "Sequential additive/subtractive changes — income statements, bridge charts",
+        "scatter_chart": "2-variable correlation — height vs weight, price vs quantity",
+        "bubble_chart": "3-variable data — scatter with size dimension for a third variable",
+    }
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(
@@ -460,14 +481,16 @@ async def list_chart_schemas(
             resp.raise_for_status()
             schemas = resp.json()
 
-            # Simplify response for readability
             result = []
             for schema in schemas:
-                result.append({
-                    "name": schema.get("name"),
+                name = schema.get("name")
+                entry = {
+                    "name": name,
                     "description": schema.get("description"),
+                    "use_case": _schema_use_cases.get(name, ""),
                     "components": schema.get("components", []),
-                })
+                }
+                result.append(entry)
 
             return json.dumps({"schemas": result, "count": len(result)}, indent=2)
     except httpx.HTTPStatusError as e:
@@ -791,7 +814,8 @@ async def open_chart_ui(
 # ASGI application setup
 # =============================================================================
 
-_mcp_app = mcp.sse_app()
+_sse_app = mcp.sse_app()
+_streamable_http_app = mcp.streamable_http_app()
 
 # MCP Server Card (SEP-1649) for /.well-known/mcp
 _SERVER_CARD = {
@@ -809,10 +833,16 @@ _SERVER_CARD = {
         "iconUrl": "https://tako.com/favicon.ico",
         "documentationUrl": "https://github.com/TakoData/tako-mcp",
     },
-    "transport": {
-        "type": "sse",
-        "endpoint": "/sse",
-    },
+    "transport": [
+        {
+            "type": "streamable-http",
+            "endpoint": "/mcp",
+        },
+        {
+            "type": "sse",
+            "endpoint": "/sse",
+        },
+    ],
     "capabilities": {
         "tools": {"listChanged": True},
     },
@@ -890,7 +920,10 @@ def _wrap_send(send, response_started_ref=None):
 
 
 async def app(scope, receive, send):
-    """ASGI application with custom error handling for MCP SSE connections."""
+    """ASGI application with custom error handling for MCP connections.
+
+    Supports both SSE (/sse, /messages/) and Streamable HTTP (/mcp) transports.
+    """
     response_started = [False]
 
     if scope["type"] == "http":
@@ -918,6 +951,23 @@ async def app(scope, receive, send):
             await response(scope, receive, wrapped_send)
             return
 
+        # Route /mcp to Streamable HTTP transport
+        if scope["path"] == "/mcp":
+            wrapped_send = _wrap_send(send, response_started)
+            try:
+                await _streamable_http_app(scope, receive, wrapped_send)
+            except Exception as e:
+                if not response_started[0]:
+                    logging.error(f"Streamable HTTP error: {type(e).__name__}: {e}", exc_info=True)
+                    try:
+                        response = JSONResponse(
+                            {"error": "Unexpected error", "code": -32000}, status_code=500
+                        )
+                        await response(scope, receive, wrapped_send)
+                    except RuntimeError:
+                        pass
+            return
+
         if scope["path"].startswith("/messages/"):
             query_string = scope.get("query_string", b"").decode()
             params = urllib.parse.parse_qs(query_string)
@@ -930,7 +980,7 @@ async def app(scope, receive, send):
     wrapped_send = _wrap_send(send, response_started)
 
     try:
-        await _mcp_app(scope, receive, wrapped_send)
+        await _sse_app(scope, receive, wrapped_send)
     except ExceptionGroup as eg:
         all_connection_errors = all(
             isinstance(exc, (ClosedResourceError, BrokenPipeError, ConnectionResetError))
@@ -1047,6 +1097,7 @@ def main():
     logging.info(f"Tako API URL: {TAKO_API_URL}")
     logging.info(f"Public Base URL: {PUBLIC_BASE_URL}")
     logging.info(f"DNS rebinding protection: {enable_dns_rebinding}")
+    logging.info(f"Transports: SSE (/sse), Streamable HTTP (/mcp)")
     logging.info(f"Listening on {host}:{port}")
     logging.info("=" * 60)
 

--- a/src/tako_mcp/server.py
+++ b/src/tako_mcp/server.py
@@ -27,7 +27,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp_ui_server import UIMetadataKey, create_ui_resource
 from mcp_ui_server.core import UIResource
 from pydantic import BaseModel, Field
-from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.responses import JSONResponse, PlainTextResponse, RedirectResponse
 
 # Suppress noisy logs from dependencies
 logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
@@ -367,7 +367,11 @@ async def get_chart_image(
         )
 
         if resp.status_code == 200:
-            image_url = f"{PUBLIC_API_URL}/api/v1/image/{pub_id}/?dark_mode={str(dark_mode).lower()}"
+            dm = str(dark_mode).lower()
+            image_url = (
+                f"{PUBLIC_API_URL}/api/v1/image/{pub_id}/"
+                f"?dark_mode={dm}"
+            )
             return ChartImageResult(
                 image_url=image_url, pub_id=pub_id, dark_mode=dark_mode
             )
@@ -960,7 +964,10 @@ _OAUTH_METADATA = {
     "issuer": OAUTH_ISSUER,
     "authorization_endpoint": f"{OAUTH_ISSUER}/oauth/authorize",
     "token_endpoint": f"{OAUTH_ISSUER}/oauth/token",
-    "registration_endpoint": f"{OAUTH_ISSUER}/oauth/register" if OAUTH_REGISTRATION_ENABLED else None,
+    "registration_endpoint": (
+        f"{OAUTH_ISSUER}/oauth/register"
+        if OAUTH_REGISTRATION_ENABLED else None
+    ),
     "response_types_supported": ["code"],
     "grant_types_supported": ["authorization_code", "refresh_token"],
     "token_endpoint_auth_methods_supported": ["none"],
@@ -974,6 +981,24 @@ def _generate_token(prefix: str = "tako") -> str:
     """Generate a cryptographically random token."""
     import secrets
     return f"{prefix}_{secrets.token_urlsafe(32)}"
+
+
+def _cleanup_expired_oauth():
+    """Remove expired authorization codes and access tokens."""
+    now = time.time()
+    expired_codes = [
+        k for k, v in _oauth_codes.items()
+        if v.get("expires_at", 0) < now
+    ]
+    for k in expired_codes:
+        del _oauth_codes[k]
+
+    expired_tokens = [
+        k for k, v in _oauth_tokens.items()
+        if v.get("expires_at", 0) < now
+    ]
+    for k in expired_tokens:
+        del _oauth_tokens[k]
 
 
 async def _handle_oauth_metadata(scope, receive, send):
@@ -1047,7 +1072,12 @@ async def _handle_oauth_authorize(scope, receive, send):
 
     if not code_challenge or code_challenge_method != "S256":
         response = JSONResponse(
-            {"error": "invalid_request", "error_description": "PKCE with S256 is required (OAuth 2.1)"},
+            {
+                "error": "invalid_request",
+                "error_description": (
+                    "PKCE with S256 is required (OAuth 2.1)"
+                ),
+            },
             status_code=400,
         )
         await response(scope, receive, send)
@@ -1072,16 +1102,14 @@ async def _handle_oauth_authorize(scope, receive, send):
         redirect_params["state"] = state
 
     redirect_url = f"{redirect_uri}?{urllib.parse.urlencode(redirect_params)}"
-    response = JSONResponse(
-        {"redirect_to": redirect_url, "code": code},
-        status_code=200,
-        headers={"Location": redirect_url},
-    )
+    response = RedirectResponse(url=redirect_url, status_code=302)
     await response(scope, receive, send)
 
 
 async def _handle_oauth_token(scope, receive, send):
     """Handle token exchange — trades authorization codes for access tokens."""
+    _cleanup_expired_oauth()
+
     if scope["method"] != "POST":
         response = JSONResponse({"error": "method_not_allowed"}, status_code=405)
         await response(scope, receive, send)
@@ -1109,30 +1137,71 @@ async def _handle_oauth_token(scope, receive, send):
     if grant_type == "authorization_code":
         code = params.get("code")
         code_verifier = params.get("code_verifier")
+        client_id = params.get("client_id")
+        redirect_uri = params.get("redirect_uri")
 
         if not code or code not in _oauth_codes:
-            response = JSONResponse({"error": "invalid_grant"}, status_code=400)
+            response = JSONResponse(
+                {"error": "invalid_grant"}, status_code=400
+            )
             await response(scope, receive, send)
             return
 
         code_record = _oauth_codes.pop(code)
 
         if code_record["expires_at"] < time.time():
-            response = JSONResponse({"error": "invalid_grant", "error_description": "Code expired"}, status_code=400)
+            response = JSONResponse(
+                {"error": "invalid_grant",
+                 "error_description": "Code expired"},
+                status_code=400,
+            )
             await response(scope, receive, send)
             return
 
-        # Verify PKCE
-        if code_verifier:
-            import hashlib
-            import base64
-            challenge = base64.urlsafe_b64encode(
-                hashlib.sha256(code_verifier.encode()).digest()
-            ).rstrip(b"=").decode()
-            if challenge != code_record["code_challenge"]:
-                response = JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
-                await response(scope, receive, send)
-                return
+        # Validate client_id matches the authorization code
+        if client_id and client_id != code_record.get("client_id"):
+            response = JSONResponse(
+                {"error": "invalid_grant",
+                 "error_description": "client_id mismatch"},
+                status_code=400,
+            )
+            await response(scope, receive, send)
+            return
+
+        # Validate redirect_uri matches the authorization code
+        if redirect_uri and redirect_uri != code_record.get("redirect_uri"):
+            response = JSONResponse(
+                {"error": "invalid_grant",
+                 "error_description": "redirect_uri mismatch"},
+                status_code=400,
+            )
+            await response(scope, receive, send)
+            return
+
+        # PKCE verification is required (OAuth 2.1)
+        if not code_verifier:
+            response = JSONResponse(
+                {"error": "invalid_request",
+                 "error_description": "code_verifier is required"},
+                status_code=400,
+            )
+            await response(scope, receive, send)
+            return
+
+        import base64
+        import hashlib
+
+        challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode()).digest()
+        ).rstrip(b"=").decode()
+        if challenge != code_record["code_challenge"]:
+            response = JSONResponse(
+                {"error": "invalid_grant",
+                 "error_description": "PKCE verification failed"},
+                status_code=400,
+            )
+            await response(scope, receive, send)
+            return
 
         access_token = _generate_token("tak")
         refresh_token = _generate_token("ref")
@@ -1211,7 +1280,10 @@ _TOOLS_DESCRIPTION = {
         ),
         "homepage": "https://tako.com",
         "repository": "https://github.com/TakoData/tako-mcp",
-        "connection": "https://mcp.tako.com/sse",
+        "connection": {
+            "streamable_http": "https://mcp.tako.com/mcp",
+            "sse": "https://mcp.tako.com/sse",
+        },
     },
     "authentication": {
         "method": "api_token parameter",
@@ -1227,17 +1299,45 @@ _TOOLS_DESCRIPTION = {
                 "finance, demographics, technology, and more. Start here when a user asks "
                 "about data trends, comparisons, or statistics."
             ),
-            "when_to_use": "When you need to find existing charts and data visualizations on any topic.",
+            "when_to_use": (
+                "When you need to find existing charts and "
+                "data visualizations on any topic."
+            ),
             "parameters": {
-                "query": {"type": "string", "required": True, "description": "Natural language search query"},
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
-                "count": {"type": "integer", "required": False, "default": 5, "range": "1-20"},
-                "search_effort": {"type": "string", "required": False, "default": "deep", "enum": ["fast", "deep"]},
-                "country_code": {"type": "string", "required": False, "default": "US"},
-                "locale": {"type": "string", "required": False, "default": "en-US"},
+                "query": {
+                    "type": "string", "required": True,
+                    "description": "Natural language search query",
+                },
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
+                "count": {
+                    "type": "integer", "required": False,
+                    "default": 5, "range": "1-20",
+                },
+                "search_effort": {
+                    "type": "string", "required": False,
+                    "default": "deep", "enum": ["fast", "deep"],
+                },
+                "country_code": {
+                    "type": "string", "required": False,
+                    "default": "US",
+                },
+                "locale": {
+                    "type": "string", "required": False,
+                    "default": "en-US",
+                },
             },
-            "returns": "SearchResults with matching charts (card_id, title, description, url, source)",
-            "example_queries": ["US GDP growth rate", "Intel vs Nvidia revenue", "climate change temperature data"],
+            "returns": (
+                "SearchResults with matching charts "
+                "(card_id, title, description, url, source)"
+            ),
+            "example_queries": [
+                "US GDP growth rate",
+                "Intel vs Nvidia revenue",
+                "climate change temperature data",
+            ],
         },
         {
             "name": "explore_knowledge_graph",
@@ -1246,36 +1346,88 @@ _TOOLS_DESCRIPTION = {
                 "Discover available entities (companies, countries), metrics (revenue, GDP), "
                 "cohorts (S&P 500, G7), and time periods in Tako's knowledge graph."
             ),
-            "when_to_use": "When you need to discover what data is available before searching.",
+            "when_to_use": (
+                "When you need to discover what data is "
+                "available before searching."
+            ),
             "parameters": {
-                "query": {"type": "string", "required": True, "description": "Natural language query to explore"},
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
-                "node_types": {"type": "array[string]", "required": False, "enum": ["entity", "metric", "cohort", "db", "units", "time_period", "property"]},
-                "limit": {"type": "integer", "required": False, "default": 20, "range": "1-50"},
+                "query": {
+                    "type": "string", "required": True,
+                    "description": "Natural language query to explore",
+                },
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
+                "node_types": {
+                    "type": "array[string]", "required": False,
+                    "enum": [
+                        "entity", "metric", "cohort", "db",
+                        "units", "time_period", "property",
+                    ],
+                },
+                "limit": {
+                    "type": "integer", "required": False,
+                    "default": 20, "range": "1-50",
+                },
             },
-            "returns": "KnowledgeGraphResult with entities, metrics, cohorts, time_periods",
+            "returns": (
+                "KnowledgeGraphResult with entities, metrics, "
+                "cohorts, time_periods"
+            ),
         },
         {
             "name": "get_chart_image",
             "category": "display",
-            "description": "Get a static PNG preview URL for a chart. Useful for including chart previews in responses.",
-            "when_to_use": "When you need a static image of a chart to display or embed.",
+            "description": (
+                "Get a static PNG preview URL for a chart. "
+                "Useful for including chart previews in responses."
+            ),
+            "when_to_use": (
+                "When you need a static image of a chart "
+                "to display or embed."
+            ),
             "parameters": {
-                "pub_id": {"type": "string", "required": True, "description": "Chart identifier (pub_id/card_id)"},
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
-                "dark_mode": {"type": "boolean", "required": False, "default": True},
+                "pub_id": {
+                    "type": "string", "required": True,
+                    "description": "Chart identifier (pub_id/card_id)",
+                },
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
+                "dark_mode": {
+                    "type": "boolean", "required": False,
+                    "default": True,
+                },
             },
             "returns": "ChartImageResult with image_url, pub_id, dark_mode",
         },
         {
             "name": "get_card_insights",
             "category": "analysis",
-            "description": "Get AI-generated analysis with bullet-point insights and a narrative summary of chart data.",
-            "when_to_use": "When you want AI-generated analysis of a chart's data.",
+            "description": (
+                "Get AI-generated analysis with bullet-point "
+                "insights and a narrative summary of chart data."
+            ),
+            "when_to_use": (
+                "When you want AI-generated analysis of "
+                "a chart's data."
+            ),
             "parameters": {
-                "pub_id": {"type": "string", "required": True, "description": "Chart identifier (pub_id/card_id)"},
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
-                "effort": {"type": "string", "required": False, "default": "medium", "enum": ["low", "medium", "high"]},
+                "pub_id": {
+                    "type": "string", "required": True,
+                    "description": "Chart identifier (pub_id/card_id)",
+                },
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
+                "effort": {
+                    "type": "string", "required": False,
+                    "default": "medium",
+                    "enum": ["low", "medium", "high"],
+                },
             },
             "returns": "ChartInsightsResult with pub_id, insights, description",
         },
@@ -1286,22 +1438,49 @@ _TOOLS_DESCRIPTION = {
                 "List all available chart templates (15+ types). Call this first when the user "
                 "wants to create a new visualization."
             ),
-            "when_to_use": "When you want to see all available chart types before creating a chart.",
+            "when_to_use": (
+                "When you want to see all available chart "
+                "types before creating a chart."
+            ),
             "parameters": {
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
             },
-            "returns": "ChartSchemaList with schemas (name, description, use_case, components) and count",
+            "returns": (
+                "ChartSchemaList with schemas "
+                "(name, description, use_case, components) and count"
+            ),
         },
         {
             "name": "get_chart_schema",
             "category": "thinviz",
-            "description": "Get the exact data format for a specific chart type. Always call this before create_chart.",
-            "when_to_use": "When you need to understand the data format for creating a chart.",
+            "description": (
+                "Get the exact data format for a specific "
+                "chart type. Always call this before create_chart."
+            ),
+            "when_to_use": (
+                "When you need to understand the data "
+                "format for creating a chart."
+            ),
             "parameters": {
-                "schema_name": {"type": "string", "required": True, "description": "Schema name (e.g., 'bar_chart', 'timeseries_card')"},
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
+                "schema_name": {
+                    "type": "string", "required": True,
+                    "description": (
+                        "Schema name "
+                        "(e.g., 'bar_chart', 'timeseries_card')"
+                    ),
+                },
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
             },
-            "returns": "ChartSchemaDetail with name, description, components, template",
+            "returns": (
+                "ChartSchemaDetail with name, description, "
+                "components, template"
+            ),
         },
         {
             "name": "create_chart",
@@ -1311,22 +1490,52 @@ _TOOLS_DESCRIPTION = {
                 "The chart will be hosted and shareable on Tako."
             ),
             "when_to_use": "When you need to create a new chart from raw data.",
-            "workflow": "list_chart_schemas → get_chart_schema → create_chart",
+            "workflow": (
+                "list_chart_schemas -> get_chart_schema "
+                "-> create_chart"
+            ),
             "parameters": {
-                "schema_name": {"type": "string", "required": True, "description": "Schema name"},
-                "components": {"type": "array[object]", "required": True, "description": "Component configs matching the schema"},
-                "api_token": {"type": "string", "required": True, "description": "Tako API token"},
-                "source": {"type": "string", "required": False, "description": "Data source attribution"},
+                "schema_name": {
+                    "type": "string", "required": True,
+                    "description": "Schema name",
+                },
+                "components": {
+                    "type": "array[object]", "required": True,
+                    "description": (
+                        "Component configs matching the schema"
+                    ),
+                },
+                "api_token": {
+                    "type": "string", "required": True,
+                    "description": "Tako API token",
+                },
+                "source": {
+                    "type": "string", "required": False,
+                    "description": "Data source attribution",
+                },
             },
-            "returns": "ChartCreateResult with card_id, title, webpage_url, embed_url, image_url",
+            "returns": (
+                "ChartCreateResult with card_id, title, "
+                "webpage_url, embed_url, image_url"
+            ),
         },
         {
             "name": "open_chart_ui",
             "category": "display",
-            "description": "Render a fully interactive chart with zooming, panning, and hover interactions via MCP-UI.",
-            "when_to_use": "When you want to display an interactive chart to the user.",
+            "description": (
+                "Render a fully interactive chart with "
+                "zooming, panning, and hover interactions "
+                "via MCP-UI."
+            ),
+            "when_to_use": (
+                "When you want to display an interactive "
+                "chart to the user."
+            ),
             "parameters": {
-                "pub_id": {"type": "string", "required": True, "description": "Chart identifier (pub_id/card_id)"},
+                "pub_id": {
+                    "type": "string", "required": True,
+                    "description": "Chart identifier (pub_id/card_id)",
+                },
                 "dark_mode": {"type": "boolean", "required": False, "default": True},
                 "width": {"type": "integer", "required": False, "default": 900},
                 "height": {"type": "integer", "required": False, "default": 600},
@@ -1335,21 +1544,81 @@ _TOOLS_DESCRIPTION = {
         },
     ],
     "chart_types": [
-        {"schema": "timeseries_card", "name": "Line/Area Chart", "use_case": "Trends over time"},
-        {"schema": "stock_card", "name": "Stock Chart", "use_case": "Financial data with ticker boxes"},
-        {"schema": "bar_chart", "name": "Bar Chart", "use_case": "Categorical comparisons"},
-        {"schema": "grouped_bar_chart", "name": "Grouped Bar Chart", "use_case": "Multi-series comparisons"},
-        {"schema": "pie_chart", "name": "Pie Chart", "use_case": "Proportional data"},
-        {"schema": "scatter_chart", "name": "Scatter Plot", "use_case": "2-variable correlations"},
-        {"schema": "bubble_chart", "name": "Bubble Chart", "use_case": "3-variable data"},
-        {"schema": "histogram", "name": "Histogram", "use_case": "Frequency distributions"},
-        {"schema": "boxplot", "name": "Box Plot", "use_case": "Statistical distributions"},
-        {"schema": "choropleth", "name": "Map", "use_case": "Geographic data (US/World)"},
-        {"schema": "treemap", "name": "Treemap", "use_case": "Hierarchical data"},
-        {"schema": "heatmap", "name": "Heatmap", "use_case": "2D matrices"},
-        {"schema": "waterfall", "name": "Waterfall Chart", "use_case": "Sequential changes"},
-        {"schema": "financial_boxes", "name": "KPI Boxes", "use_case": "Key metrics display"},
-        {"schema": "table", "name": "Table", "use_case": "Tabular data"},
+        {
+            "schema": "timeseries_card",
+            "name": "Line/Area Chart",
+            "use_case": "Trends over time",
+        },
+        {
+            "schema": "stock_card",
+            "name": "Stock Chart",
+            "use_case": "Financial data with ticker boxes",
+        },
+        {
+            "schema": "bar_chart",
+            "name": "Bar Chart",
+            "use_case": "Categorical comparisons",
+        },
+        {
+            "schema": "grouped_bar_chart",
+            "name": "Grouped Bar Chart",
+            "use_case": "Multi-series comparisons",
+        },
+        {
+            "schema": "pie_chart",
+            "name": "Pie Chart",
+            "use_case": "Proportional data",
+        },
+        {
+            "schema": "scatter_chart",
+            "name": "Scatter Plot",
+            "use_case": "2-variable correlations",
+        },
+        {
+            "schema": "bubble_chart",
+            "name": "Bubble Chart",
+            "use_case": "3-variable data",
+        },
+        {
+            "schema": "histogram",
+            "name": "Histogram",
+            "use_case": "Frequency distributions",
+        },
+        {
+            "schema": "boxplot",
+            "name": "Box Plot",
+            "use_case": "Statistical distributions",
+        },
+        {
+            "schema": "choropleth",
+            "name": "Map",
+            "use_case": "Geographic data (US/World)",
+        },
+        {
+            "schema": "treemap",
+            "name": "Treemap",
+            "use_case": "Hierarchical data",
+        },
+        {
+            "schema": "heatmap",
+            "name": "Heatmap",
+            "use_case": "2D matrices",
+        },
+        {
+            "schema": "waterfall",
+            "name": "Waterfall Chart",
+            "use_case": "Sequential changes",
+        },
+        {
+            "schema": "financial_boxes",
+            "name": "KPI Boxes",
+            "use_case": "Key metrics display",
+        },
+        {
+            "schema": "table",
+            "name": "Table",
+            "use_case": "Tabular data",
+        },
     ],
 }
 
@@ -1394,43 +1663,100 @@ _SERVER_CARD = {
     "tools": [
         {
             "name": "knowledge_search",
-            "description": "Search Tako's knowledge base for charts and data visualizations on any topic.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+            "description": (
+                "Search Tako's knowledge base for charts "
+                "and data visualizations on any topic."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
         },
         {
             "name": "explore_knowledge_graph",
-            "description": "Discover available entities, metrics, cohorts, and time periods in Tako's knowledge graph.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+            "description": (
+                "Discover available entities, metrics, "
+                "cohorts, and time periods in Tako's "
+                "knowledge graph."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
         },
         {
             "name": "get_chart_image",
-            "description": "Get a static PNG preview image URL for a chart.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+            "description": (
+                "Get a static PNG preview image URL "
+                "for a chart."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
         },
         {
             "name": "get_card_insights",
-            "description": "Get AI-generated analysis and insights for a chart.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+            "description": (
+                "Get AI-generated analysis and insights "
+                "for a chart."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
         },
         {
             "name": "list_chart_schemas",
-            "description": "List all available chart templates for creating custom visualizations.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+            "description": (
+                "List all available chart templates "
+                "for creating custom visualizations."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
         },
         {
             "name": "get_chart_schema",
-            "description": "Get the detailed schema and data format for a specific chart type.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": False},
+            "description": (
+                "Get the detailed schema and data format "
+                "for a specific chart type."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
         },
         {
             "name": "create_chart",
-            "description": "Create a new interactive chart from raw data using 15+ chart types.",
-            "annotations": {"readOnlyHint": False, "destructiveHint": False, "openWorldHint": True},
+            "description": (
+                "Create a new interactive chart from raw "
+                "data using 15+ chart types."
+            ),
+            "annotations": {
+                "readOnlyHint": False,
+                "destructiveHint": False,
+                "openWorldHint": True,
+            },
         },
         {
             "name": "open_chart_ui",
-            "description": "Open a fully interactive chart with zooming, panning, and hover interactions.",
-            "annotations": {"readOnlyHint": True, "destructiveHint": False, "openWorldHint": True},
+            "description": (
+                "Open a fully interactive chart with "
+                "zooming, panning, and hover interactions."
+            ),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "openWorldHint": True,
+            },
         },
     ],
 }
@@ -1556,7 +1882,11 @@ async def app(scope, receive, send):
             for exc in eg.exceptions
         )
         if all_connection_errors:
-            logging.debug(f"Client disconnected (ExceptionGroup): path={scope.get('path', 'unknown')}")
+            path = scope.get('path', 'unknown')
+            logging.debug(
+                f"Client disconnected (ExceptionGroup): "
+                f"path={path}"
+            )
         else:
             raise
     except ClosedResourceError:
@@ -1581,7 +1911,10 @@ async def app(scope, receive, send):
             except RuntimeError:
                 pass
         else:
-            logging.debug(f"Client connection reset mid-stream: path={scope.get('path', 'unknown')}")
+            logging.debug(
+                "Client connection reset mid-stream: "
+                f"path={scope.get('path', 'unknown')}"
+            )
     except Exception as e:
         error_str = str(e)
         if "Could not find session" in error_str:


### PR DESCRIPTION
  MCP Discoverability — Phase 2             
                                                                                                                                                        
  Summary                                   
                                                                                                                                                        
  - Add structured Pydantic output models for all 8 MCP tools, enabling automatic outputSchema and structuredContent generation via FastMCP             
  - Add OAuth 2.1 authorization server with PKCE (S256), dynamic client registration (RFC 7591), and authorization code + refresh token grants
  - Add OpenAPI 3.1.0 spec (openapi.yaml) with x-agent-hints, x-semantic-tags, and x-tool-annotations extensions for agent discoverability
  - Add agent framework integrations: LangChain, CrewAI, AutoGen, Vercel AI SDK — all exposing the full 8-tool surface
  - Add OpenAI GPT Actions spec for ChatGPT plugin compatibility
  - Add registry listing configs for Glama, MCP Index, Docker MCP Catalog, and Awesome MCP Servers
  - Add /v1/tools endpoint with structured tool descriptions, parameters, and example queries for agent consumption
  - Replace trytako.com references with tako.com across the codebase

  What changed

  src/tako_mcp/server.py (core)
  - 11 Pydantic output models (SearchResults, ChartImageResult, KnowledgeGraphResult, etc.)
  - All 7 data tools return typed Pydantic models instead of JSON strings; errors raise TakoToolError
  - Full OAuth 2.1 server: /.well-known/oauth-authorization-server, /oauth/register, /oauth/authorize, /oauth/token
  - /v1/tools agent-facing endpoint with tool metadata, parameters, and workflows
  - MCP Server Card at /.well-known/mcp updated with OAuth details

  openapi.yaml (new — 2,434 lines)
  - OpenAPI 3.1.0 spec documenting all REST and MCP tool endpoints
  - Agent-optimized extensions: x-agent-hints (usage, caching, workflows), x-semantic-tags, x-tool-annotations
  - x-mcp-tools top-level extension with canonical tool definitions

  integrations/ (new)
  - langchain_tako.py — TakoToolkit with 8 BaseTool subclasses, async-first with asyncio.run() sync fallbacks
  - crewai_tako.py — 8 CrewAI BaseTool classes with create_tako_tools() factory
  - autogen_tako.py — 8 AutoGen function definitions with register_tako_tools() helper
  - vercel_ai_tako.ts — 8 Vercel AI SDK tool() definitions with Zod schemas
  - openai_actions.yaml — GPT Actions spec with x-openai-isConsequential flags

  registry/ (new)
  - glama.yaml, mcp-index.json, docker-mcp.yaml, awesome-mcp-servers.md

  