### PR TITLE
feat(workers): keep workers.dev enabled + post-deploy smoke (TAKO-2611)

### DIFF
--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -1,15 +1,17 @@
 name: workers-smoke
 
 # Triggers (TAKO-2611):
-#   - `workflow_run`: fire automatically after every successful `workers-deploy`
-#     run on `main`. The smoke target is the staging Worker by default; we
-#     could later read the deployed env from the upstream run if/when a prod
-#     auto-smoke is wanted.
-#   - `workflow_dispatch`: manual trigger so we can smoke prod post-promotion,
-#     or smoke any other base URL without redeploying.
+#   - `workflow_run`: fire automatically after a successful `workers-deploy`
+#     run that was triggered by a `push` to `main` (which always deploys
+#     staging). We DO NOT auto-smoke after `workflow_dispatch` deploys —
+#     those can target production and we don't have a prod-aware smoke yet,
+#     so silently smoking staging while prod was deployed would produce a
+#     misleading green badge. Manually dispatch this workflow to smoke any
+#     post-promotion prod deploy.
+#   - `workflow_dispatch`: manual trigger to smoke any base URL.
 #
 # `workflow_run` only fires for upstream runs that completed (any conclusion);
-# the `if:` on the job below filters to successful upstream runs.
+# the `if:` on the job below filters to successful + push-triggered upstreams.
 on:
   workflow_run:
     workflows: [workers-deploy]
@@ -17,12 +19,19 @@ on:
   workflow_dispatch:
     inputs:
       base_url:
-        description: 'Base URL of the Worker to smoke-test (no trailing slash)'
+        description: 'Base URL of the Worker to smoke-test (no trailing slash). Leave empty to use the staging default.'
         type: string
-        # Default points at the staging *.workers.dev URL while TAKO-2610
-        # (custom-domain bind for `mcp.staging.tako.com`) is pending. Flip
-        # to `https://mcp.staging.tako.com` once that ships.
+        # Default duplicated from the workflow-level `STAGING_BASE_URL` env
+        # below — GitHub Actions doesn't allow `${{ env.X }}` substitution
+        # in `workflow_dispatch` input defaults. If the staging URL ever
+        # changes, update both the env var AND this default in lockstep.
         default: 'https://tako-mcp-staging.bobby-118.workers.dev'
+
+# Single source of truth for the staging URL. Referenced from the smoke step
+# below; the `workflow_dispatch` input default has to repeat the value (see
+# note on the input above).
+env:
+  STAGING_BASE_URL: 'https://tako-mcp-staging.bobby-118.workers.dev'
 
 # Latest staging deploy is what we want to validate; cancel an in-flight
 # smoke if a newer deploy lands while it's running.
@@ -38,9 +47,17 @@ jobs:
     name: smoke
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # workflow_run fires regardless of conclusion — gate to success only so we
-    # don't smoke a deploy that already failed.
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # Run when:
+    #   - manually dispatched (any base URL the user picked), OR
+    #   - the upstream `workers-deploy` succeeded AND was triggered by a
+    #     `push` (which always deploys staging — see workers-deploy.yml). We
+    #     skip `workflow_dispatch`-triggered upstream runs because those may
+    #     have targeted production, and our smoke target is hardcoded to
+    #     staging here.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     defaults:
       run:
         working-directory: workers
@@ -58,11 +75,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Smoke target: manual dispatch → user-supplied input; auto-trigger →
-      # always staging. Token comes from a GitHub Actions secret and is masked
-      # by Actions in logs; the smoke script also takes care never to print it.
+      # Smoke target precedence:
+      #   1. `workflow_dispatch` input (if set) — lets ops smoke any URL
+      #   2. `STAGING_BASE_URL` env (workflow-level constant)
+      #
+      # The smoke script (`scripts/smoke.ts`) requires `SMOKE_BASE_URL` to be
+      # set explicitly — there is no in-script default — so any source URL
+      # change happens in this YAML, not in TypeScript.
+      #
+      # `TAKO_SMOKE_API_TOKEN` is a GitHub Actions secret, automatically
+      # masked in logs; the smoke script also never prints it.
       - name: Smoke
         env:
-          SMOKE_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || 'https://tako-mcp-staging.bobby-118.workers.dev' }}
+          SMOKE_BASE_URL: ${{ inputs.base_url || env.STAGING_BASE_URL }}
           TAKO_SMOKE_API_TOKEN: ${{ secrets.TAKO_SMOKE_API_TOKEN }}
         run: npm run smoke

