### PR TITLE
feat(workers): MCP Apps widget for open_chart_ui (TAKO-2679)

### DIFF
--- a/registry/server.json
+++ b/registry/server.json
@@ -233,7 +233,7 @@
     },
     {
       "name": "open_chart_ui",
-      "description": "Use this when you want to display a fully interactive chart to the user. Returns the embed URL plus a ready-to-render iframe HTML snippet with zoom, pan, and hover interactions. Prefer this over get_chart_image when the user wants to explore the data interactively.",
+      "description": "Use this when you want to show a chart to the user. The chart's PNG is returned as a native MCP image content block — clients (claude.ai etc.) render it inline automatically; do NOT echo `![…](image_url)` markdown for it (that would re-display the chart behind a click-to-load gate). Also returns `embed_url` for a fully interactive version with zoom, pan, hover — surface it as a markdown link, e.g. `[Open interactive chart](embed_url)`. Never paste raw HTML or `<iframe>` markup; chat clients render markdown, not arbitrary HTML.",
       "parameters": {
         "pub_id": {
           "type": "string",
@@ -247,12 +247,12 @@
         },
         "width": {
           "type": "integer",
-          "description": "Advisory width in pixels. The returned `iframe_html` pins the iframe to `width=\"100%\"` so it fills its container; consumers should use this value to size the container they render `iframe_html` into. Mirrors the Python reference, which only uses `width` as an MCP-UI `PREFERRED_FRAME_SIZE` hint.",
+          "description": "Advisory width in pixels for the rendered chart container. The PNG endpoint ignores it; pass through to the client as a sizing hint only.",
           "default": 900
         },
         "height": {
           "type": "integer",
-          "description": "Initial iframe height in pixels. Applied directly in the iframe's CSS (`height` + `min-height`) — no resize handshake.",
+          "description": "Advisory height in pixels for the rendered chart container. The PNG endpoint ignores it; pass through to the client as a sizing hint only.",
           "default": 600
         }
       },

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -176,6 +176,44 @@ try {
   }
   ok(`tools/list → ${tools.length} tools (${toolNames.join(", ")})`);
 
+  // ----- MCP Apps wiring on open_chart_ui --------------------------------
+  // The widget bundle must be advertised two ways: the tool listing carries
+  // `_meta.ui.resourceUri`, and `resources/list` exposes a resource at that
+  // URI with the MCP Apps mimeType. Without both, MCP Apps clients
+  // (claude.ai, ChatGPT) silently fall back to the static-image path and
+  // we lose the interactive embed. Soft-warn if either is missing rather
+  // than failing — the smoke is still useful for the URL/image path even
+  // if the widget piece broke in this deploy.
+  const openChart = tools.find((t) => t.name === "open_chart_ui");
+  const openChartUiMeta = (openChart?._meta as { ui?: { resourceUri?: unknown } } | undefined)?.ui;
+  if (
+    !openChartUiMeta ||
+    typeof openChartUiMeta.resourceUri !== "string" ||
+    !openChartUiMeta.resourceUri.startsWith("ui://")
+  ) {
+    console.warn(
+      `[warn] open_chart_ui._meta.ui.resourceUri missing or not a ui:// URI ` +
+        `(got: ${JSON.stringify(openChart?._meta)})`,
+    );
+  } else {
+    const widgetUri = openChartUiMeta.resourceUri;
+    const { resources } = await client.listResources();
+    const widget = resources.find((r) => r.uri === widgetUri);
+    if (!widget) {
+      console.warn(
+        `[warn] resources/list does not include ${widgetUri} ` +
+          `(got: ${resources.map((r) => r.uri).join(", ") || "<none>"})`,
+      );
+    } else if (widget.mimeType !== "text/html;profile=mcp-app") {
+      console.warn(
+        `[warn] widget ${widgetUri} mimeType is ${JSON.stringify(widget.mimeType)} ` +
+          `(expected "text/html;profile=mcp-app")`,
+      );
+    } else {
+      ok(`open_chart_ui → MCP Apps widget at ${widgetUri} (${widget.mimeType})`);
+    }
+  }
+
   // ----- a) knowledge_search canary --------------------------------------
   const ksResult = await callOk(client, "knowledge_search", {
     query: CANARY_QUERY,
@@ -278,17 +316,53 @@ try {
   const ouResult = await callOk(client, "open_chart_ui", {
     pub_id: chainPubId,
   });
-  // open_chart_ui's structured payload includes `iframe_html` + `url`-ish
-  // fields; we don't pin to a specific shape (it's a UI helper that may
-  // evolve), only that it returns a structured object referencing pub_id.
+  // Structured payload carries `image_url` + `embed_url` (URL-only, no
+  // raw HTML — see the regression notes in tools/open_chart_ui.ts). The
+  // tool also appends an inline `image` content block via the
+  // `extraContentBlocks` hook so claude.ai-style clients render the chart
+  // without a click-to-load gate. The hook is best-effort: the image
+  // block is only present when the PNG endpoint responds with image
+  // bytes. We assert structuredContent is well-formed (always required)
+  // but only WARN if the inline image is missing — a slow PNG render or
+  // a transient upstream blip should not fail the smoke.
   const ouStructured = ouResult.structuredContent as
-    | Record<string, unknown>
+    | { embed_url?: string; image_url?: string; pub_id?: string }
     | undefined;
+  assert(ouStructured, "open_chart_ui missing structuredContent");
   assert(
-    ouStructured && typeof ouStructured === "object",
-    "open_chart_ui missing structuredContent",
+    typeof ouStructured.embed_url === "string" &&
+      HTTP_URL_REGEX.test(ouStructured.embed_url),
+    `open_chart_ui.embed_url is not http(s): ${JSON.stringify(ouStructured.embed_url)}`,
   );
-  ok(`open_chart_ui {pub_id:${chainPubId}} → structuredContent present`);
+  assert(
+    typeof ouStructured.image_url === "string" &&
+      HTTP_URL_REGEX.test(ouStructured.image_url),
+    `open_chart_ui.image_url is not http(s): ${JSON.stringify(ouStructured.image_url)}`,
+  );
+  const ouContent = (ouResult.content ?? []) as Array<{
+    type: string;
+    mimeType?: string;
+    data?: string;
+  }>;
+  const inlineImage = ouContent.find((b) => b.type === "image");
+  if (inlineImage) {
+    assert(
+      typeof inlineImage.mimeType === "string" &&
+        inlineImage.mimeType.startsWith("image/"),
+      `open_chart_ui inline image mimeType not image/*: ${JSON.stringify(inlineImage.mimeType)}`,
+    );
+    assert(
+      typeof inlineImage.data === "string" && inlineImage.data.length > 0,
+      "open_chart_ui inline image has no base64 data",
+    );
+    ok(
+      `open_chart_ui {pub_id:${chainPubId}} → structuredContent + inline ${inlineImage.mimeType} (${inlineImage.data.length} base64 chars)`,
+    );
+  } else {
+    ok(
+      `open_chart_ui {pub_id:${chainPubId}} → structuredContent present (no inline image — soft-fail path; URL fallback OK)`,
+    );
+  }
 
   // ----- f) create_chart NEGATIVE test ----------------------------------
   // Smoke must not have side effects, so we verify create_chart fails

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -116,7 +116,9 @@ describe("worker routing", () => {
     expect(res.status).toBe(200);
 
     const body = (await res.json()) as {
-      result: { tools: Array<{ name: string }> };
+      result: {
+        tools: Array<{ name: string; _meta?: Record<string, unknown> }>;
+      };
     };
     const names = body.result.tools.map((t) => t.name).sort();
     // The exact set of tools registered by the codegen barrel. When a tool
@@ -131,6 +133,130 @@ describe("worker routing", () => {
       "list_reports",
       "open_chart_ui",
     ]);
+
+    // MCP Apps: `open_chart_ui` ships a widget bundle, so its tool listing
+    // must carry the widget URI under BOTH `_meta.ui.resourceUri` (the
+    // open MCP Apps spec, read by claude.ai / VS Code / Goose) AND
+    // `_meta["openai/outputTemplate"]` (the OpenAI Apps SDK namespace,
+    // read by ChatGPT — without it ChatGPT loads the widget but never
+    // pipes structuredContent into `window.openai.toolOutput`, so the
+    // widget stays on its loading state forever). Other tools ship no
+    // widget and should declare neither field.
+    const openChart = body.result.tools.find((t) => t.name === "open_chart_ui");
+    // Three metadata keys, all carrying the same widget URI — matches what
+    // OpenAI's official `@modelcontextprotocol/ext-apps` helper emits.
+    // Different hosts read different keys (and different versions of the
+    // same host may have read different keys historically), so we set
+    // them all and let each host pick what it expects.
+    expect(openChart?._meta).toMatchObject({
+      ui: { resourceUri: "ui://tako/embed/chart" },
+      "ui/resourceUri": "ui://tako/embed/chart",
+      "openai/outputTemplate": "ui://tako/embed/chart",
+    });
+    for (const t of body.result.tools) {
+      if (t.name === "open_chart_ui") continue;
+      const meta = t._meta as
+        | {
+            ui?: unknown;
+            "ui/resourceUri"?: unknown;
+            "openai/outputTemplate"?: unknown;
+          }
+        | undefined;
+      expect(meta?.ui).toBeUndefined();
+      expect(meta?.["ui/resourceUri"]).toBeUndefined();
+      expect(meta?.["openai/outputTemplate"]).toBeUndefined();
+    }
+  });
+
+  it("POST /mcp resources/list includes the open_chart_ui widget bundle", async () => {
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 10,
+        method: "resources/list",
+        params: {},
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        resources: Array<{
+          uri: string;
+          mimeType?: string;
+          _meta?: Record<string, unknown>;
+        }>;
+      };
+    };
+    const widget = body.result.resources.find(
+      (r) => r.uri === "ui://tako/embed/chart",
+    );
+    expect(widget).toBeDefined();
+    expect(widget?.mimeType).toBe("text/html;profile=mcp-app");
+    // CSP-allowed iframe domain mirrors `resolvePublicBase(env)` (which in
+    // tests resolves to `DJANGO_BASE_URL` / `http://localhost:8000`). The
+    // widget embeds Tako's own embed page; without this the host's CSP
+    // blocks the inner iframe. ChatGPT also reads `_meta.ui.csp.frameDomains`
+    // (the open spec) for iframe permissions; the OpenAI-namespaced
+    // `widgetCSP` field is for `redirect_domains` (safe-link handling),
+    // a different concept we don't need.
+    expect(widget?._meta).toMatchObject({
+      ui: { csp: { frameDomains: ["http://localhost:8000"] } },
+    });
+  });
+
+  it("POST /mcp resources/read returns the widget HTML at the MCP Apps mimeType", async () => {
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 11,
+        method: "resources/read",
+        params: { uri: "ui://tako/embed/chart" },
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        contents: Array<{ uri: string; mimeType?: string; text?: string }>;
+      };
+    };
+    expect(body.result.contents).toHaveLength(1);
+    const item = body.result.contents[0]! as {
+      uri: string;
+      mimeType?: string;
+      text?: string;
+      _meta?: { ui?: { csp?: { frameDomains?: unknown } } };
+    };
+    expect(item.uri).toBe("ui://tako/embed/chart");
+    expect(item.mimeType).toBe("text/html;profile=mcp-app");
+    // Content-item `_meta.ui.csp` is what ChatGPT and other MCP-Apps
+    // hosts read during `resources/read` — content-item value takes
+    // precedence over registration-level `_meta` per the ext-apps
+    // contract. Without this on the read response, frame-ancestors
+    // stays empty and the inner iframe is blocked by the host's CSP.
+    expect(item._meta).toMatchObject({
+      ui: { csp: { frameDomains: ["http://localhost:8000"] } },
+    });
+    // Sanity-check the bundle's wire protocol: it MUST listen for the
+    // `ui/notifications/tool-result` JSON-RPC method (the post-message
+    // event the host emits on every tool call) and validate `embed_url`
+    // is http(s) before assigning to `iframe.src`. If this regresses,
+    // the widget either silently never renders or exposes itself to a
+    // hostile `javascript:` payload from a compromised server.
+    expect(item.text).toContain("ui/notifications/tool-result");
+    expect(item.text).toContain("https?:");
+    expect(item.text).toContain("tako-embed");
   });
 
   it("POST /mcp tools/call invokes the registered handler and surfaces structuredContent", async () => {
@@ -163,7 +289,7 @@ describe("worker routing", () => {
         structuredContent?: {
           pub_id: string;
           embed_url: string;
-          iframe_html: string;
+          image_url: string;
           dark_mode: boolean;
           width: number;
           height: number;
@@ -173,7 +299,9 @@ describe("worker routing", () => {
 
     // `structuredContent` is the typed payload; clients without that support
     // fall back to the `content[0].text` JSON string. Both must be present
-    // when the tool declares an `outputSchema`.
+    // when the tool declares an `outputSchema`. The output deliberately does
+    // NOT carry an `iframe_html` field — see open_chart_ui.ts header for
+    // the regression that motivated dropping it.
     expect(body.result.structuredContent).toMatchObject({
       pub_id: "abc123",
       dark_mode: true,
@@ -181,7 +309,10 @@ describe("worker routing", () => {
       height: 600,
     });
     expect(body.result.structuredContent?.embed_url).toContain("/embed/abc123/");
-    expect(body.result.structuredContent?.iframe_html).toContain("<iframe");
+    expect(body.result.structuredContent?.image_url).toContain(
+      "/api/v1/image/abc123/",
+    );
+    expect(body.result.structuredContent).not.toHaveProperty("iframe_html");
     expect(body.result.content[0]).toMatchObject({ type: "text" });
     const parsed = JSON.parse(body.result.content[0]!.text) as {
       pub_id: string;

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -33,6 +33,15 @@ export const SERVER_NAME = "tako-mcp";
 export const SERVER_VERSION = "0.1.0";
 
 /**
+ * MCP Apps UI resource MIME type. Hosts (claude.ai, ChatGPT Apps SDK, VS
+ * Code Insiders, Goose) gate sandbox-iframe rendering on this exact value
+ * — plain `text/html` resources are treated as opaque and not rendered as
+ * widgets. Source: MCP Apps standard ("text/html;profile=mcp-app") and
+ * the OpenAI Apps SDK "Build your MCP server" guide.
+ */
+const APP_UI_MIME_TYPE = "text/html;profile=mcp-app";
+
+/**
  * The CfWorker schema validator is stateless (it compiles a schema on each
  * `validate` call), so one module-scope instance is reused across warm
  * invocations rather than allocating a fresh one per `/mcp` POST.
@@ -101,6 +110,101 @@ function registerTool(
     }
   }
 
+  // MCP Apps: when the tool ships a UI bundle, register it as a separate
+  // resource and thread the widget URI into the tool's registration via
+  // BOTH the open-spec field and the OpenAI-namespaced field. Clients
+  // that support MCP Apps fetch the resource, sandbox it in an iframe,
+  // and pipe each `tools/call` result to the widget. Clients without
+  // MCP Apps support ignore the metadata and rely on the default
+  // text + image content blocks the registry already emits.
+  //
+  // Two metadata fields, two clients:
+  //
+  //   - `_meta.ui.resourceUri` — the open MCP Apps standard
+  //     (blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps).
+  //     claude.ai, VS Code Insiders, and Goose read this field. They
+  //     also pass the `tools/call` result to the widget via a JSON-RPC
+  //     `postMessage` (`ui/notifications/tool-result`).
+  //
+  //   - `_meta["openai/outputTemplate"]` — ChatGPT's Apps SDK reads
+  //     this exact namespaced key. It controls TWO things on ChatGPT's
+  //     side: which widget URI to load AND whether structuredContent
+  //     gets piped into `window.openai.toolOutput`. Without it, the
+  //     widget loads (because ChatGPT can fall back on `_meta.ui` to
+  //     find the URI) but `toolOutput` stays null forever, leaving the
+  //     widget stuck on its loading state. Found the hard way: the
+  //     debug widget polled `window.openai.toolOutput` 40 times across
+  //     10 seconds and watched it never populate, even though
+  //     `openai:set_globals` events fired with `detail.globals` set.
+  if (tool.appUiResource !== undefined) {
+    const ui = tool.appUiResource(ctx.env);
+    const uiMeta: Record<string, unknown> = {};
+    if (ui.frameDomains && ui.frameDomains.length > 0) {
+      uiMeta.csp = { frameDomains: ui.frameDomains };
+    }
+    // Resource registration. CSP-allowed iframe domains live on
+    // `_meta.ui.csp.frameDomains` (open MCP Apps spec). The bundle's
+    // `_meta.ui` is set in TWO places by design (matches the official
+    // `@modelcontextprotocol/ext-apps` helper):
+    //
+    //   1. Resource registration metadata (third arg to
+    //      `server.registerResource`) — surfaces in the `resources/list`
+    //      response so clients can discover CSP rules without fetching.
+    //   2. The content item itself (inside `readCallback`'s
+    //      `contents[0]._meta`) — clients reading the bundle read CSP
+    //      from here, and per the ext-apps docs the content-item value
+    //      "takes precedence" over the registration value. ChatGPT
+    //      specifically reads the content-item `_meta` during
+    //      `resources/read`; without it, frame-ancestors stays empty
+    //      and the inner `<iframe src="https://tako.com/embed/…">` is
+    //      blocked even though the registration metadata declared the
+    //      domain.
+    server.registerResource(
+      ui.name,
+      ui.uri,
+      {
+        // Per the MCP Apps spec: the host gates UI rendering on this
+        // exact MIME type. Plain "text/html" is treated as a normal
+        // resource and won't be sandbox-rendered as a widget.
+        mimeType: APP_UI_MIME_TYPE,
+        ...(Object.keys(uiMeta).length > 0 ? { _meta: { ui: uiMeta } } : {}),
+      },
+      // Static bundle — no per-request templating. The widget reads its
+      // chart-specific data (pub_id, embed_url, dark_mode, …) from each
+      // `tools/call` result via either `window.openai.toolOutput`
+      // (ChatGPT) or a `ui/notifications/tool-result` postMessage
+      // (claude.ai), so the same bundle serves every chart.
+      async (uri) => {
+        const contentItem: {
+          uri: string;
+          mimeType: string;
+          text: string;
+          _meta?: Record<string, unknown>;
+        } = {
+          uri: uri.toString(),
+          mimeType: APP_UI_MIME_TYPE,
+          text: ui.html,
+        };
+        if (Object.keys(uiMeta).length > 0) {
+          contentItem._meta = { ui: uiMeta };
+        }
+        return { contents: [contentItem] };
+      },
+    );
+    // Tool-side metadata: set the modern `_meta.ui.resourceUri`, the
+    // legacy flat `_meta["ui/resourceUri"]` (the official ext-apps
+    // helper auto-mirrors these for backward compat with older host
+    // readers — we do the same so a ChatGPT build still reading the
+    // legacy key works), and `_meta["openai/outputTemplate"]` (OpenAI
+    // namespace alias). Three keys, one URI — same data delivered
+    // under whichever name the host happens to read.
+    config._meta = {
+      ui: { resourceUri: ui.uri },
+      "ui/resourceUri": ui.uri,
+      "openai/outputTemplate": ui.uri,
+    };
+  }
+
   server.registerTool(
     tool.name,
     config as Parameters<McpServer["registerTool"]>[1],
@@ -125,12 +229,46 @@ function registerTool(
       // fall back to the text content. When no outputSchema, text-only is
       // sufficient.
       const text = JSON.stringify(output, null, 2);
+      const content: Array<
+        | { type: "text"; text: string }
+        | { type: "image"; data: string; mimeType: string }
+      > = [{ type: "text", text }];
+      // Optional per-tool hook to append extra MCP content blocks (image,
+      // audio, resource). Best-effort: a thrown hook degrades to the text
+      // + structuredContent that's already there rather than failing the
+      // call.
+      //
+      // SKIPPED when the tool also ships an `appUiResource`. Reason:
+      // when both are set, the response carries `content: [text, image]`
+      // + a `_meta.ui.resourceUri` pointing at a widget. The base64
+      // image inflates the JSON-RPC response by ~70-400 KB which on
+      // ChatGPT was tokenized at ~150K tokens and apparently triggers
+      // an internal size guard that silently disables widget data flow
+      // (`window.openai.toolOutput` stays null, `openai:set_globals`
+      // events fire only with maxHeight/maxWidth). The image is also
+      // redundant for clients that DO render the widget — the widget
+      // shows the chart interactively, an inline PNG below it would
+      // duplicate. Clients without widget support still see the
+      // structuredContent JSON (with `image_url` and `embed_url`) and
+      // can render those as markdown.
+      if (
+        tool.extraContentBlocks !== undefined &&
+        tool.appUiResource === undefined
+      ) {
+        try {
+          const extra = await tool.extraContentBlocks(output, ctx);
+          content.push(...extra);
+        } catch (err) {
+          console.error(
+            `extraContentBlocks hook failed for ${tool.name}:`,
+            err,
+          );
+        }
+      }
       const result: {
-        content: Array<{ type: "text"; text: string }>;
+        content: typeof content;
         structuredContent?: Record<string, unknown>;
-      } = {
-        content: [{ type: "text", text }],
-      };
+      } = { content };
       if (tool.outputSchema !== undefined) {
         result.structuredContent = output as Record<string, unknown>;
       }

--- a/workers/src/tools/open_chart_ui.test.ts
+++ b/workers/src/tools/open_chart_ui.test.ts
@@ -170,6 +170,26 @@ describe("open_chart_ui extraContentBlocks", () => {
     expect(blocks).toEqual([]);
   });
 
+  it("returns [] on a 0-byte response body (renderer returned early)", async () => {
+    // A 200 with content-type: image/png but an empty body would otherwise
+    // produce `{ data: "", mimeType: "image/png" }` — an invalid image
+    // block clients would try to render. Mirrors the oversize bail.
+    mockFetchOnce(pngResponse(new Uint8Array(0)));
+
+    const blocks = await open_chart_ui.extraContentBlocks!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      CTX,
+    );
+    expect(blocks).toEqual([]);
+  });
+
   it("returns [] on network errors (fetch throws)", async () => {
     vi.stubGlobal(
       "fetch",

--- a/workers/src/tools/open_chart_ui.test.ts
+++ b/workers/src/tools/open_chart_ui.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Tests for `open_chart_ui`'s `extraContentBlocks` hook.
+ *
+ * The handler itself is a pure URL builder (covered by index.test.ts); the
+ * hook is where the interesting behavior lives — it fetches the PNG, base64s
+ * it, and degrades gracefully on every failure mode. We assert the success
+ * path produces a valid `image` content block, and that each known failure
+ * mode (non-200, wrong content-type, oversize body, network error) returns
+ * `[]` so the tool call still resolves with the text + structuredContent
+ * fallback.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Env } from "../env.js";
+import type { ToolContext } from "./types.js";
+import open_chart_ui from "./open_chart_ui.js";
+import { mockFetchOnce } from "./__test_helpers.js";
+
+const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
+const CTX: ToolContext = { token: "sk-test", env: ENV };
+
+const HANDLER_INPUT = {
+  pub_id: "abc123",
+  dark_mode: true,
+  width: 900,
+  height: 600,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function pngResponse(
+  bytes: Uint8Array,
+  contentType = "image/png",
+): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: { "content-type": contentType },
+  });
+}
+
+describe("open_chart_ui handler", () => {
+  it("returns embed_url, image_url, and echoes inputs", async () => {
+    const out = await open_chart_ui.handler(HANDLER_INPUT, CTX);
+
+    expect(out.pub_id).toBe("abc123");
+    expect(out.embed_url).toBe(
+      "https://staging.trytako.com/embed/abc123/?theme=dark",
+    );
+    expect(out.image_url).toBe(
+      "https://staging.trytako.com/api/v1/image/abc123/?dark_mode=true",
+    );
+    expect(out.dark_mode).toBe(true);
+    expect(out.width).toBe(900);
+    expect(out.height).toBe(600);
+  });
+
+  it("encodes pub_id into the URLs (no path traversal / unescaped chars)", async () => {
+    const out = await open_chart_ui.handler(
+      { ...HANDLER_INPUT, pub_id: "weird/id with space" },
+      CTX,
+    );
+    // `encodeURIComponent` escapes both "/" and " ". This is the security
+    // boundary that keeps a hostile pub_id out of the URL path structure.
+    expect(out.embed_url).toContain("/embed/weird%2Fid%20with%20space/");
+    expect(out.image_url).toContain(
+      "/api/v1/image/weird%2Fid%20with%20space/",
+    );
+  });
+
+  it("light-mode flag flips the embed theme query and the image dark_mode flag", async () => {
+    const out = await open_chart_ui.handler(
+      { ...HANDLER_INPUT, dark_mode: false },
+      CTX,
+    );
+    expect(out.embed_url).toContain("?theme=light");
+    expect(out.image_url).toContain("dark_mode=false");
+  });
+});
+
+describe("open_chart_ui extraContentBlocks", () => {
+  it("inlines the PNG as a base64 image content block on a 200 image/png response", async () => {
+    // Synthetic non-empty payload — the hook doesn't decode or validate
+    // the bytes, just base64s them, so any non-empty buffer is enough.
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    mockFetchOnce(pngResponse(png));
+
+    const blocks = await open_chart_ui.extraContentBlocks!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      CTX,
+    );
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatchObject({
+      type: "image",
+      mimeType: "image/png",
+    });
+    // base64 of the 8-byte PNG header is "iVBORw0KGgo=".
+    expect((blocks[0] as { data: string }).data).toBe("iVBORw0KGgo=");
+  });
+
+  it("strips charset and other params off the content-type before reporting it as mimeType", async () => {
+    const png = new Uint8Array([0x89, 0x50]);
+    mockFetchOnce(pngResponse(png, "image/png; charset=binary"));
+
+    const blocks = await open_chart_ui.extraContentBlocks!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      CTX,
+    );
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { mimeType: string }).mimeType).toBe("image/png");
+  });
+
+  it("returns [] when the PNG endpoint returns non-200", async () => {
+    mockFetchOnce(new Response("not found", { status: 404 }));
+
+    const blocks = await open_chart_ui.extraContentBlocks!(
+      {
+        pub_id: "missing",
+        embed_url: "https://example.com/embed/missing/?theme=dark",
+        image_url: "https://example.com/api/v1/image/missing/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      CTX,
+    );
+    expect(blocks).toEqual([]);
+  });
+
+  it("returns [] when the response is not an image (e.g. an HTML error page from a redirect)", async () => {
+    // Defensive: an upstream that redirects "GET /api/v1/image/..." to a
+    // login page would otherwise let us base64 the HTML and ship it as
+    // mimeType: "image/png". Reject anything that doesn't look like an
+    // image.
+    mockFetchOnce(
+      new Response("<html>error</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      }),
+    );
+
+    const blocks = await open_chart_ui.extraContentBlocks!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      CTX,
+    );
+    expect(blocks).toEqual([]);
+  });
+
+  it("returns [] on network errors (fetch throws)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => {
+        throw new TypeError("network error");
+      }),
+    );
+
+    const blocks = await open_chart_ui.extraContentBlocks!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      CTX,
+    );
+    expect(blocks).toEqual([]);
+  });
+});
+
+describe("open_chart_ui appUiResource", () => {
+  it("returns a stable URI, the MCP Apps mimeType-bound bundle, and the env's web base as the only allowed frame domain", () => {
+    const ui = open_chart_ui.appUiResource!(ENV);
+    // URI stability is part of the contract: clients cache fetched
+    // bundles by URI, so renaming this would force every connected
+    // claude.ai / ChatGPT session to re-fetch.
+    expect(ui.uri).toBe("ui://tako/embed/chart");
+    expect(ui.name).toBe("open_chart_ui_widget");
+    // frameDomains must be exactly the env's public web base — no
+    // wildcards, no extra origins. The widget only ever embeds Tako's
+    // own embed page, so a tighter allow-list is the right default.
+    expect(ui.frameDomains).toEqual(["https://staging.trytako.com"]);
+  });
+
+  it("bundles the JSON-RPC tool-result listener and validates embed_url is http(s) before assigning to iframe.src", () => {
+    const ui = open_chart_ui.appUiResource!(ENV);
+    expect(ui.html).toContain("ui/notifications/tool-result");
+    // Defense-in-depth scheme check — a hostile MCP server could ship
+    // a `javascript:` URL that, without this guard, would execute in
+    // the widget origin once dropped into `iframe.src`. The handler
+    // already validates the output schema, but the widget is the last
+    // hop before the DOM, so duplicating the check is justified.
+    expect(ui.html).toContain("https?:");
+    expect(ui.html).toContain("addEventListener");
+    expect(ui.html).toContain('id="tako-embed"');
+    // Spec-compliant content type, signalling the host this is an MCP
+    // Apps widget bundle (not an opaque text/html resource).
+    expect(ui.html).toContain("<!doctype html>");
+  });
+});

--- a/workers/src/tools/open_chart_ui.ts
+++ b/workers/src/tools/open_chart_ui.ts
@@ -266,8 +266,8 @@ const WIDGET_HTML = `<!doctype html>
   // Subscribe to host updates. Multiple event-name candidates because
   // OpenAI's emitted name has drifted across SDK releases. Bind on both
   // \`window\` and \`document\` because some hosts dispatch on one and not
-  // the other. Also handles re-runs when the tool is invoked again in
-  // the same widget.
+  // the other. Prevents duplicate renders from redundant events within a
+  // single tool call (\`render()\` is one-shot via the \`rendered\` flag).
   var EVENT_NAMES = [
     "openai:set_globals",
     "openai:tool_result",
@@ -394,6 +394,10 @@ const open_chart_ui = {
       // that doesn't look like an image.
       if (!contentType.startsWith("image/")) return [];
       const buffer = await response.arrayBuffer();
+      // 0-byte 200 is plausible if a renderer returned early; emitting a
+      // `{ data: "", mimeType: "image/png" }` block would have clients try
+      // to render an invalid image. Mirror the oversize bail.
+      if (buffer.byteLength === 0) return [];
       if (buffer.byteLength > MAX_INLINE_PNG_BYTES) return [];
       return [
         {

--- a/workers/src/tools/open_chart_ui.ts
+++ b/workers/src/tools/open_chart_ui.ts
@@ -1,43 +1,44 @@
 /**
- * `open_chart_ui` — return everything a client needs to render an interactive
- * Tako chart iframe.
+ * `open_chart_ui` — return an inlined chart image plus URLs for the static
+ * PNG and the interactive embed.
  *
- * Ports `open_chart_ui` from `src/tako_mcp/server.py:691`.
+ * Originally ported from `open_chart_ui` in `src/tako_mcp/server.py:691`,
+ * which used `mcp-ui`'s `create_ui_resource()` to emit an MCP `resource`
+ * content block containing a live iframe. The TS port previously stuffed a
+ * ready-to-render `<iframe>` HTML string into a JSON output field; the LLM
+ * helpfully echoed it as text and clients displayed `<iframe …></iframe>`
+ * verbatim. Iteration two switched to `image_url` + `embed_url` and asked
+ * the LLM to render `![chart](image_url)` — better, but claude.ai web gates
+ * external markdown images behind a "Show Image" click-to-load.
  *
- * KNOWN REGRESSION vs the Python reference: the Python tool returns a
- * `list[UIResource]` via the `mcp-ui` library, which MCP-UI-aware clients
- * (e.g. Claude Desktop with the MCP-UI extension) auto-render as a live
- * interactive iframe. The TS registry contract (`mcp.ts:95-117`) currently
- * only emits `type: "text"` content blocks, so we cannot hand back a raw
- * MCP-UI `resource` content block without a `ToolModule` contract
- * extension (e.g. an optional `toContentBlocks(output)` hook). That
- * extension is out of scope for Phase 2 port. Clients that previously saw
- * an auto-rendered chart here will now see a JSON payload containing the
- * iframe HTML — a real UX regression for those clients.
+ * Current shape: emit a native MCP `image` content block with the PNG
+ * inlined as base64 (via the `extraContentBlocks` hook). claude.ai renders
+ * tool-emitted `image` blocks inline with no click gate — same path
+ * built-in image tools use. The structured output still carries `image_url`
+ * (for clients that want to fetch the bytes themselves or save the file)
+ * and `embed_url` (a markdown link to the fully interactive version with
+ * zoom, pan, hover).
  *
- * Interim shape: return `embed_url` plus a ready-to-render `iframe_html`
- * string. Clients that can inject HTML inline (some Claude clients with UI
- * extensions, some custom inspectors) can render; thin clients can still
- * show the `embed_url` as a clickable link.
+ * The `extraContentBlocks` hook fetches the PNG server-side and base64s it.
+ * If that fetch fails, the hook returns `[]` and the response degrades to
+ * the text + structured payload — the LLM can still surface the URLs as
+ * markdown so the user gets *something*. Errors don't fail the tool call.
  *
- * Follow-up work to re-enable full interactivity: extend `ToolModule` with
- * a content-block emitter, port `create_ui_resource()` equivalent, and
- * update this tool to emit a `resource` block containing the HTML and a
- * `ui://tako/embed/{pub_id}` URI. Track under a dedicated ticket.
+ * Follow-up work for clients that DO support MCP-UI (Claude Desktop with
+ * the MCP-UI extension): emit a `resource` block with a
+ * `ui://tako/embed/{pub_id}` URI alongside the inlined image. The hook
+ * contract already supports this — just extend `ToolContentBlock` and add
+ * a second entry to the returned array. claude.ai web does not render
+ * MCP-UI `resource` blocks today, so the inlined image is the most
+ * explicit thing we can ship there.
  *
- * Additional deliberate omission vs Python: the Python version shipped a
- * `window.addEventListener("message")` handler that reflowed the iframe
- * height in response to `{type: "tako::resize"}` postMessages from the
- * embedded chart. The TS port omits it — even a thin client that drops
- * `iframe_html` into the DOM will lose the auto-resize. Re-add alongside
- * the MCP-UI content-block work above.
- *
- * No Django call — purely a URL + HTML builder.
+ * Subrequest cost: one extra outbound `fetch` to the PNG endpoint per
+ * tool call. Within Workers' 50/1000 cap with plenty of headroom.
  */
 import { z } from "zod";
 
-import { resolvePublicBase } from "../env.js";
-import type { ToolModule } from "./types.js";
+import { resolvePublicApiBase, resolvePublicBase } from "../env.js";
+import type { AppUiResource, ToolContentBlock, ToolModule } from "./types.js";
 
 const inputSchema = z.object({
   pub_id: z
@@ -54,7 +55,7 @@ const inputSchema = z.object({
     .min(1)
     .default(900)
     .describe(
-      'Advisory width in pixels. The returned `iframe_html` pins the iframe to `width="100%"` so it fills its container; consumers should use this value to size the container they render `iframe_html` into. Mirrors the Python reference, which only uses `width` as an MCP-UI `PREFERRED_FRAME_SIZE` hint.',
+      "Advisory width in pixels for the rendered chart container. The PNG endpoint ignores it; pass through to the client as a sizing hint only.",
     ),
   height: z
     .number()
@@ -62,13 +63,13 @@ const inputSchema = z.object({
     .min(1)
     .default(600)
     .describe(
-      "Initial iframe height in pixels. Applied directly in the iframe's CSS (`height` + `min-height`) — no resize handshake.",
+      "Advisory height in pixels for the rendered chart container. The PNG endpoint ignores it; pass through to the client as a sizing hint only.",
     ),
 });
 
 // Tighter than `z.string().url()` — Zod's URL check accepts `javascript:`,
-// `data:`, and other non-web schemes. Since `embed_url` is handed to a
-// browser (possibly inlined into an `<iframe src>`), constrain to http(s).
+// `data:`, and other non-web schemes. Both URLs below flow to a browser
+// (markdown image src / link href), so constrain to http(s).
 const HTTP_URL_REGEX = /^https?:\/\//;
 
 const outputSchema = z.object({
@@ -76,29 +77,250 @@ const outputSchema = z.object({
   embed_url: z
     .string()
     .regex(HTTP_URL_REGEX, { message: "embed_url must be http(s)" }),
-  iframe_html: z.string(),
+  image_url: z
+    .string()
+    .regex(HTTP_URL_REGEX, { message: "image_url must be http(s)" }),
   dark_mode: z.boolean(),
-  // `width` is advisory — the iframe in `iframe_html` is `width="100%"`,
-  // so consumers render at whatever container width they choose and use
-  // this value as the suggested target. `height` is authoritative —
-  // baked into the iframe's CSS.
   width: z.number().int().positive(),
   height: z.number().int().positive(),
 });
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#x27;");
+// Cap how big a PNG we'll inline. Above this we skip the image block and
+// let the URL-only fallback take over. Two reasons: (1) the encoded base64
+// adds ~33% to wire weight on top of the JSON-RPC envelope, so a 5 MB PNG
+// becomes ~7 MB in the response — past the practical limit some MCP
+// clients tolerate before truncating or stalling; (2) Workers' default
+// response size guidance discourages large bodies. Tako chart PNGs run
+// 50-300 KB in practice, so 4 MB is generous headroom that still trips on
+// pathological cases.
+const MAX_INLINE_PNG_BYTES = 4 * 1024 * 1024;
+
+/**
+ * MCP Apps widget URI. Stable — DO NOT bump.
+ *
+ * We tried suffixing with `/v2` to bust ChatGPT's sticky resource
+ * cache (which doesn't clear on disconnect+reconnect). It didn't help
+ * ChatGPT (their data-flow problem is separate from resource caching)
+ * AND it broke the Claude desktop app: Claude desktop caches resource
+ * URIs at the connector level beyond connector lifecycle, so renaming
+ * the URI made every previously-installed Claude desktop session 404
+ * with `MCP error -32602: Resource ui://tako/embed/chart not found`.
+ * Lesson: once a URI ships, it's effectively permanent. If the bundle
+ * needs cache-busting in the future, register a NEW URI alongside the
+ * old one rather than replacing it.
+ */
+const APP_UI_RESOURCE_URI = "ui://tako/embed/chart";
+const APP_UI_RESOURCE_NAME = "open_chart_ui_widget";
+
+/**
+ * Bundle the host loads into a sandboxed iframe. One thin `<iframe>`
+ * pointing at Tako's existing `/embed/{pub_id}` page — we delegate
+ * rendering, zoom/pan/hover, and resize to that page rather than
+ * reimplementing chart UI inside the widget.
+ *
+ * Wire protocol: the host posts JSON-RPC `ui/notifications/tool-result`
+ * messages whose `params` contain `structuredContent` from the most
+ * recent `tools/call`. We read `embed_url` (already validated http(s) by
+ * the tool's output schema) and update `iframe.src`. `embed_url` carries
+ * the theme query and pub_id encoding the handler computed, so the
+ * widget never builds URLs itself — the security boundary stays
+ * server-side.
+ *
+ * Defense-in-depth: re-validate `embed_url` is http(s) before assigning
+ * to `iframe.src`. A hostile MCP server could ship a `javascript:` URL
+ * that, without this check, would execute in the widget origin once
+ * dropped into `src`. The handler validates too, but the widget is the
+ * last hop before the DOM, so duplication is justified.
+ */
+const WIDGET_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="x-tako-widget" content="open_chart_ui/v1" />
+<title>Tako chart</title>
+<style>
+  html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: transparent; color: #8b8f95; font: 14px system-ui, -apple-system, sans-serif; }
+  #tako-embed { width: 100% !important; border: 0 !important; display: block !important; background: transparent; }
+  #tako-placeholder {
+    display: flex; align-items: center; justify-content: center;
+    width: 100%; min-height: 240px;
+  }
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+<div id="tako-placeholder">Loading chart…</div>
+<iframe
+  id="tako-embed"
+  class="hidden"
+  scrolling="no"
+  frameborder="0"
+  allow="fullscreen"
+  title="Tako chart"
+></iframe>
+<script>
+(function () {
+  "use strict";
+  var frame = document.getElementById("tako-embed");
+  var placeholder = document.getElementById("tako-placeholder");
+  var rendered = false;
+
+  function log(label, payload) {
+    try { console.log("[tako-widget]", label, payload); } catch (e) {}
+  }
+
+  // \`structuredContent\` is the tool's output dict (pub_id, embed_url,
+  // image_url, dark_mode, width, height). Two arrival paths in practice:
+  //
+  //  - ChatGPT Apps SDK: \`window.openai\` exposes a few candidate keys
+  //    (\`toolOutput\` is documented but null in dev-mode custom
+  //    connectors as of 2026-04; the data lands under \`widget.*\` or
+  //    \`toolResponseMetadata.structuredContent\` for our case).
+  //    Updates arrive via the \`openai:set_globals\` CustomEvent.
+  //
+  //  - MCP Apps open spec (claude.ai web/desktop, VS Code Insiders,
+  //    Goose): \`ui/notifications/tool-result\` JSON-RPC over postMessage
+  //    with \`params.structuredContent\`.
+  //
+  // We try every key path so one bundle works on every host without a
+  // user-agent sniff. Cost of the extra checks is negligible.
+
+  // Some hosts gate widget data delivery on the iframe signaling its
+  // intrinsic height. We notify on load (placeholder height) and again
+  // after rendering. No-op on hosts that don't expose the function.
+  function notifyHeight(h) {
+    try {
+      if (window.openai && typeof window.openai.notifyIntrinsicHeight === "function") {
+        window.openai.notifyIntrinsicHeight(h);
+      }
+    } catch (e) { /* ignore */ }
+  }
+
+  function render(structuredContent) {
+    if (rendered) return true;
+    if (!structuredContent || typeof structuredContent !== "object") return false;
+    var url = structuredContent.embed_url;
+    // Defense-in-depth: re-validate http(s) before assigning to
+    // \`iframe.src\`. The handler validates server-side too, but the
+    // widget is the last hop before the DOM, so a hostile MCP server
+    // shipping \`javascript:\` would otherwise execute in the widget
+    // origin once dropped into \`src\`.
+    if (typeof url !== "string" || !/^https?:\\/\\//.test(url)) return false;
+    if (frame.src !== url) frame.src = url;
+    var h =
+      typeof structuredContent.height === "number" && structuredContent.height > 0
+        ? structuredContent.height
+        : 600;
+    frame.style.height = h + "px";
+    frame.style.minHeight = h + "px";
+    frame.setAttribute("height", String(h));
+    frame.classList.remove("hidden");
+    placeholder.classList.add("hidden");
+    rendered = true;
+    notifyHeight(h);
+    log("rendered", { src: url, height: h });
+    return true;
+  }
+
+  function pickFromOpenAi() {
+    var w = window;
+    if (!w || !w.openai || typeof w.openai !== "object") return null;
+    return (
+      w.openai.toolOutput ||
+      (w.openai.widget && w.openai.widget.toolOutput) ||
+      (w.openai.widget && w.openai.widget.structuredContent) ||
+      (w.openai.widget && w.openai.widget.payload) ||
+      (w.openai.toolResponseMetadata && w.openai.toolResponseMetadata.structuredContent) ||
+      null
+    );
+  }
+  function pickFromGlobals(globals) {
+    if (!globals || typeof globals !== "object") return null;
+    return (
+      globals.toolOutput ||
+      globals.structuredContent ||
+      (globals.widget && globals.widget.toolOutput) ||
+      (globals.widget && globals.widget.structuredContent) ||
+      (globals.widget && globals.widget.payload) ||
+      null
+    );
+  }
+
+  notifyHeight(240);
+
+  // Synchronous probe wins when the host injects data before our script
+  // runs; otherwise we fall through to a 10s polling window because
+  // ChatGPT populates the global at unpredictable times. Cost: one
+  // property read every 250 ms.
+  if (!render(pickFromOpenAi())) {
+    var attempts = 0;
+    var handle = setInterval(function () {
+      attempts += 1;
+      if (render(pickFromOpenAi()) || attempts >= 40) {
+        clearInterval(handle);
+      }
+    }, 250);
+  }
+
+  // Subscribe to host updates. Multiple event-name candidates because
+  // OpenAI's emitted name has drifted across SDK releases. Bind on both
+  // \`window\` and \`document\` because some hosts dispatch on one and not
+  // the other. Also handles re-runs when the tool is invoked again in
+  // the same widget.
+  var EVENT_NAMES = [
+    "openai:set_globals",
+    "openai:tool_result",
+    "openai:tool_response",
+    "openai:globals_set",
+    "openai:update",
+    "openai:state",
+  ];
+  var handler = function (event) {
+    var detail = event && event.detail;
+    var globals = detail && detail.globals;
+    render(pickFromGlobals(globals) || pickFromOpenAi());
+  };
+  EVENT_NAMES.forEach(function (name) {
+    window.addEventListener(name, handler);
+    document.addEventListener(name, handler);
+  });
+
+  // MCP Apps open-spec bridge — \`ui/notifications/tool-result\`
+  // JSON-RPC over postMessage. claude.ai, VS Code Insiders, and Goose
+  // follow this; ChatGPT uses the \`window.openai\` path above.
+  window.addEventListener("message", function (event) {
+    var msg = event.data;
+    if (!msg || typeof msg !== "object") return;
+    if (msg.jsonrpc !== "2.0") return;
+    if (msg.method !== "ui/notifications/tool-result") return;
+    var params = msg.params || {};
+    render(params.structuredContent);
+  });
+
+  log("listener attached", {
+    hasOpenAiGlobal: typeof window.openai !== "undefined",
+  });
+})();
+</script>
+</body>
+</html>`;
+// Bound how long we'll wait on the PNG endpoint before giving up. The
+// content block is "nice to have" — better to ship the URL fallback
+// quickly than block the whole tool call on a slow render.
+const PNG_FETCH_TIMEOUT_MS = 8_000;
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  // `Buffer` is available because `nodejs_compat` is enabled in
+  // wrangler.jsonc. Avoids the `String.fromCharCode(...spread)` pattern
+  // which can blow the call stack on multi-megabyte inputs.
+  return Buffer.from(buffer).toString("base64");
 }
 
 const open_chart_ui = {
   name: "open_chart_ui",
   description:
-    "Use this when you want to display a fully interactive chart to the user. Returns the embed URL plus a ready-to-render iframe HTML snippet with zoom, pan, and hover interactions. Prefer this over get_chart_image when the user wants to explore the data interactively.",
+    "Use this when you want to show a chart to the user. The chart's PNG is returned as a native MCP image content block — clients (claude.ai etc.) render it inline automatically; do NOT echo `![…](image_url)` markdown for it (that would re-display the chart behind a click-to-load gate). Also returns `embed_url` for a fully interactive version with zoom, pan, hover — surface it as a markdown link, e.g. `[Open interactive chart](embed_url)`. Never paste raw HTML or `<iframe>` markup; chat clients render markdown, not arbitrary HTML.",
   inputSchema,
   outputSchema,
   annotations: {
@@ -108,58 +330,83 @@ const open_chart_ui = {
     openWorldHint: true,
   },
   async handler(input, ctx) {
-    // `resolvePublicBase` prefers `PUBLIC_BASE_URL` (user-browser origin)
-    // and falls back to `DJANGO_BASE_URL`, validating non-empty, http/https
-    // scheme, and no trailing slash. The validated value flows directly
-    // into the `<iframe src="...">` below, so we rely on the helper's
-    // scheme check (not `encodeURIComponent` or `escapeHtml` alone) as the
-    // security boundary — a `javascript:` PUBLIC_BASE_URL would otherwise
-    // produce an iframe that executes script on render.
-    const base = resolvePublicBase(ctx.env);
+    // `resolvePublicBase` (web origin, e.g. `tako.com`) and
+    // `resolvePublicApiBase` (API origin, e.g. `api.tako.com`) are kept
+    // distinct because production splits them; both fall back to
+    // `DJANGO_BASE_URL` when the dedicated bindings aren't set. Each
+    // helper validates non-empty + http/https + no trailing slash and
+    // throws loud on bad config — these URLs go straight to user
+    // browsers, so they're a security boundary.
+    const webBase = resolvePublicBase(ctx.env);
+    const apiBase = resolvePublicApiBase(ctx.env);
     const theme = input.dark_mode ? "dark" : "light";
     const pubId = encodeURIComponent(input.pub_id);
-    const embedUrl = `${base}/embed/${pubId}/?theme=${theme}`;
-    const safeUrl = escapeHtml(embedUrl);
-
-    const iframeHtml = `<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>
-      html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: transparent; }
-      /* width: 100% by design — matches the Python reference. input.width is
-         advisory only; consumers size the container that wraps this HTML. */
-      #tako-embed {
-        width: 100% !important;
-        height: ${input.height}px !important;
-        min-height: ${input.height}px !important;
-        border: 0 !important;
-        display: block !important;
-      }
-    </style>
-  </head>
-  <body>
-    <iframe
-      id="tako-embed"
-      width="100%"
-      height="${input.height}"
-      src="${safeUrl}"
-      scrolling="no"
-      frameborder="0"
-      allow="fullscreen"
-    ></iframe>
-  </body>
-</html>`;
+    const embed_url = `${webBase}/embed/${pubId}/?theme=${theme}`;
+    const image_url = `${apiBase}/api/v1/image/${pubId}/?dark_mode=${input.dark_mode ? "true" : "false"}`;
 
     return {
       pub_id: input.pub_id,
-      embed_url: embedUrl,
-      iframe_html: iframeHtml,
+      embed_url,
+      image_url,
       dark_mode: input.dark_mode,
       width: input.width,
       height: input.height,
     };
+  },
+  appUiResource(env): AppUiResource {
+    // `frameDomains` is the host CSP's allow-list for nested iframes —
+    // without the widget's parent origin in here, the host blocks
+    // `<iframe src="https://tako.com/embed/...">`. We pin to exactly the
+    // public web origin (e.g. `tako.com` / `staging.trytako.com`) the
+    // tool also writes into `embed_url`, so the two move together. No
+    // wildcards: the widget only ever embeds Tako's own embed page.
+    const webBase = resolvePublicBase(env);
+    return {
+      uri: APP_UI_RESOURCE_URI,
+      name: APP_UI_RESOURCE_NAME,
+      html: WIDGET_HTML,
+      frameDomains: [webBase],
+    };
+  },
+  async extraContentBlocks(output, _ctx): Promise<ToolContentBlock[]> {
+    // Fetch the PNG so we can inline it as a base64 image content block —
+    // claude.ai renders tool-emitted images inline (no click-to-load gate
+    // that markdown image URLs trigger). All failure modes here degrade
+    // silently to `[]`: the tool's text + structuredContent already carry
+    // a working response, and the LLM can fall back to surfacing
+    // `embed_url` as a link. We don't fail the whole tool call over a
+    // presentation hiccup.
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(),
+      PNG_FETCH_TIMEOUT_MS,
+    );
+    try {
+      const response = await fetch(output.image_url, {
+        signal: controller.signal,
+      });
+      if (!response.ok) return [];
+      const contentType = response.headers.get("content-type") ?? "";
+      // Defensive: the PNG endpoint should always return image/png, but
+      // an upstream redirect to an HTML error page would otherwise let us
+      // base64 the HTML and ship it as `mimeType: "image/png"` — a
+      // garbage block the client would try to render. Reject anything
+      // that doesn't look like an image.
+      if (!contentType.startsWith("image/")) return [];
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > MAX_INLINE_PNG_BYTES) return [];
+      return [
+        {
+          type: "image",
+          data: arrayBufferToBase64(buffer),
+          mimeType: contentType.split(";")[0]!.trim(),
+        },
+      ];
+    } catch {
+      return [];
+    } finally {
+      clearTimeout(timeout);
+    }
   },
 } satisfies ToolModule<typeof inputSchema, z.infer<typeof outputSchema>>;
 

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -49,6 +49,53 @@ export interface ToolAnnotations {
 }
 
 /**
+ * Extra content blocks a tool can append to its result alongside the default
+ * JSON-stringified text block. Only the shapes we currently use are typed
+ * here — extend as new block types are needed (audio, resource, …). Mirrors
+ * the relevant subset of the MCP SDK's `ContentBlockSchema`.
+ */
+export type ToolContentBlock =
+  | { type: "image"; data: string; mimeType: string };
+
+/**
+ * MCP Apps UI bundle attached to a tool. When a tool declares this, the
+ * registry registers the bundle as an MCP resource at `uri` and threads
+ * `_meta.ui.resourceUri = uri` into the tool's MCP registration. Clients
+ * that support MCP Apps (claude.ai web/desktop, ChatGPT via Apps SDK, VS
+ * Code Insiders, Goose) fetch the bundle, sandbox it in an iframe, and
+ * forward each `tools/call` result to the widget over a JSON-RPC
+ * `postMessage` bridge (`ui/notifications/tool-result`). Clients without
+ * MCP Apps support ignore `_meta.ui` and the resource registration; the
+ * default text + image content blocks remain a working fallback.
+ *
+ * The factory is called once per `McpServer` instance (one per `/mcp`
+ * request) and receives the request's env, so per-environment values
+ * (e.g. `frameDomains` derived from `PUBLIC_BASE_URL`) can be baked into
+ * the registration without leaking env-specific strings into a static
+ * declaration.
+ *
+ * Spec references:
+ *  - MIME type and `_meta.ui.resourceUri` shape: OpenAI Apps SDK,
+ *    "Build your MCP server" / MCP Apps standard.
+ *  - `_meta.ui.csp.frameDomains`: required by the host sandbox so the
+ *    widget can embed an `<iframe src="https://tako.com/embed/...">`.
+ */
+export interface AppUiResource {
+  /** Unique resource URI, e.g. `"ui://tako/embed/chart"`. */
+  uri: string;
+  /** Stable resource name used in the SDK registration. */
+  name: string;
+  /** Bundled HTML (CSS+JS inline) the host loads into the sandbox iframe. */
+  html: string;
+  /**
+   * Hosts the widget may embed as nested iframes. Required for the chart
+   * embed: without this the host's CSP blocks the inner `<iframe src=
+   * "https://tako.com/embed/...">`.
+   */
+  frameDomains?: string[];
+}
+
+/**
  * The shape every tool file default-exports.
  *
  * Typical usage:
@@ -77,6 +124,26 @@ export interface ToolModule<
   outputSchema?: z.ZodType<Output>;
   annotations: ToolAnnotations;
   handler: (input: z.infer<InputSchema>, ctx: ToolContext) => Promise<Output>;
+  /**
+   * Optional hook to append extra MCP content blocks (image, audio, resource)
+   * after the default JSON-stringified text block. Called once per
+   * `tools/call`, after `handler` resolves. Tools should treat this as
+   * best-effort presentation: if the hook throws or returns `[]`, the text +
+   * `structuredContent` pair already provides a working response.
+   *
+   * Example: `open_chart_ui` uses this to inline a base64 PNG so MCP clients
+   * (claude.ai etc.) render the chart without a click-to-load gate.
+   */
+  extraContentBlocks?: (
+    output: Output,
+    ctx: ToolContext,
+  ) => Promise<ToolContentBlock[]>;
+  /**
+   * Optional MCP Apps UI bundle. Declared as a factory so values that
+   * depend on env (e.g. `frameDomains` from `PUBLIC_BASE_URL`) can be
+   * baked in at registration time. See {@link AppUiResource}.
+   */
+  appUiResource?: (env: Env) => AppUiResource;
 }
 
 /**
@@ -100,4 +167,9 @@ export interface AnyToolModule {
   outputSchema?: z.ZodType<unknown>;
   annotations: ToolAnnotations;
   handler: (input: unknown, ctx: ToolContext) => Promise<unknown>;
+  extraContentBlocks?: (
+    output: unknown,
+    ctx: ToolContext,
+  ) => Promise<ToolContentBlock[]>;
+  appUiResource?: (env: Env) => AppUiResource;
 }

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -133,6 +133,12 @@ export interface ToolModule<
    *
    * Example: `open_chart_ui` uses this to inline a base64 PNG so MCP clients
    * (claude.ai etc.) render the chart without a click-to-load gate.
+   *
+   * Skipped when `appUiResource` is also set on the same tool — see `mcp.ts`
+   * for the wiring. Rationale: combining a widget bundle with a large inline
+   * image trips ChatGPT's ~150K-token response guard and silently disables
+   * widget data flow, and the image is redundant when the widget renders the
+   * chart interactively anyway.
    */
   extraContentBlocks?: (
     output: Output,


### PR DESCRIPTION
## Summary

- Drops the JSON-blob-with-inline-iframe-HTML payload from `open_chart_ui`. Output is now `pub_id` / `embed_url` / `image_url` / `dark_mode` / `width` / `height` — no more raw `<iframe>` markup leaking into chat as text.
- Adds a generic `appUiResource` hook on `ToolModule`. When a tool declares it, `mcp.ts` registers the bundle as an MCP resource (`mimeType: text/html;profile=mcp-app`, CSP `frameDomains` pinned to the public embed origin) and threads the URI into `_meta` under all three of `ui.resourceUri` (open MCP Apps spec), `ui/resourceUri` (legacy flat), and `openai/outputTemplate` (OpenAI Apps SDK namespace).
- `open_chart_ui` ships a thin widget bundle: a single `<iframe>` whose `src` updates from `structuredContent.embed_url` arriving over either the `window.openai` global (ChatGPT Apps SDK — multi-key probing because the documented `toolOutput` is null for dev-mode custom connectors) or `ui/notifications/tool-result` postMessage ( / VS Code / Goose).
- Adds `extraContentBlocks` hook for an inline base64 PNG fallback. **Skipped when an `appUiResource` is also set** — in combination, the response crossed ChatGPT's internal size guard (~150K tokens) and silently disabled widget data flow. The image is also redundant when the widget renders the chart interactively.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 83/83 passing (added 10 unit tests for `open_chart_ui` handler / `extraContentBlocks` hook / `appUiResource` factory; 4 integration tests for `_meta.ui` on `tools/list`, `resources/list`, and `resources/read`)
- [x] `npm run registry:check` — ok
- [x] Verified live in ChatGPT (custom connector + developer mode) — interactive Tako chart renders inline
- [ ] Other MCP clients (Claude desktop, VS Code Insiders, Goose) — fall back to `structuredContent` + markdown link; widget will activate automatically when those clients support MCP Apps

## Notes

- This PR ships **only the chart fix**. OAuth follow-up (separate PR — replaces the static-Bearer auth path with a real OAuth flow for ChatGPT custom connectors).
- Smoke updated (`workers/scripts/smoke.ts`) to assert `_meta.ui.resourceUri` on the tool listing and the registered resource on `resources/list`. Soft-warns rather than fails so the smoke is still useful even if only the widget piece broke in a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)