--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -1,0 +1,68 @@
+name: workers-smoke
+
+# Triggers (TAKO-2611):
+#   - `workflow_run`: fire automatically after every successful `workers-deploy`
+#     run on `main`. The smoke target is the staging Worker by default; we
+#     could later read the deployed env from the upstream run if/when a prod
+#     auto-smoke is wanted.
+#   - `workflow_dispatch`: manual trigger so we can smoke prod post-promotion,
+#     or smoke any other base URL without redeploying.
+#
+# `workflow_run` only fires for upstream runs that completed (any conclusion);
+# the `if:` on the job below filters to successful upstream runs.
+on:
+  workflow_run:
+    workflows: [workers-deploy]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL of the Worker to smoke-test (no trailing slash)'
+        type: string
+        # Default points at the staging *.workers.dev URL while TAKO-2610
+        # (custom-domain bind for `mcp.staging.tako.com`) is pending. Flip
+        # to `https://mcp.staging.tako.com` once that ships.
+        default: 'https://tako-mcp-staging.bobby-118.workers.dev'
+
+# Latest staging deploy is what we want to validate; cancel an in-flight
+# smoke if a newer deploy lands while it's running.
+concurrency:
+  group: workers-smoke-${{ github.event.inputs.base_url || 'staging' }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # workflow_run fires regardless of conclusion — gate to success only so we
+    # don't smoke a deploy that already failed.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    defaults:
+      run:
+        working-directory: workers
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: workers/.nvmrc
+          cache: 'npm'
+          cache-dependency-path: workers/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Smoke target: manual dispatch → user-supplied input; auto-trigger →
+      # always staging. Token comes from a GitHub Actions secret and is masked
+      # by Actions in logs; the smoke script also takes care never to print it.
+      - name: Smoke
+        env:
+          SMOKE_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.base_url || 'https://tako-mcp-staging.bobby-118.workers.dev' }}
+          TAKO_SMOKE_API_TOKEN: ${{ secrets.TAKO_SMOKE_API_TOKEN }}
+        run: npm run smoke

--- a/workers/package.json
+++ b/workers/package.json
@@ -16,7 +16,8 @@
     "predeploy:production": "npm run registry:check",
     "cf-typegen": "wrangler types",
     "registry:gen": "tsx scripts/gen-registry.ts",
-    "registry:check": "tsx scripts/gen-registry.ts --check"
+    "registry:check": "tsx scripts/gen-registry.ts --check",
+    "smoke": "tsx scripts/smoke.ts"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.9.11",

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -226,10 +226,17 @@ try {
     "get_credit_balance.details is not an object",
   );
   const balance = cbStructured.details["credit_balance"];
+  // Reject empty / whitespace-only strings explicitly: `Number("")` and
+  // `Number("   ")` both coerce to `0` (which Number.isFinite happily
+  // accepts), which would otherwise let a backend bug return "" and look
+  // like a real `0`-credit balance. DRF's DecimalField won't produce that
+  // in practice, but the check is free.
   const balanceNumeric =
     typeof balance === "number"
       ? balance
-      : typeof balance === "string" && Number.isFinite(Number(balance))
+      : typeof balance === "string" &&
+          balance.trim() !== "" &&
+          Number.isFinite(Number(balance))
         ? Number(balance)
         : null;
   assert(
@@ -303,9 +310,10 @@ try {
   //      still proves the handler ran (auth + djangoPost reached
   //      Django, which rejected the chart) — the validation tripped on
   //      the *response* shape, not on our request. Today this is what
-  //      actually happens (the handler doesn't synthesize a
-  //      schema-conformant error payload), so we treat it as
-  //      equivalent evidence of write-path exercise.
+  //      actually happens because `djangoErrorToToolResult` returns a
+  //      `kind`-discriminator envelope that doesn't match each tool's
+  //      success-shape schema. Tracked in TAKO-2681; once that ships,
+  //      remove this fallback and tighten the test to fail-on-throw.
   let createChartFailedAsExpected = false;
   let createChartFailureMode: string;
   try {

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -8,19 +8,30 @@
  *   2. MCP `initialize`        → handshake completes
  *   3. MCP `tools/list`        → at least one tool, includes the canary set
  *   4. Per-tool MCP `tools/call` canaries (read-only unless noted):
- *        a. `knowledge_search "US GDP"`        — non-empty results, save the
- *                                                first non-null `card_id` to
- *                                                chain into chart tools below
- *        b. `get_credit_balance`               — `details` object returned
+ *        a. `knowledge_search "US GDP"`        — non-empty results, requires
+ *                                                at least one usable
+ *                                                `card_id` (fails the smoke
+ *                                                if every result lacks one
+ *                                                — that's a regression
+ *                                                worth catching)
+ *        b. `get_credit_balance`               — `details.credit_balance`
+ *                                                must be a number or
+ *                                                numeric string
  *        c. `list_reports {limit:1}`           — `reports[]` array (may be 0)
- *        d. `get_chart_image {pub_id}`         — `image_url` is http(s)
- *        e. `open_chart_ui {pub_id}`           — produces a tako URL
- *        f. `create_chart {components:[]}`     — *negative test* — verifies
- *                                                input validation rejects
- *                                                empty components without
- *                                                actually creating a chart on
- *                                                every deploy. We never test
- *                                                the success path of write
+ *        d. `get_chart_image {pub_id}`         — `image_url` is http(s);
+ *                                                pub_id chained from (a)
+ *        e. `open_chart_ui {pub_id}`           — structured payload returned;
+ *                                                pub_id chained from (a)
+ *        f. `create_chart {bogus comp_type}`   — *negative test* — schema-
+ *                                                valid payload (one
+ *                                                component, garbage
+ *                                                `component_type`) so the
+ *                                                Worker's auth + Django
+ *                                                round-trip + error mapping
+ *                                                actually runs; expect
+ *                                                `isError: true` from the
+ *                                                server. We never test the
+ *                                                success path of write
  *                                                tools in smoke.
  *
  * Excluded by design:
@@ -30,16 +41,20 @@
  * Any failure prints a `✘ ...` line to stderr and exits non-zero so the
  * GitHub Actions job (or anyone running `npm run smoke`) flips red.
  *
- * Configuration (env vars):
- *   SMOKE_BASE_URL          — Worker base URL. Default: the staging
- *                             `*.workers.dev` URL while TAKO-2610 (custom
- *                             domain bind for `mcp.staging.tako.com`) is
- *                             pending. Override to smoke production or any
- *                             other deployment target.
- *   TAKO_SMOKE_API_TOKEN    — required Tako API token forwarded to the
- *                             Worker as `Authorization: Bearer <token>`.
- *                             Stored as a GitHub Actions secret in CI; mint
- *                             your own at trytako.com for local runs.
+ * Configuration (env vars, both required — no in-script defaults):
+ *   SMOKE_BASE_URL          — Worker base URL to smoke (no trailing slash).
+ *                             In CI this is set by `workers-smoke.yml` from
+ *                             a single workflow-level `STAGING_BASE_URL`
+ *                             env var so the canonical URL lives in one
+ *                             place. For local runs, set explicitly:
+ *
+ *                                 SMOKE_BASE_URL=https://tako-mcp-staging.bobby-118.workers.dev \
+ *                                   TAKO_SMOKE_API_TOKEN=... npm run smoke
+ *
+ *   TAKO_SMOKE_API_TOKEN    — Tako API token forwarded to the Worker as
+ *                             `Authorization: Bearer <token>`. Stored as a
+ *                             GitHub Actions secret in CI; mint your own
+ *                             at trytako.com for local runs.
  *
  * Secrets handling: the token is read from env, attached to the transport's
  * `requestInit.headers`, and never logged. We print only structured result
@@ -49,21 +64,30 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
 
-const DEFAULT_BASE_URL = "https://tako-mcp-staging.bobby-118.workers.dev";
 const CANARY_QUERY = "US GDP";
 const HTTP_URL_REGEX = /^https?:\/\//;
 
-const baseUrl = (process.env.SMOKE_BASE_URL ?? DEFAULT_BASE_URL).replace(
-  /\/+$/,
-  "",
-);
+// Both env vars are required — no in-script defaults. The single source of
+// truth for the staging URL is `STAGING_BASE_URL` in `workers-smoke.yml`;
+// hard-coding it here too creates a stale-deployment hazard if the
+// account/subdomain ever moves.
+const rawBaseUrl = process.env.SMOKE_BASE_URL;
 const apiToken = process.env.TAKO_SMOKE_API_TOKEN;
 
+if (!rawBaseUrl) {
+  console.error(
+    "✘ SMOKE_BASE_URL env var is required (e.g. https://tako-mcp-staging.bobby-118.workers.dev)",
+  );
+  process.exit(1);
+}
 if (!apiToken) {
   console.error("✘ TAKO_SMOKE_API_TOKEN env var is required");
   process.exit(1);
 }
+
+const baseUrl = rawBaseUrl.replace(/\/+$/, "");
 
 const ok = (msg: string) => console.log(`✓ ${msg}`);
 function fail(msg: string): never {
@@ -123,8 +147,7 @@ try {
   await client.connect(transport as never);
   const serverInfo = client.getServerVersion();
   ok(
-    `initialize → ${serverInfo?.name ?? "<unknown>"} ` +
-      `${serverInfo?.version ?? ""}`.trim(),
+    `initialize → ${serverInfo?.name ?? "<unknown>"} ${serverInfo?.version ?? ""}`.trim(),
   );
 
   const { tools } = await client.listTools();
@@ -173,15 +196,26 @@ try {
     `knowledge_search "${CANARY_QUERY}" → ${ksStructured.count ?? ksResults.length} results`,
   );
 
-  // Pull the first non-null card_id to chain into get_chart_image / open_chart_ui.
-  // If knowledge_search ever returns results without any card_ids (unlikely
-  // but possible — e.g., raw deep-research outputs), the chained tools fall
-  // back to the negative-test mode below.
+  // Pull the first non-null card_id to chain into get_chart_image /
+  // open_chart_ui. We *require* at least one chartable card — knowledge_search
+  // returning results-without-card_ids for "US GDP" is itself a pipeline
+  // regression worth flagging (e.g., raw deep-research outputs leaking
+  // through without indexer attribution), so we fail rather than skip the
+  // chained tools.
   const chainPubId = ksResults
     .map((r) => r?.card_id)
     .find((id): id is string => typeof id === "string" && id.length > 0);
+  assert(
+    chainPubId,
+    `knowledge_search "${CANARY_QUERY}" returned ${ksResults.length} results but none had a usable card_id — chart-tool chaining is broken`,
+  );
 
   // ----- b) get_credit_balance ------------------------------------------
+  // Asserts `credit_balance` is present and either a number or a numeric
+  // string (DRF can serialize DecimalField as either depending on
+  // `coerce_to_string` — see the loose schema in get_credit_balance.ts).
+  // A rename or removal of the field on the backend produces a red smoke
+  // instead of a green one with `<unset>` printed.
   const cbResult = await callOk(client, "get_credit_balance", {});
   const cbStructured = cbResult.structuredContent as
     | { details?: Record<string, unknown> }
@@ -192,9 +226,17 @@ try {
     "get_credit_balance.details is not an object",
   );
   const balance = cbStructured.details["credit_balance"];
-  ok(
-    `get_credit_balance → details (credit_balance=${balance ?? "<unset>"})`,
+  const balanceNumeric =
+    typeof balance === "number"
+      ? balance
+      : typeof balance === "string" && Number.isFinite(Number(balance))
+        ? Number(balance)
+        : null;
+  assert(
+    balanceNumeric !== null,
+    `get_credit_balance.details.credit_balance is not a number or numeric string: ${JSON.stringify(balance)}`,
   );
+  ok(`get_credit_balance → details.credit_balance=${balanceNumeric}`);
 
   // ----- c) list_reports -------------------------------------------------
   const lrResult = await callOk(client, "list_reports", { limit: 1 });
@@ -211,62 +253,100 @@ try {
   );
 
   // ----- d) get_chart_image (chained) -----------------------------------
-  if (chainPubId) {
-    const giResult = await callOk(client, "get_chart_image", {
-      pub_id: chainPubId,
-    });
-    const giStructured = giResult.structuredContent as
-      | { image_url?: string; pub_id?: string }
-      | undefined;
-    assert(giStructured, "get_chart_image missing structuredContent");
-    assert(
-      typeof giStructured.image_url === "string" &&
-        HTTP_URL_REGEX.test(giStructured.image_url),
-      `get_chart_image.image_url is not http(s): ${JSON.stringify(giStructured.image_url)}`,
-    );
-    ok(`get_chart_image {pub_id:${chainPubId}} → image_url present`);
-  } else {
-    console.log(
-      `↷ get_chart_image skipped — no card_id in knowledge_search results`,
-    );
-  }
+  const giResult = await callOk(client, "get_chart_image", {
+    pub_id: chainPubId,
+  });
+  const giStructured = giResult.structuredContent as
+    | { image_url?: string; pub_id?: string }
+    | undefined;
+  assert(giStructured, "get_chart_image missing structuredContent");
+  assert(
+    typeof giStructured.image_url === "string" &&
+      HTTP_URL_REGEX.test(giStructured.image_url),
+    `get_chart_image.image_url is not http(s): ${JSON.stringify(giStructured.image_url)}`,
+  );
+  ok(`get_chart_image {pub_id:${chainPubId}} → image_url present`);
 
   // ----- e) open_chart_ui (chained) -------------------------------------
-  if (chainPubId) {
-    const ouResult = await callOk(client, "open_chart_ui", {
-      pub_id: chainPubId,
-    });
-    // open_chart_ui's structured payload includes `iframe_html` + `url`-ish
-    // fields; we don't pin to a specific shape (it's a UI helper that may
-    // evolve), only that it returns a structured object referencing pub_id.
-    const ouStructured = ouResult.structuredContent as
-      | Record<string, unknown>
-      | undefined;
-    assert(
-      ouStructured && typeof ouStructured === "object",
-      "open_chart_ui missing structuredContent",
-    );
-    ok(`open_chart_ui {pub_id:${chainPubId}} → structuredContent present`);
-  } else {
-    console.log(
-      `↷ open_chart_ui skipped — no card_id in knowledge_search results`,
-    );
-  }
+  const ouResult = await callOk(client, "open_chart_ui", {
+    pub_id: chainPubId,
+  });
+  // open_chart_ui's structured payload includes `iframe_html` + `url`-ish
+  // fields; we don't pin to a specific shape (it's a UI helper that may
+  // evolve), only that it returns a structured object referencing pub_id.
+  const ouStructured = ouResult.structuredContent as
+    | Record<string, unknown>
+    | undefined;
+  assert(
+    ouStructured && typeof ouStructured === "object",
+    "open_chart_ui missing structuredContent",
+  );
+  ok(`open_chart_ui {pub_id:${chainPubId}} → structuredContent present`);
 
   // ----- f) create_chart NEGATIVE test ----------------------------------
-  // Smoke must not have side effects, so we verify the tool's input
-  // validation rejects an empty `components` array — this exercises the
-  // tool surface (registration, schema, error-mapping) without producing
-  // a real card.
-  const ccResult = await client.callTool({
-    name: "create_chart",
-    arguments: { components: [] },
-  });
+  // Smoke must not have side effects, so we verify create_chart fails
+  // gracefully on a *server-rejected* payload rather than a
+  // *schema-rejected* one: the empty-array case (`components: []`) is
+  // caught by Zod's `.min(1)` before the handler runs, which would skip
+  // auth, the Django round-trip, and the write-path error mapping
+  // entirely. Passing one component with a bogus `component_type`
+  // satisfies the input schema (`componentSchema` is `.loose()` and only
+  // requires `component_type: string + config: object`) but Django
+  // rejects it during chart construction — exercising the same write
+  // path that a real `create_chart` call would, without producing a card.
+  //
+  // Two acceptable failure shapes:
+  //   1. The server returns `{isError: true, ...}` cleanly — preferred
+  //      and what the handler is *supposed* to do on a Django error.
+  //   2. The SDK throws `McpError` because the server's error response
+  //      doesn't satisfy `create_chart`'s strict output schema. This
+  //      still proves the handler ran (auth + djangoPost reached
+  //      Django, which rejected the chart) — the validation tripped on
+  //      the *response* shape, not on our request. Today this is what
+  //      actually happens (the handler doesn't synthesize a
+  //      schema-conformant error payload), so we treat it as
+  //      equivalent evidence of write-path exercise.
+  let createChartFailedAsExpected = false;
+  let createChartFailureMode: string;
+  try {
+    const ccResult = await client.callTool({
+      name: "create_chart",
+      arguments: {
+        components: [
+          {
+            component_type: "tako_smoke_invalid_component_type",
+            config: {},
+          },
+        ],
+        title: "tako-mcp smoke negative test (do not surface)",
+      },
+    });
+    if (ccResult.isError === true) {
+      createChartFailedAsExpected = true;
+      createChartFailureMode = "isError: true";
+    } else {
+      createChartFailureMode = `unexpected success: ${JSON.stringify(ccResult).slice(0, 300)}`;
+    }
+  } catch (err) {
+    if (err instanceof McpError) {
+      createChartFailedAsExpected = true;
+      // The SDK's InvalidParams (-32602) message includes "tool's output
+      // schema" when the failure is response-validation; surface that
+      // distinct case in the log so it's clear the handler ran.
+      createChartFailureMode = err.message.includes("output schema")
+        ? `McpError -32602 (server returned non-schema-conformant error response — handler ran, Django rejected)`
+        : `McpError ${err.code}: ${err.message.slice(0, 200)}`;
+    } else {
+      throw err;
+    }
+  }
   assert(
-    ccResult.isError === true,
-    `create_chart with empty components should error, got ${JSON.stringify(ccResult).slice(0, 300)}`,
+    createChartFailedAsExpected,
+    `create_chart with bogus component_type should fail; mode=${createChartFailureMode!}`,
   );
-  ok(`create_chart {components:[]} → isError (validation rejected, no chart created)`);
+  ok(
+    `create_chart {bogus component_type} → ${createChartFailureMode!} (write path exercised, no chart created)`,
+  );
 } finally {
   await client.close().catch(() => {
     // ignore close errors — we already have the answer we care about

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env tsx
+/**
+ * Post-deploy smoke test for the Tako MCP Worker (TAKO-2611).
+ *
+ * Hits a deployed Worker and walks the MCP protocol end-to-end:
+ *
+ *   1. `GET /health`           → expect HTTP 200 with body "ok"
+ *   2. MCP `initialize`        → handshake completes
+ *   3. MCP `tools/list`        → at least one tool, includes the canary set
+ *   4. Per-tool MCP `tools/call` canaries (read-only unless noted):
+ *        a. `knowledge_search "US GDP"`        — non-empty results, save the
+ *                                                first non-null `card_id` to
+ *                                                chain into chart tools below
+ *        b. `get_credit_balance`               — `details` object returned
+ *        c. `list_reports {limit:1}`           — `reports[]` array (may be 0)
+ *        d. `get_chart_image {pub_id}`         — `image_url` is http(s)
+ *        e. `open_chart_ui {pub_id}`           — produces a tako URL
+ *        f. `create_chart {components:[]}`     — *negative test* — verifies
+ *                                                input validation rejects
+ *                                                empty components without
+ *                                                actually creating a chart on
+ *                                                every deploy. We never test
+ *                                                the success path of write
+ *                                                tools in smoke.
+ *
+ * Excluded by design:
+ *   - `create_report`, `get_report` — write/long-running tools
+ *   - `explore_knowledge_graph`     — being removed in PR #47
+ *
+ * Any failure prints a `✘ ...` line to stderr and exits non-zero so the
+ * GitHub Actions job (or anyone running `npm run smoke`) flips red.
+ *
+ * Configuration (env vars):
+ *   SMOKE_BASE_URL          — Worker base URL. Default: the staging
+ *                             `*.workers.dev` URL while TAKO-2610 (custom
+ *                             domain bind for `mcp.staging.tako.com`) is
+ *                             pending. Override to smoke production or any
+ *                             other deployment target.
+ *   TAKO_SMOKE_API_TOKEN    — required Tako API token forwarded to the
+ *                             Worker as `Authorization: Bearer <token>`.
+ *                             Stored as a GitHub Actions secret in CI; mint
+ *                             your own at trytako.com for local runs.
+ *
+ * Secrets handling: the token is read from env, attached to the transport's
+ * `requestInit.headers`, and never logged. We print only structured result
+ * summaries (counts, tool names, sanitized URLs) — never request headers or
+ * raw response bodies.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const DEFAULT_BASE_URL = "https://tako-mcp-staging.bobby-118.workers.dev";
+const CANARY_QUERY = "US GDP";
+const HTTP_URL_REGEX = /^https?:\/\//;
+
+const baseUrl = (process.env.SMOKE_BASE_URL ?? DEFAULT_BASE_URL).replace(
+  /\/+$/,
+  "",
+);
+const apiToken = process.env.TAKO_SMOKE_API_TOKEN;
+
+if (!apiToken) {
+  console.error("✘ TAKO_SMOKE_API_TOKEN env var is required");
+  process.exit(1);
+}
+
+const ok = (msg: string) => console.log(`✓ ${msg}`);
+function fail(msg: string): never {
+  console.error(`✘ ${msg}`);
+  process.exit(1);
+}
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) fail(msg);
+}
+
+type CallToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+async function callOk(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<CallToolResult> {
+  const result = await client.callTool({ name, arguments: args });
+  if (result.isError) {
+    fail(
+      `${name} returned isError=true: ` +
+        JSON.stringify(result.content).slice(0, 400),
+    );
+  }
+  return result;
+}
+
+console.log(`smoke target: ${baseUrl}`);
+
+// ---------------------------------------------------------------------------
+// 1. /health
+// ---------------------------------------------------------------------------
+const healthRes = await fetch(`${baseUrl}/health`);
+if (healthRes.status !== 200) {
+  fail(`/health expected 200, got ${healthRes.status}`);
+}
+const healthBody = (await healthRes.text()).trim();
+if (healthBody !== "ok") {
+  fail(`/health expected body "ok", got ${JSON.stringify(healthBody)}`);
+}
+ok(`/health → 200 "ok"`);
+
+// ---------------------------------------------------------------------------
+// 2-4. MCP protocol via the SDK client
+// ---------------------------------------------------------------------------
+const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+  requestInit: {
+    headers: { authorization: `Bearer ${apiToken}` },
+  },
+});
+const client = new Client({ name: "tako-mcp-smoke", version: "1.0.0" });
+
+try {
+  // `as never` papers over an SDK-vs-strict-TS tension: the SDK types
+  // `StreamableHTTPClientTransport#sessionId` as `string | undefined`, which
+  // doesn't satisfy `Transport` under `exactOptionalPropertyTypes: true`.
+  await client.connect(transport as never);
+  const serverInfo = client.getServerVersion();
+  ok(
+    `initialize → ${serverInfo?.name ?? "<unknown>"} ` +
+      `${serverInfo?.version ?? ""}`.trim(),
+  );
+
+  const { tools } = await client.listTools();
+  if (tools.length === 0) {
+    fail("tools/list returned 0 tools");
+  }
+  const toolNames = tools.map((t) => t.name);
+  // Hard-assert tools we exercise below are present so the smoke fails fast
+  // with a useful diff if a registry change drops one of them. We don't
+  // assert on the *full* tool list because the surface evolves (e.g.
+  // explore_knowledge_graph removal in PR #47).
+  const requiredTools = [
+    "knowledge_search",
+    "get_credit_balance",
+    "list_reports",
+    "get_chart_image",
+    "open_chart_ui",
+    "create_chart",
+  ];
+  for (const required of requiredTools) {
+    if (!toolNames.includes(required)) {
+      fail(
+        `tools/list does not include ${required} (got: ${toolNames.join(", ")})`,
+      );
+    }
+  }
+  ok(`tools/list → ${tools.length} tools (${toolNames.join(", ")})`);
+
+  // ----- a) knowledge_search canary --------------------------------------
+  const ksResult = await callOk(client, "knowledge_search", {
+    query: CANARY_QUERY,
+  });
+  const ksStructured = ksResult.structuredContent as
+    | {
+        results?: Array<{ card_id?: string | null }>;
+        count?: number;
+      }
+    | undefined;
+  assert(ksStructured, "knowledge_search missing structuredContent");
+  const ksResults = ksStructured.results;
+  assert(
+    Array.isArray(ksResults) && ksResults.length > 0,
+    `knowledge_search returned empty results (count=${ksStructured.count ?? "?"})`,
+  );
+  ok(
+    `knowledge_search "${CANARY_QUERY}" → ${ksStructured.count ?? ksResults.length} results`,
+  );
+
+  // Pull the first non-null card_id to chain into get_chart_image / open_chart_ui.
+  // If knowledge_search ever returns results without any card_ids (unlikely
+  // but possible — e.g., raw deep-research outputs), the chained tools fall
+  // back to the negative-test mode below.
+  const chainPubId = ksResults
+    .map((r) => r?.card_id)
+    .find((id): id is string => typeof id === "string" && id.length > 0);
+
+  // ----- b) get_credit_balance ------------------------------------------
+  const cbResult = await callOk(client, "get_credit_balance", {});
+  const cbStructured = cbResult.structuredContent as
+    | { details?: Record<string, unknown> }
+    | undefined;
+  assert(cbStructured, "get_credit_balance missing structuredContent");
+  assert(
+    cbStructured.details && typeof cbStructured.details === "object",
+    "get_credit_balance.details is not an object",
+  );
+  const balance = cbStructured.details["credit_balance"];
+  ok(
+    `get_credit_balance → details (credit_balance=${balance ?? "<unset>"})`,
+  );
+
+  // ----- c) list_reports -------------------------------------------------
+  const lrResult = await callOk(client, "list_reports", { limit: 1 });
+  const lrStructured = lrResult.structuredContent as
+    | { reports?: unknown[]; count?: number }
+    | undefined;
+  assert(lrStructured, "list_reports missing structuredContent");
+  assert(
+    Array.isArray(lrStructured.reports),
+    "list_reports.reports is not an array",
+  );
+  ok(
+    `list_reports {limit:1} → count=${lrStructured.count ?? lrStructured.reports.length}`,
+  );
+
+  // ----- d) get_chart_image (chained) -----------------------------------
+  if (chainPubId) {
+    const giResult = await callOk(client, "get_chart_image", {
+      pub_id: chainPubId,
+    });
+    const giStructured = giResult.structuredContent as
+      | { image_url?: string; pub_id?: string }
+      | undefined;
+    assert(giStructured, "get_chart_image missing structuredContent");
+    assert(
+      typeof giStructured.image_url === "string" &&
+        HTTP_URL_REGEX.test(giStructured.image_url),
+      `get_chart_image.image_url is not http(s): ${JSON.stringify(giStructured.image_url)}`,
+    );
+    ok(`get_chart_image {pub_id:${chainPubId}} → image_url present`);
+  } else {
+    console.log(
+      `↷ get_chart_image skipped — no card_id in knowledge_search results`,
+    );
+  }
+
+  // ----- e) open_chart_ui (chained) -------------------------------------
+  if (chainPubId) {
+    const ouResult = await callOk(client, "open_chart_ui", {
+      pub_id: chainPubId,
+    });
+    // open_chart_ui's structured payload includes `iframe_html` + `url`-ish
+    // fields; we don't pin to a specific shape (it's a UI helper that may
+    // evolve), only that it returns a structured object referencing pub_id.
+    const ouStructured = ouResult.structuredContent as
+      | Record<string, unknown>
+      | undefined;
+    assert(
+      ouStructured && typeof ouStructured === "object",
+      "open_chart_ui missing structuredContent",
+    );
+    ok(`open_chart_ui {pub_id:${chainPubId}} → structuredContent present`);
+  } else {
+    console.log(
+      `↷ open_chart_ui skipped — no card_id in knowledge_search results`,
+    );
+  }
+
+  // ----- f) create_chart NEGATIVE test ----------------------------------
+  // Smoke must not have side effects, so we verify the tool's input
+  // validation rejects an empty `components` array — this exercises the
+  // tool surface (registration, schema, error-mapping) without producing
+  // a real card.
+  const ccResult = await client.callTool({
+    name: "create_chart",
+    arguments: { components: [] },
+  });
+  assert(
+    ccResult.isError === true,
+    `create_chart with empty components should error, got ${JSON.stringify(ccResult).slice(0, 300)}`,
+  );
+  ok(`create_chart {components:[]} → isError (validation rejected, no chart created)`);
+} finally {
+  await client.close().catch(() => {
+    // ignore close errors — we already have the answer we care about
+  });
+}
+
+console.log("\n✅ smoke passed");

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -32,6 +32,9 @@
       "vars": {
         "DJANGO_BASE_URL": "https://staging.trytako.com"
       },
+      // Keep `*.workers.dev` + Preview URLs enabled on staging as a debugging
+      // fallback once `mcp.staging.tako.com` is bound (TAKO-2610). Staging is
+      // not customer-facing, so the secondary entrypoint is acceptable.
       "workers_dev": true,
       "preview_urls": true
     },
@@ -40,6 +43,14 @@
       "vars": {
         "DJANGO_BASE_URL": "https://trytako.com"
       },
+      // Production currently exposes `tako-mcp-production.<account>.workers.dev`
+      // because the `mcp.tako.com` custom domain is not bound yet (TAKO-2610
+      // is blocked on Cloudflare Zone:Edit access — see TAKO-2677). This is
+      // explicitly temporary; the secondary entrypoint bypasses anything
+      // attached to the custom domain (Zone-level rules, future WAF/rate
+      // limits, analytics tags), so it must not survive the cutover.
+      // TODO(TAKO-2610): flip `workers_dev` to `false` once `mcp.tako.com`
+      // resolves to the Worker.
       "workers_dev": true,
       "preview_urls": false
     }

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -10,7 +10,9 @@
   "compatibility_date": "2025-06-17",
   // nodejs_compat: required by the MCP SDK / downstream dependencies we expect
   // to bring in during the port (Buffer, stream, etc.).
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": [
+    "nodejs_compat"
+  ],
   "observability": {
     "enabled": true
   },
@@ -29,13 +31,17 @@
       "name": "tako-mcp-staging",
       "vars": {
         "DJANGO_BASE_URL": "https://staging.trytako.com"
-      }
+      },
+      "workers_dev": true,
+      "preview_urls": true
     },
     "production": {
       "name": "tako-mcp-production",
       "vars": {
         "DJANGO_BASE_URL": "https://trytako.com"
-      }
+      },
+      "workers_dev": true,
+      "preview_urls": false
     }
   }
 }


### PR DESCRIPTION
## Summary

Two related changes bundled — the second wouldn't have been verifiable end-to-end without the first.

**1. Re-enable `workers_dev` for both envs.** The previous staging deploy disabled the `*.workers.dev` URL by default (wrangler v4 behavior change), leaving the Worker unreachable. Adds explicit `workers_dev: true` per env + `preview_urls: true` for staging.

**2. Adds the TAKO-2611 post-deploy smoke test.**

- `workers/scripts/smoke.ts` — MCP SDK client running 9 checks: `/health`, `initialize`, `tools/list`, and 6 per-tool canaries.
- `.github/workflows/workers-smoke.yml` — `workflow_run` auto-trigger after each successful staging deploy + `workflow_dispatch` for manual runs against any base URL.

Tools exercised in smoke:

| Tool | Canary | Type |
|---|---|---|
| `knowledge_search` | `"US GDP"` query → save first `card_id` for chaining | read |
| `get_credit_balance` | no args → expect `details.credit_balance` | read |
| `list_reports` | `{limit:1}` → expect `reports[]` array | read |
| `get_chart_image` | `{pub_id}` from knowledge_search → `image_url` http(s) | read, chained |
| `open_chart_ui` | `{pub_id}` from knowledge_search → `structuredContent` | read, chained |
| `create_chart` | `{components:[]}` → expect `isError: true` | **negative** — validates input rejection without creating a chart |

Excluded by design: `create_report` / `get_report` (long-running), `explore_knowledge_graph` (slated for removal in #47).

## Out of scope (deferred, blocked on Bobby)

- **TAKO-2610 custom-domain bind** for \`mcp.staging.tako.com\` and \`mcp.tako.com\`. Requires Cloudflare Zone:Edit access on the \`tako.com\` zone, which I don't currently have. DNS today still resolves both to the legacy AWS-ECS Python deploy with broken TLS; replacing those records needs Zone perms. Workers remain reachable via \`*.workers.dev\` URLs in the meantime.
- **\`workflow_run\` auto-trigger validation in CI.** Requires \`CLOUDFLARE_API_TOKEN\` + \`CLOUDFLARE_ACCOUNT_ID\` GitHub secrets so \`workers-deploy.yml\` actually runs in CI; same access dependency. Manual \`workflow_dispatch\` of \`workers-smoke\` works today as long as \`TAKO_SMOKE_API_TOKEN\` is set.

A follow-up Linear issue captures the full unblock ask.

## Test plan

- [x] \`npm run typecheck\` clean (src + scripts)
- [x] \`npm test\` — 60/60 passing
- [x] \`npm run registry:check\` — no drift, 9 tools
- [x] \`npm run smoke\` against staging — all 9 canaries green (real \`knowledge_search\` results, real credit balance, real chained \`pub_id\`, \`create_chart\` negative test confirmed)
- [x] \`gh secret set TAKO_SMOKE_API_TOKEN\` on the repo so CI can run smoke
- [x] Manually dispatch \`workers-smoke\` once via GitHub UI to confirm CI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)