### PR TITLE
feat(workers): multi-user OAuth via Stytch + JWT-stateless tokens (TAKO-2679)

### DIFF
--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -33,6 +33,55 @@ export interface Env {
    * include a trailing slash.
    */
   PUBLIC_API_URL?: string;
+  /**
+   * HMAC-SHA256 signing secret for every JWT the OAuth subsystem mints
+   * (auth codes, refresh tokens, access tokens, DCR client_ids, state /
+   * session cookies). Optional: when unset, `/authorize`, `/token`,
+   * `/register`, `/login`, and `/oauth/stytch_callback` all return 503
+   * and the Worker still serves the existing static-Bearer Claude Code
+   * path on `/mcp`. Set per-env via `wrangler secret put OAUTH_SIGN_KEY`.
+   */
+  OAUTH_SIGN_KEY?: string;
+  /**
+   * Base64-encoded 32-byte key (AES-256) used to encrypt the per-user
+   * Tako API token before embedding it in OAuth access / refresh /
+   * auth-code claims. Held separately from `OAUTH_SIGN_KEY` so the
+   * signing key can be hot-rotated without exposing previously-issued
+   * encrypted token claims to a leaked signing key. Optional in the
+   * same sense as `OAUTH_SIGN_KEY`. Set via
+   * `openssl rand -base64 32 | wrangler secret put OAUTH_ENC_KEY`.
+   */
+  OAUTH_ENC_KEY?: string;
+  /**
+   * Stytch project ID (e.g. `project-test-…` or `project-live-…`).
+   * Used as the username half of the HTTP Basic credential when the
+   * Worker calls Stytch's authenticate APIs server-to-server. Distinct
+   * from `STYTCH_PUBLIC_TOKEN` which the browser-side login page uses.
+   */
+  STYTCH_PROJECT_ID?: string;
+  /**
+   * Stytch project secret. Pairs with `STYTCH_PROJECT_ID` for HTTP Basic
+   * auth on Stytch's API. Treated as a Worker secret.
+   */
+  STYTCH_SECRET?: string;
+  /**
+   * Stytch public token. Embedded in the `/login` HTML page so the
+   * browser-side Stytch SDK can drive Google / magic-link auth. Safe to
+   * expose; it cannot, by itself, authenticate users — Stytch only
+   * issues real sessions via redirects back to URLs registered against
+   * the project ID.
+   */
+  STYTCH_PUBLIC_TOKEN?: string;
+  /**
+   * Base URL of the Stytch API for this project.
+   * - Test projects: `https://test.stytch.com`
+   * - Live projects: `https://api.stytch.com`
+   *
+   * Held as a binding (not derived from the project ID) so we can
+   * point at a sandbox without juggling project IDs. Must NOT include
+   * a trailing slash.
+   */
+  STYTCH_BASE_URL?: string;
 }
 
 /**

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -1,5 +1,14 @@
 import type { Env } from "./env.js";
 import { handleMcpRequest } from "./mcp.js";
+import {
+  handleAuthorize,
+  handleAuthServerMetadata,
+  handleLogin,
+  handleProtectedResourceMetadata,
+  handleRegister,
+  handleStytchCallback,
+  handleToken,
+} from "./oauth/handlers.js";
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -21,6 +30,40 @@ export default {
     // MCP clients (Claude Desktop, CLI) do not issue preflights. Revisit
     // when Phase 2 introduces streaming tools or browser-based clients —
     // see the `transport.close()` TODO in `mcp.ts`.
+
+    // OAuth 2.1 + DCR + PKCE (TAKO-2679). The two `.well-known/...`
+    // discovery docs let MCP hosts (Claude.ai, ChatGPT) bootstrap the
+    // OAuth flow from just the resource URL. `/register`, `/authorize`,
+    // `/token` implement the protocol per the MCP spec; `/login` and
+    // `/oauth/stytch_callback` are the user-facing parts of the dance
+    // that map a Stytch login to a Tako API token under the hood.
+    if (
+      request.method === "GET" &&
+      url.pathname === "/.well-known/oauth-protected-resource"
+    ) {
+      return handleProtectedResourceMetadata(request);
+    }
+    if (
+      request.method === "GET" &&
+      url.pathname === "/.well-known/oauth-authorization-server"
+    ) {
+      return handleAuthServerMetadata(request);
+    }
+    if (url.pathname === "/register") {
+      return handleRegister(request, env);
+    }
+    if (url.pathname === "/authorize") {
+      return handleAuthorize(request, env);
+    }
+    if (url.pathname === "/token") {
+      return handleToken(request, env);
+    }
+    if (url.pathname === "/login") {
+      return handleLogin(request, env);
+    }
+    if (url.pathname === "/oauth/stytch_callback") {
+      return handleStytchCallback(request, env);
+    }
 
     return new Response("not found", {
       status: 404,

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -41,13 +41,13 @@ export default {
       request.method === "GET" &&
       url.pathname === "/.well-known/oauth-protected-resource"
     ) {
-      return handleProtectedResourceMetadata(request);
+      return handleProtectedResourceMetadata(request, env);
     }
     if (
       request.method === "GET" &&
       url.pathname === "/.well-known/oauth-authorization-server"
     ) {
-      return handleAuthServerMetadata(request);
+      return handleAuthServerMetadata(request, env);
     }
     if (url.pathname === "/register") {
       return handleRegister(request, env);

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -20,6 +20,7 @@ import {
   DjangoUnauthorizedError,
 } from "./django.js";
 import type { Env } from "./env.js";
+import { tryResolveOAuthAccessToken } from "./oauth/access.js";
 import { TOOL_REGISTRY } from "./tools/_registry.js";
 import type { AnyToolModule, ToolContext } from "./tools/types.js";
 
@@ -220,15 +221,27 @@ export async function handleMcpRequest(
 ): Promise<Response> {
   // Gate the whole endpoint behind Bearer auth. If the header is missing /
   // malformed / empty, return a uniform 401 before invoking the SDK.
-  let token: string;
+  let bearer: string;
   try {
-    token = extractBearer(request);
+    bearer = extractBearer(request);
   } catch (err) {
     if (err instanceof BearerAuthError) {
-      return bearerAuthResponse(err);
+      return bearerAuthResponse(request, err);
     }
     throw err;
   }
+
+  // Two-mode bearer handling:
+  // - OAuth access JWT issued by /token: verify signature, decrypt the
+  //   per-user Tako API token from the `enc_tako_token` claim, forward
+  //   that token downstream as `X-API-Key`. Each user authenticates as
+  //   themselves to Django.
+  // - Raw Tako API token (the existing Claude Code path): non-JWT shape,
+  //   `tryResolveOAuthAccessToken` returns null, we forward the bearer
+  //   verbatim. Backwards-compatible with every Claude Code install in
+  //   the wild.
+  const oauthMappedToken = await tryResolveOAuthAccessToken(bearer, env);
+  const token = oauthMappedToken ?? bearer;
 
   const ctx: ToolContext = { token, env };
 
@@ -288,9 +301,14 @@ export async function handleMcpRequest(
  * {@link bearerAuthErrorToJsonRpc}; see `auth.ts`.
  *
  * Emits `WWW-Authenticate: Bearer` per RFC 6750 §3 so clients know to
- * supply a Bearer token on retry.
+ * supply a Bearer token on retry. The `resource_metadata` parameter
+ * (RFC 9728) points the client at our OAuth protected-resource discovery
+ * doc — that is how MCP hosts (Claude.ai, ChatGPT) bootstrap an OAuth
+ * flow when they have only the MCP URL and got a 401.
  */
-function bearerAuthResponse(err: BearerAuthError): Response {
+function bearerAuthResponse(request: Request, err: BearerAuthError): Response {
+  const origin = new URL(request.url).origin;
+  const resourceMetadataUrl = `${origin}/.well-known/oauth-protected-resource`;
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
@@ -301,7 +319,7 @@ function bearerAuthResponse(err: BearerAuthError): Response {
       status: 401,
       headers: {
         "Content-Type": "application/json; charset=utf-8",
-        "WWW-Authenticate": `Bearer error="invalid_token"`,
+        "WWW-Authenticate": `Bearer error="invalid_token", resource_metadata="${resourceMetadataUrl}"`,
       },
     },
   );

--- a/workers/src/oauth/access.test.ts
+++ b/workers/src/oauth/access.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { Env } from "../env.js";
+import { tryResolveOAuthAccessToken } from "./access.js";
+import { encryptAesGcm, signJwt } from "./jwt.js";
+import type { AccessTokenClaims } from "./types.js";
+
+const SIGN_KEY = "test-sign-key-access-test";
+
+function freshEncKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s);
+}
+
+function envWith(overrides: Partial<Env>): Env {
+  return {
+    DJANGO_BASE_URL: "https://example.test",
+    OAUTH_SIGN_KEY: SIGN_KEY,
+    OAUTH_ENC_KEY: freshEncKey(),
+    ...overrides,
+  };
+}
+
+async function mintAccessToken(
+  env: Env,
+  takoToken: string,
+): Promise<string> {
+  const enc_tako_token = await encryptAesGcm(takoToken, env.OAUTH_ENC_KEY!);
+  const claims: AccessTokenClaims = {
+    type: "access",
+    scope: "mcp",
+    user_id: "user-1",
+    user_email: "alice@example.com",
+    enc_tako_token,
+    exp: Math.floor(Date.now() / 1000) + 60,
+  };
+  return signJwt(claims, env.OAUTH_SIGN_KEY!);
+}
+
+describe("tryResolveOAuthAccessToken", () => {
+  it("decrypts the Tako token from a valid OAuth access JWT", async () => {
+    const env = envWith({});
+    const token = await mintAccessToken(env, "real-tako-token-xyz");
+    const downstream = await tryResolveOAuthAccessToken(token, env);
+    expect(downstream).toBe("real-tako-token-xyz");
+  });
+
+  it("returns null for non-JWT bearers (raw Tako tokens)", async () => {
+    const env = envWith({});
+    expect(
+      await tryResolveOAuthAccessToken("plain-tako-api-token", env),
+    ).toBeNull();
+  });
+
+  it("returns null when OAUTH_SIGN_KEY is unset (OAuth disabled)", async () => {
+    const env = envWith({});
+    const token = await mintAccessToken(env, "x");
+    // Strip OAUTH_SIGN_KEY rather than set it to undefined — the Env
+    // interface uses `exactOptionalPropertyTypes`, so explicit `undefined`
+    // doesn't satisfy `field?: string`.
+    const { OAUTH_SIGN_KEY: _omit, ...disabledEnv } = env;
+    void _omit;
+    expect(
+      await tryResolveOAuthAccessToken(token, disabledEnv as Env),
+    ).toBeNull();
+  });
+
+  it("returns null when OAUTH_ENC_KEY is unset", async () => {
+    const env = envWith({});
+    const token = await mintAccessToken(env, "x");
+    const { OAUTH_ENC_KEY: _omit, ...disabledEnv } = env;
+    void _omit;
+    expect(
+      await tryResolveOAuthAccessToken(token, disabledEnv as Env),
+    ).toBeNull();
+  });
+
+  it("returns null when token signature uses a different signing key", async () => {
+    const envA = envWith({});
+    const envB: Env = { ...envA, OAUTH_SIGN_KEY: "completely-different-key" };
+    const token = await mintAccessToken(envA, "x");
+    expect(await tryResolveOAuthAccessToken(token, envB)).toBeNull();
+  });
+
+  it("returns null when type discriminator is wrong (e.g., refresh token)", async () => {
+    const env = envWith({});
+    const enc_tako_token = await encryptAesGcm("x", env.OAUTH_ENC_KEY!);
+    const refreshShaped = await signJwt(
+      {
+        type: "refresh", // not "access"
+        scope: "mcp",
+        user_id: "u",
+        user_email: "e",
+        enc_tako_token,
+        exp: Math.floor(Date.now() / 1000) + 60,
+      },
+      env.OAUTH_SIGN_KEY!,
+    );
+    expect(await tryResolveOAuthAccessToken(refreshShaped, env)).toBeNull();
+  });
+
+  it("returns null when ENC_KEY was rotated under a still-valid signing key", async () => {
+    const env = envWith({});
+    const token = await mintAccessToken(env, "x");
+    const rotatedEnv: Env = { ...env, OAUTH_ENC_KEY: freshEncKey() };
+    expect(await tryResolveOAuthAccessToken(token, rotatedEnv)).toBeNull();
+  });
+});

--- a/workers/src/oauth/access.ts
+++ b/workers/src/oauth/access.ts
@@ -43,9 +43,14 @@ export async function tryResolveOAuthAccessToken(
     // raw Tako-token mode. Same semantics as the legacy Claude Code path.
     return null;
   }
-  // Cheap shape check — `<header>.<body>.<sig>`. Avoids the HMAC import
-  // for non-JWT bearers (the common case for Claude Code raw-token use).
-  if (bearer.split(".").length !== 3) return null;
+  // Cheap shape check — three base64url segments separated by dots.
+  // Avoids the HMAC import for non-JWT bearers (the common case for
+  // Claude Code raw-token use) and is tighter than `split(".").length`
+  // alone — a Tako token that happens to contain two dots would no
+  // longer falsely look like a JWT.
+  if (!/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(bearer)) {
+    return null;
+  }
 
   const claims = await verifyJwt<AccessTokenClaims>(bearer, sign);
   if (!claims || claims.type !== "access") return null;

--- a/workers/src/oauth/access.ts
+++ b/workers/src/oauth/access.ts
@@ -1,0 +1,68 @@
+/**
+ * Access-token verification for incoming `/mcp` requests. Called by
+ * `mcp.ts` before the JSON-RPC handler runs; if the bearer is a valid
+ * OAuth access token issued by `/token`, returns the decrypted Tako API
+ * token to forward downstream as `X-API-Key`. If it's anything else
+ * (raw Tako API token, malformed, expired) returns `null` and the
+ * caller falls through to the existing static-Bearer path.
+ *
+ * Keeping this in its own file (rather than inside `handlers.ts`) makes
+ * the `mcp.ts` import surface narrow and ensures the OAuth handlers can
+ * evolve their internals (e.g., adding a KV-backed revocation cache
+ * later) without touching the MCP request hot path.
+ */
+
+import type { Env } from "../env.js";
+import { decryptAesGcm, verifyJwt } from "./jwt.js";
+import type { AccessTokenClaims } from "./types.js";
+
+/**
+ * Verify an incoming bearer token as a Worker-issued OAuth access JWT.
+ * Returns the decrypted Tako API token on success, `null` otherwise
+ * (any failure path: missing config, wrong shape, bad signature,
+ * expired, decryption failure).
+ *
+ * The fall-through behavior is deliberate: a raw Tako API token (the
+ * existing Claude Code path) is not a JWT and will fail the shape
+ * check immediately, so this function never accidentally consumes
+ * a non-OAuth bearer.
+ */
+export async function tryResolveOAuthAccessToken(
+  bearer: string,
+  env: Env,
+): Promise<string | null> {
+  const sign = env.OAUTH_SIGN_KEY;
+  const enc = env.OAUTH_ENC_KEY;
+  if (
+    typeof sign !== "string" ||
+    sign.length === 0 ||
+    typeof enc !== "string" ||
+    enc.length === 0
+  ) {
+    // OAuth not configured on this env — every bearer falls through to
+    // raw Tako-token mode. Same semantics as the legacy Claude Code path.
+    return null;
+  }
+  // Cheap shape check — `<header>.<body>.<sig>`. Avoids the HMAC import
+  // for non-JWT bearers (the common case for Claude Code raw-token use).
+  if (bearer.split(".").length !== 3) return null;
+
+  const claims = await verifyJwt<AccessTokenClaims>(bearer, sign);
+  if (!claims || claims.type !== "access") return null;
+  if (typeof claims.enc_tako_token !== "string") return null;
+
+  const decrypted = await decryptAesGcm(claims.enc_tako_token, enc);
+  if (decrypted === null) {
+    // Signature verified (so the token came from us) but decryption
+    // failed — strongly implies the encryption key was rotated without
+    // also rotating the signing key, leaving in-flight access tokens
+    // un-decryptable. Log so this is visible during a key-rotation
+    // incident; return null so the request fails closed.
+    console.error(
+      "OAuth access token signature valid but Tako-token decryption failed " +
+        "(likely encryption-key rotation without coordinated signing-key rotation)",
+    );
+    return null;
+  }
+  return decrypted;
+}

--- a/workers/src/oauth/cookies.test.ts
+++ b/workers/src/oauth/cookies.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildClearCookie,
+  buildSetCookie,
+  readCookie,
+  SESSION_COOKIE,
+  STATE_COOKIE,
+} from "./cookies.js";
+
+describe("buildSetCookie", () => {
+  it("includes all required attributes", () => {
+    const cookie = buildSetCookie("foo", "bar", { maxAgeSeconds: 600 });
+    expect(cookie).toContain("foo=bar");
+    expect(cookie).toContain("Path=/");
+    expect(cookie).toContain("Max-Age=600");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    expect(cookie).toContain("SameSite=Lax");
+  });
+
+  it("does not set a Domain attribute (cookie scoped to Worker host)", () => {
+    const cookie = buildSetCookie("foo", "bar", { maxAgeSeconds: 600 });
+    expect(cookie).not.toContain("Domain");
+  });
+
+  it("respects sameSite override", () => {
+    const cookie = buildSetCookie("foo", "bar", {
+      maxAgeSeconds: 60,
+      sameSite: "Strict",
+    });
+    expect(cookie).toContain("SameSite=Strict");
+  });
+});
+
+describe("buildClearCookie", () => {
+  it("emits an empty value with Max-Age=0", () => {
+    const cookie = buildClearCookie(SESSION_COOKIE);
+    expect(cookie).toContain(`${SESSION_COOKIE}=`);
+    expect(cookie).toContain("Max-Age=0");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+  });
+});
+
+describe("readCookie", () => {
+  it("returns null when no Cookie header", () => {
+    const req = new Request("https://example.com/");
+    expect(readCookie(req, "foo")).toBeNull();
+  });
+
+  it("returns null when target cookie not present", () => {
+    const req = new Request("https://example.com/", {
+      headers: { cookie: "other=1; another=2" },
+    });
+    expect(readCookie(req, "foo")).toBeNull();
+  });
+
+  it("extracts a single cookie", () => {
+    const req = new Request("https://example.com/", {
+      headers: { cookie: "foo=bar" },
+    });
+    expect(readCookie(req, "foo")).toBe("bar");
+  });
+
+  it("extracts the right cookie from a multi-cookie header", () => {
+    const req = new Request("https://example.com/", {
+      headers: {
+        cookie: `${STATE_COOKIE}=state-jwt; ${SESSION_COOKIE}=session-jwt; other=ok`,
+      },
+    });
+    expect(readCookie(req, STATE_COOKIE)).toBe("state-jwt");
+    expect(readCookie(req, SESSION_COOKIE)).toBe("session-jwt");
+    expect(readCookie(req, "other")).toBe("ok");
+  });
+
+  it("does not match cookies whose names share a prefix", () => {
+    const req = new Request("https://example.com/", {
+      headers: { cookie: "fooBar=1; foo=2" },
+    });
+    expect(readCookie(req, "foo")).toBe("2");
+  });
+});

--- a/workers/src/oauth/cookies.ts
+++ b/workers/src/oauth/cookies.ts
@@ -1,0 +1,100 @@
+/**
+ * Cookie utilities for the Worker-issued state and session cookies.
+ *
+ * The Worker uses two cookies during the OAuth dance, both signed JWTs:
+ * - `tako_oauth_state` — short-lived (10min), written when /authorize
+ *   redirects to /login; carries OAuth params across the Stytch round-trip.
+ * - `tako_oauth_session` — medium-lived (30min), written by
+ *   /oauth/stytch_callback after the Stytch + Tako lookup succeeds; carries
+ *   `{user_id, user_email, encrypted_tako_token}` so /authorize and POST
+ *   /authorize can complete without re-doing the upstream lookups.
+ *
+ * Both cookies are HttpOnly + Secure + SameSite=Lax. Lax (not Strict)
+ * because the OAuth dance involves redirects from third-party origins
+ * (claude.ai, chatgpt.com); Strict would suppress the cookie on those
+ * cross-origin entry points and break the flow. Lax is the right level
+ * since cookies are still scoped to the Worker's origin and the JWTs
+ * are signed.
+ */
+
+export const STATE_COOKIE = "tako_oauth_state";
+export const SESSION_COOKIE = "tako_oauth_session";
+
+/** Conservative TTLs. Tunable when we have user data. */
+export const STATE_COOKIE_MAX_AGE_S = 10 * 60;
+export const SESSION_COOKIE_MAX_AGE_S = 30 * 60;
+
+interface CookieOptions {
+  maxAgeSeconds: number;
+  /**
+   * Override SameSite. The default `Lax` is correct for top-level
+   * navigation flows (redirects between OAuth participants). Pass
+   * `None` only when a cookie absolutely must travel on a third-party
+   * iframe / cross-site fetch — neither of our cookies needs that.
+   */
+  sameSite?: "Lax" | "Strict" | "None";
+}
+
+/**
+ * Build a `Set-Cookie` header value. Always HttpOnly + Secure;
+ * `path=/` so /authorize, /oauth/stytch_callback, and POST /authorize
+ * all see the same cookies.
+ */
+export function buildSetCookie(
+  name: string,
+  value: string,
+  opts: CookieOptions,
+): string {
+  const sameSite = opts.sameSite ?? "Lax";
+  // Cookie `Max-Age` and `Path` are widely supported and unambiguous.
+  // We avoid setting an explicit `Domain` so the cookie defaults to
+  // the Worker's host (e.g. `mcp.tako.com`) — never accidentally
+  // shared with sibling domains.
+  return [
+    `${name}=${value}`,
+    "Path=/",
+    `Max-Age=${opts.maxAgeSeconds}`,
+    "HttpOnly",
+    "Secure",
+    `SameSite=${sameSite}`,
+  ].join("; ");
+}
+
+/**
+ * Build a `Set-Cookie` header that immediately invalidates the named
+ * cookie. Used to clean up `tako_oauth_state` after consumption and
+ * `tako_oauth_session` on explicit logout.
+ */
+export function buildClearCookie(name: string): string {
+  return [
+    `${name}=`,
+    "Path=/",
+    "Max-Age=0",
+    "HttpOnly",
+    "Secure",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+/**
+ * Parse the value of a single named cookie out of an incoming `Cookie`
+ * header. Returns `null` if absent. Does not handle multiple cookies
+ * with the same name (which shouldn't happen for our cookies — they
+ * are always set on the same Path) and does no value decoding beyond
+ * splitting on `=` once: our cookie values are JWTs, which contain only
+ * URL-safe characters by construction.
+ */
+export function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get("cookie");
+  if (header === null) return null;
+  const parts = header.split(";");
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const k = trimmed.slice(0, eq);
+    if (k !== name) continue;
+    return trimmed.slice(eq + 1);
+  }
+  return null;
+}

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -167,6 +167,104 @@ describe("/register (DCR)", () => {
     );
     expect(res.status).toBe(400);
   });
+
+  it("rejects a `javascript:` redirect_uri", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "evil",
+          redirect_uris: ["javascript:alert(1)"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "invalid_redirect_uri",
+    );
+  });
+
+  it("rejects a `data:` redirect_uri", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          redirect_uris: ["data:text/html,<script>alert(1)</script>"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-loopback `http:` redirect_uri", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          redirect_uris: ["http://evil.example.com/cb"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts `http://localhost` redirect_uri (developer use)", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "dev-host",
+          redirect_uris: ["http://localhost:3000/cb"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects client_name with control characters", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "evil\nlog-injection",
+          redirect_uris: ["https://client.example.com/cb"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects oversized request bodies with 413", async () => {
+    const env = envWith();
+    const huge = "x".repeat(5000);
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: huge,
+          redirect_uris: ["https://client.example.com/cb"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(413);
+  });
 });
 
 /* --------------------------- /authorize --------------------------- */
@@ -270,6 +368,84 @@ describe("/authorize", () => {
     );
     expect(redirected.searchParams.get("state")).toBe("client-state");
     expect(redirected.searchParams.get("code")?.split(".").length).toBe(3);
+  });
+
+  it("rejects code_challenge_method=plain (only S256 is supported)", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", "plain-challenge-string");
+    url.searchParams.set("code_challenge_method", "plain");
+    const res = await handleAuthorize(
+      new Request(url.toString(), { method: "GET" }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("escapes HTML-injecting client_name in the consent page", async () => {
+    const env = envWith();
+    // Inject a registration with a client_name that would break out of
+    // attribute / text contexts if escaping is forgotten anywhere.
+    const claims = {
+      type: "client_id" as const,
+      client_name: "evil<script>alert(1)</script>\"'",
+      redirect_uris: ["https://client.example.com/cb"],
+      iat: Math.floor(Date.now() / 1000),
+    };
+    const clientId = await signJwt(claims, env.OAUTH_SIGN_KEY!);
+    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "GET",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Raw <script> from the client_name must NOT appear unescaped.
+    expect(html).not.toContain("<script>alert(1)</script>");
+    // The escaped form should be present so the page still tells the
+    // user which client_name was registered.
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("rebuilds form-action from validated params (not raw query string)", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    // An attacker-supplied unknown query param should not survive
+    // into the form-action URL.
+    url.searchParams.set("attacker_param", "whatever");
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "GET",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const html = await res.text();
+    expect(html).not.toContain("attacker_param");
   });
 
   it("rejects redirect_uri not in client's registered list", async () => {
@@ -422,6 +598,89 @@ describe("/token", () => {
     expect(refreshRes.status).toBe(200);
     const body = (await refreshRes.json()) as { access_token: string };
     expect(body.access_token.split(".").length).toBe(3);
+  });
+
+  it("rejects mismatched redirect_uri at /token", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const { verifier, challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://attacker.example.com/cb",
+          code_verifier: verifier,
+          client_id: clientId,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(400);
+    expect(((await tokenRes.json()) as { error: string }).error).toBe(
+      "invalid_grant",
+    );
+  });
+
+  it("rejects mismatched client_id at /token (belt-and-suspenders vs PKCE)", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const otherClientId = await mintClientId(env, "https://other.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const { verifier, challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    // Client B presents the form with their own client_id even though
+    // the auth code was minted for client A.
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          client_id: otherClientId,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(400);
+    expect(((await tokenRes.json()) as { error: string }).error).toBe(
+      "invalid_grant",
+    );
   });
 
   it("rejects unsupported grant_type", async () => {

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Env } from "../env.js";
 import {
@@ -9,7 +9,7 @@ import {
   handleRegister,
   handleToken,
 } from "./handlers.js";
-import { encryptAesGcm, signJwt } from "./jwt.js";
+import { decryptAesGcm, encryptAesGcm, signJwt } from "./jwt.js";
 import {
   buildSetCookie,
   SESSION_COOKIE,
@@ -72,17 +72,97 @@ async function mintClientId(env: Env, redirectUri: string): Promise<string> {
   return signJwt(claims, env.OAUTH_SIGN_KEY!);
 }
 
-async function mintSessionCookie(env: Env, takoToken: string): Promise<string> {
-  const enc_tako_token = await encryptAesGcm(takoToken, env.OAUTH_ENC_KEY!);
+/**
+ * Mint a `tako_oauth_session` cookie value. Carries an encrypted Stytch
+ * session JWT (placeholder ASCII string is fine — handler only decrypts
+ * + forwards it as a Cookie header to a mocked Tako fetch). Tests that
+ * exercise POST /authorize must also stub `globalThis.fetch` so the
+ * Tako-token re-fetch returns whatever value the test wants embedded in
+ * the issued auth code; see `mockTakoTokenFetch`.
+ */
+async function mintSessionCookie(
+  env: Env,
+  stytchJwtPlaceholder = "stub.stytch.session",
+): Promise<string> {
+  const enc_stytch_session_jwt = await encryptAesGcm(
+    stytchJwtPlaceholder,
+    env.OAUTH_ENC_KEY!,
+  );
   const claims: SessionCookieClaims = {
     type: "session",
     user_id: "user-1",
     user_email: "alice@example.com",
-    enc_tako_token,
+    enc_stytch_session_jwt,
     exp: Math.floor(Date.now() / 1000) + 600,
   };
   return signJwt(claims, env.OAUTH_SIGN_KEY!);
 }
+
+/**
+ * Stub `globalThis.fetch` so a server-side call to Tako's
+ * `/api/v1/api_token/` endpoint returns the supplied token value.
+ * Used by tests that exercise POST /authorize, since that handler now
+ * re-fetches the Tako token from the user's Stytch session at consent
+ * time (see Option 2 in the OAuth design doc).
+ */
+function mockTakoTokenFetch(token: string): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes("/api/v1/api_token/")) {
+        return new Response(JSON.stringify({ token }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      // Anything else is unexpected from these tests; fail loudly so
+      // we notice if the handler grows another upstream call.
+      return new Response(`unmocked fetch: ${url}`, { status: 599 });
+    }),
+  );
+}
+
+/**
+ * Stub `globalThis.fetch` so Tako's `/api/v1/api_token/` returns the
+ * given non-200 status. Used to test the error branches in POST /authorize.
+ */
+function mockTakoTokenFetchStatus(status: number): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.includes("/api/v1/api_token/")) {
+        return new Response("error", { status });
+      }
+      return new Response(`unmocked fetch: ${url}`, { status: 599 });
+    }),
+  );
+}
+
+beforeEach(() => {
+  // Every test starts with a fetch stub that resolves Tako's
+  // `/api/v1/api_token/` to a generic token. Tests that need to
+  // verify a specific token value or test an error path call
+  // `mockTakoTokenFetch(...)` / `mockTakoTokenFetchStatus(...)`
+  // themselves to override.
+  vi.unstubAllGlobals();
+  mockTakoTokenFetch("default-mocked-tako-token");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 /* --------------------------- Discovery --------------------------- */
 
@@ -314,7 +394,7 @@ describe("/authorize", () => {
   it("GET with valid session renders HTML consent page", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -359,7 +439,7 @@ describe("/authorize", () => {
   it("POST with valid session redirects to client with auth code", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -414,7 +494,7 @@ describe("/authorize", () => {
       iat: Math.floor(Date.now() / 1000),
     };
     const clientId = await signJwt(claims, env.OAUTH_SIGN_KEY!);
-    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -442,7 +522,7 @@ describe("/authorize", () => {
   it("rebuilds form-action from validated params (not raw query string)", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -468,7 +548,7 @@ describe("/authorize", () => {
   it("rejects redirect_uri not in client's registered list", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -499,7 +579,7 @@ describe("/token", () => {
   }> {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const sessionJwt = await mintSessionCookie(env);
     const { verifier, challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -560,7 +640,7 @@ describe("/token", () => {
   it("rejects authorization_code grant with mismatched PKCE verifier", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -620,7 +700,7 @@ describe("/token", () => {
   it("rejects mismatched redirect_uri at /token", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const sessionJwt = await mintSessionCookie(env);
     const { verifier, challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -661,7 +741,7 @@ describe("/token", () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
     const otherClientId = await mintClientId(env, "https://other.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const sessionJwt = await mintSessionCookie(env);
     const { verifier, challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -807,7 +887,7 @@ describe("/authorize hardening", () => {
   it("accepts the supported `mcp` scope", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
-    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const sessionJwt = await mintSessionCookie(env);
     const { challenge } = await pkcePair();
     const url = new URL("https://mcp.example.com/authorize");
     url.searchParams.set("client_id", clientId);
@@ -875,6 +955,152 @@ describe("/authorize hardening", () => {
     ) as { exp?: number; iat: number };
     expect(payload.exp).toBeDefined();
     expect(payload.exp!).toBeGreaterThan(payload.iat);
+  });
+});
+
+/* --------------------------- /authorize POST re-fetches Tako token --------------------------- */
+
+describe("/authorize POST always re-fetches the Tako token (Option 2)", () => {
+  async function runAuthorizePost(
+    env: Env,
+  ): Promise<{ accessToken: string; verifier: string; clientId: string }> {
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { verifier, challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(authorizeRes.status).toBe(302);
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+
+    // Exchange the auth code for tokens so the test can decrypt the
+    // resulting access token's enc_tako_token claim.
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          client_id: clientId,
+        }).toString(),
+      }),
+      env,
+    );
+    const body = (await tokenRes.json()) as { access_token: string };
+    return { accessToken: body.access_token, verifier, clientId };
+  }
+
+  function decodeAccessClaims(jwt: string): Record<string, unknown> {
+    const parts = jwt.split(".");
+    return JSON.parse(
+      atob(parts[1]!.replace(/-/g, "+").replace(/_/g, "/")),
+    ) as Record<string, unknown>;
+  }
+
+  it("embeds the freshly-fetched Tako token in the issued auth code, not a cached value", async () => {
+    const env = envWith();
+    // Mock fetch to return a known token. The session cookie itself
+    // carries only the encrypted Stytch JWT — no Tako token cached.
+    mockTakoTokenFetch("FRESH_TAKO_TOKEN_FROM_DJANGO");
+    const { accessToken } = await runAuthorizePost(env);
+    const claims = decodeAccessClaims(accessToken);
+    const decrypted = await decryptAesGcm(
+      claims["enc_tako_token"] as string,
+      env.OAUTH_ENC_KEY!,
+    );
+    expect(decrypted).toBe("FRESH_TAKO_TOKEN_FROM_DJANGO");
+  });
+
+  it("reflects rotation: a second consent flow uses the rotated Tako token", async () => {
+    const env = envWith();
+
+    mockTakoTokenFetch("OLD_TAKO_TOKEN");
+    const first = await runAuthorizePost(env);
+    const firstDecrypted = await decryptAesGcm(
+      decodeAccessClaims(first.accessToken)["enc_tako_token"] as string,
+      env.OAUTH_ENC_KEY!,
+    );
+    expect(firstDecrypted).toBe("OLD_TAKO_TOKEN");
+
+    // Simulate rotation at trytako.com: subsequent fetches return the new token.
+    mockTakoTokenFetch("NEW_TAKO_TOKEN_AFTER_ROTATION");
+    const second = await runAuthorizePost(env);
+    const secondDecrypted = await decryptAesGcm(
+      decodeAccessClaims(second.accessToken)["enc_tako_token"] as string,
+      env.OAUTH_ENC_KEY!,
+    );
+    expect(secondDecrypted).toBe("NEW_TAKO_TOKEN_AFTER_ROTATION");
+  });
+
+  it("returns a 401 sign-in-required page when Stytch session is rejected by Tako", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    // Tako returns 401 → unauthorized → user must re-login.
+    mockTakoTokenFetchStatus(401);
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    // Session cookie cleared so the next /authorize forces a fresh /login.
+    expect(setCookie).toContain(`${SESSION_COOKIE}=`);
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("returns a 400 'mint a Tako token' page when user has no Tako API token", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    // 404 from Tako means user hasn't minted a token yet.
+    mockTakoTokenFetchStatus(404);
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("trytako.com");
   });
 });
 

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -795,6 +795,25 @@ describe("/token", () => {
       "unsupported_grant_type",
     );
   });
+
+  it("returns invalid_request when grant_type is missing", async () => {
+    const env = envWith();
+    const res = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ code: "x" }).toString(),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: string;
+      error_description: string;
+    };
+    expect(body.error).toBe("invalid_request");
+    expect(body.error_description).toBe("grant_type is required");
+  });
 });
 
 /* --------------------------- /login --------------------------- */
@@ -904,6 +923,47 @@ describe("/authorize hardening", () => {
       env,
     );
     expect(res.status).toBe(200);
+  });
+
+  it("treats empty `?scope=` as the default `mcp` scope", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { verifier, challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("scope", "");
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(authorizeRes.status).toBe(302);
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          client_id: clientId,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { scope: string };
+    expect(body.scope).toBe("mcp");
   });
 
   it("rejects an expired client_id (registration TTL)", async () => {

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -87,9 +87,10 @@ async function mintSessionCookie(env: Env, takoToken: string): Promise<string> {
 /* --------------------------- Discovery --------------------------- */
 
 describe("discovery", () => {
-  it("/.well-known/oauth-protected-resource advertises auth server", async () => {
+  it("/.well-known/oauth-protected-resource advertises auth server when configured", async () => {
     const res = handleProtectedResourceMetadata(
       new Request("https://mcp.example.com/.well-known/oauth-protected-resource"),
+      envWith(),
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -100,11 +101,12 @@ describe("discovery", () => {
     expect(body.authorization_servers).toEqual(["https://mcp.example.com"]);
   });
 
-  it("/.well-known/oauth-authorization-server lists endpoints + PKCE S256", async () => {
+  it("/.well-known/oauth-authorization-server lists endpoints + PKCE S256 when configured", async () => {
     const res = handleAuthServerMetadata(
       new Request(
         "https://mcp.example.com/.well-known/oauth-authorization-server",
       ),
+      envWith(),
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -117,6 +119,21 @@ describe("discovery", () => {
     expect(body.token_endpoint).toBe("https://mcp.example.com/token");
     expect(body.registration_endpoint).toBe("https://mcp.example.com/register");
     expect(body.code_challenge_methods_supported).toContain("S256");
+  });
+
+  it("returns 404 when OAuth is disabled (no metadata advertised)", async () => {
+    const res1 = handleProtectedResourceMetadata(
+      new Request("https://mcp.example.com/.well-known/oauth-protected-resource"),
+      ENV_NO_OAUTH,
+    );
+    expect(res1.status).toBe(404);
+    const res2 = handleAuthServerMetadata(
+      new Request(
+        "https://mcp.example.com/.well-known/oauth-authorization-server",
+      ),
+      ENV_NO_OAUTH,
+    );
+    expect(res2.status).toBe(404);
   });
 });
 
@@ -725,6 +742,139 @@ describe("/login", () => {
       expect(html).toContain("/oauth/stytch_callback");
       expect(html).toContain("Continue with Google");
     });
+  });
+});
+
+/* --------------------------- HTML response hardening --------------------------- */
+
+describe("HTML responses set defensive headers", () => {
+  async function fetchHtml(): Promise<Response> {
+    const env = envWith();
+    return handleLogin(new Request("https://mcp.example.com/login"), env);
+  }
+
+  it("sets X-Frame-Options: DENY (clickjacking defense)", async () => {
+    const res = await fetchHtml();
+    expect(res.headers.get("x-frame-options")).toBe("DENY");
+  });
+
+  it("sets CSP frame-ancestors 'none' (modern clickjacking defense)", async () => {
+    const res = await fetchHtml();
+    expect(res.headers.get("content-security-policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+  });
+
+  it("sets Cache-Control: no-store (no proxy caching of auth pages)", async () => {
+    const res = await fetchHtml();
+    const cc = res.headers.get("cache-control") ?? "";
+    expect(cc).toContain("no-store");
+    expect(cc).toContain("no-cache");
+  });
+
+  it("sets X-Content-Type-Options: nosniff", async () => {
+    const res = await fetchHtml();
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("sets Referrer-Policy: no-referrer (don't leak OAuth params on outbound clicks)", async () => {
+    const res = await fetchHtml();
+    expect(res.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+});
+
+/* --------------------------- /authorize scope + client_id expiry --------------------------- */
+
+describe("/authorize hardening", () => {
+  it("rejects unsupported scope values", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("scope", "admin:write");
+    const res = await handleAuthorize(
+      new Request(url.toString(), { method: "GET" }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts the supported `mcp` scope", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("scope", "mcp");
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "GET",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an expired client_id (registration TTL)", async () => {
+    const env = envWith();
+    // Mint a client_id that's already expired.
+    const expiredClient: ClientIdClaims = {
+      type: "client_id",
+      client_name: "expired-test",
+      redirect_uris: ["https://client.example.com/cb"],
+      iat: Math.floor(Date.now() / 1000) - 1000,
+      exp: Math.floor(Date.now() / 1000) - 100,
+    };
+    const expiredClientId = await signJwt(expiredClient, env.OAUTH_SIGN_KEY!);
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", expiredClientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    const res = await handleAuthorize(
+      new Request(url.toString(), { method: "GET" }),
+      env,
+    );
+    // 401 from the invalid_client branch — verifyJwt returned null
+    // because exp is in the past.
+    expect(res.status).toBe(401);
+  });
+
+  it("issues client_id JWTs with an `exp` (registrations age out)", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "exp-check",
+          redirect_uris: ["https://client.example.com/cb"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { client_id: string };
+    // Decode the JWT body manually and check that exp is set.
+    const parts = body.client_id.split(".");
+    const payload = JSON.parse(
+      atob(parts[1]!.replace(/-/g, "+").replace(/_/g, "/")),
+    ) as { exp?: number; iat: number };
+    expect(payload.exp).toBeDefined();
+    expect(payload.exp!).toBeGreaterThan(payload.iat);
   });
 });
 

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, it } from "vitest";
+
+import type { Env } from "../env.js";
+import {
+  handleAuthorize,
+  handleAuthServerMetadata,
+  handleLogin,
+  handleProtectedResourceMetadata,
+  handleRegister,
+  handleToken,
+} from "./handlers.js";
+import { encryptAesGcm, signJwt } from "./jwt.js";
+import {
+  buildSetCookie,
+  SESSION_COOKIE,
+  STATE_COOKIE,
+} from "./cookies.js";
+import type { ClientIdClaims, SessionCookieClaims } from "./types.js";
+
+const SIGN_KEY = "test-sign-key-handlers";
+
+function freshEncKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s);
+}
+
+function envWith(overrides: Partial<Env> = {}): Env {
+  return {
+    DJANGO_BASE_URL: "https://example.test",
+    OAUTH_SIGN_KEY: SIGN_KEY,
+    OAUTH_ENC_KEY: freshEncKey(),
+    STYTCH_PROJECT_ID: "project-test-stub",
+    STYTCH_SECRET: "secret-stub",
+    STYTCH_PUBLIC_TOKEN: "public-token-test-stub",
+    STYTCH_BASE_URL: "https://test.stytch.com",
+    ...overrides,
+  };
+}
+
+const ENV_NO_OAUTH: Env = {
+  DJANGO_BASE_URL: "https://example.test",
+};
+
+const enc = new TextEncoder();
+
+function b64url(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+async function pkcePair(): Promise<{ verifier: string; challenge: string }> {
+  const verifierBytes = crypto.getRandomValues(new Uint8Array(32));
+  const verifier = b64url(verifierBytes);
+  const challengeBytes = await crypto.subtle.digest(
+    "SHA-256",
+    enc.encode(verifier),
+  );
+  return { verifier, challenge: b64url(challengeBytes) };
+}
+
+async function mintClientId(env: Env, redirectUri: string): Promise<string> {
+  const claims: ClientIdClaims = {
+    type: "client_id",
+    client_name: "test-client",
+    redirect_uris: [redirectUri],
+    iat: Math.floor(Date.now() / 1000),
+  };
+  return signJwt(claims, env.OAUTH_SIGN_KEY!);
+}
+
+async function mintSessionCookie(env: Env, takoToken: string): Promise<string> {
+  const enc_tako_token = await encryptAesGcm(takoToken, env.OAUTH_ENC_KEY!);
+  const claims: SessionCookieClaims = {
+    type: "session",
+    user_id: "user-1",
+    user_email: "alice@example.com",
+    enc_tako_token,
+    exp: Math.floor(Date.now() / 1000) + 600,
+  };
+  return signJwt(claims, env.OAUTH_SIGN_KEY!);
+}
+
+/* --------------------------- Discovery --------------------------- */
+
+describe("discovery", () => {
+  it("/.well-known/oauth-protected-resource advertises auth server", async () => {
+    const res = handleProtectedResourceMetadata(
+      new Request("https://mcp.example.com/.well-known/oauth-protected-resource"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      resource: string;
+      authorization_servers: string[];
+    };
+    expect(body.resource).toBe("https://mcp.example.com/mcp");
+    expect(body.authorization_servers).toEqual(["https://mcp.example.com"]);
+  });
+
+  it("/.well-known/oauth-authorization-server lists endpoints + PKCE S256", async () => {
+    const res = handleAuthServerMetadata(
+      new Request(
+        "https://mcp.example.com/.well-known/oauth-authorization-server",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      authorization_endpoint: string;
+      token_endpoint: string;
+      registration_endpoint: string;
+      code_challenge_methods_supported: string[];
+    };
+    expect(body.authorization_endpoint).toBe("https://mcp.example.com/authorize");
+    expect(body.token_endpoint).toBe("https://mcp.example.com/token");
+    expect(body.registration_endpoint).toBe("https://mcp.example.com/register");
+    expect(body.code_challenge_methods_supported).toContain("S256");
+  });
+});
+
+/* --------------------------- DCR --------------------------- */
+
+describe("/register (DCR)", () => {
+  it("returns 503 when OAuth is disabled", async () => {
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          redirect_uris: ["https://client.example.com/cb"],
+        }),
+      }),
+      ENV_NO_OAUTH,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 201 with a signed client_id JWT on valid registration", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "test-host",
+          redirect_uris: ["https://client.example.com/cb"],
+        }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { client_id: string };
+    expect(body.client_id.split(".").length).toBe(3);
+  });
+
+  it("rejects an empty redirect_uris array", async () => {
+    const env = envWith();
+    const res = await handleRegister(
+      new Request("https://mcp.example.com/register", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ redirect_uris: [] }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+/* --------------------------- /authorize --------------------------- */
+
+describe("/authorize", () => {
+  it("GET without session redirects to /login and sets state cookie", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("state", "xyz");
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), { method: "GET" }),
+      env,
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/login");
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).not.toBeNull();
+    expect(setCookie!).toContain(`${STATE_COOKIE}=`);
+    expect(setCookie!).toContain("HttpOnly");
+  });
+
+  it("GET with valid session renders HTML consent page", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "GET",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("alice@example.com");
+    expect(html).toContain("test-client");
+    expect(html).toContain("Allow");
+    expect(html).toContain("Cancel");
+  });
+
+  it("POST without session is rejected with 401", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    const res = await handleAuthorize(
+      new Request(url.toString(), { method: "POST" }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("POST with valid session redirects to client with auth code", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("state", "client-state");
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location");
+    expect(location).not.toBeNull();
+    const redirected = new URL(location!);
+    expect(redirected.origin + redirected.pathname).toBe(
+      "https://client.example.com/cb",
+    );
+    expect(redirected.searchParams.get("state")).toBe("client-state");
+    expect(redirected.searchParams.get("code")?.split(".").length).toBe(3);
+  });
+
+  it("rejects redirect_uri not in client's registered list", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-x");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://attacker.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "GET",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+/* --------------------------- /token --------------------------- */
+
+describe("/token", () => {
+  async function runFullFlow(): Promise<{
+    env: Env;
+    accessToken: string;
+    refreshToken: string;
+    scope: string;
+  }> {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const { verifier, challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("scope", "mcp");
+
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          client_id: clientId,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token: string;
+      scope: string;
+      token_type: string;
+      expires_in: number;
+    };
+    expect(body.token_type).toBe("Bearer");
+    return {
+      env,
+      accessToken: body.access_token,
+      refreshToken: body.refresh_token,
+      scope: body.scope,
+    };
+  }
+
+  it("authorization_code grant issues access + refresh tokens", async () => {
+    const result = await runFullFlow();
+    expect(result.accessToken.split(".").length).toBe(3);
+    expect(result.refreshToken.split(".").length).toBe(3);
+    expect(result.scope).toBe("mcp");
+  });
+
+  it("rejects authorization_code grant with mismatched PKCE verifier", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env, "tako-token-real");
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: "wrong-verifier",
+          client_id: clientId,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(400);
+    expect(((await tokenRes.json()) as { error: string }).error).toBe(
+      "invalid_grant",
+    );
+  });
+
+  it("refresh_token grant issues new tokens", async () => {
+    const { env, refreshToken } = await runFullFlow();
+    const refreshRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(refreshRes.status).toBe(200);
+    const body = (await refreshRes.json()) as { access_token: string };
+    expect(body.access_token.split(".").length).toBe(3);
+  });
+
+  it("rejects unsupported grant_type", async () => {
+    const env = envWith();
+    const res = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "password" }).toString(),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe(
+      "unsupported_grant_type",
+    );
+  });
+});
+
+/* --------------------------- /login --------------------------- */
+
+describe("/login", () => {
+  it("returns 503 when OAuth is disabled", () => {
+    const res = handleLogin(
+      new Request("https://mcp.example.com/login"),
+      ENV_NO_OAUTH,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("renders an HTML login page with Stytch SDK and public token", () => {
+    const env = envWith();
+    const res = handleLogin(
+      new Request("https://mcp.example.com/login"),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    return res.text().then((html) => {
+      expect(html).toContain("https://js.stytch.com/stytch.js");
+      expect(html).toContain("public-token-test-stub");
+      expect(html).toContain("/oauth/stytch_callback");
+      expect(html).toContain("Continue with Google");
+    });
+  });
+});
+
+/* --------------------------- helper unused-export grounding --------------------------- */
+
+describe("test helpers stay imported", () => {
+  it("buildSetCookie is referenced (keeps the cookies module live in tree-shake)", () => {
+    expect(typeof buildSetCookie).toBe("function");
+  });
+});

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -1,0 +1,866 @@
+/**
+ * HTTP handlers for the OAuth 2.1 + DCR + PKCE surface, plus the
+ * Stytch-mediated login dance that backs it. Every handler is a pure
+ * `(request, env) => Response` function so they're easy to wire into
+ * `index.ts` and easy to unit-test in isolation.
+ *
+ * Flow overview:
+ *
+ *   Claude.ai / ChatGPT
+ *      │
+ *      ▼
+ *   GET /authorize ──no session?──▶ set state cookie, 302 to /login
+ *      │
+ *      ▼
+ *   GET /login ──renders Stytch UI──▶ user picks Google / magic-link
+ *      │
+ *      ▼
+ *   Stytch (Google / email) ──redirect──▶ GET /oauth/stytch_callback
+ *      │
+ *      ▼
+ *   /oauth/stytch_callback:
+ *     1. exchange ?token for Stytch session JWT + user info
+ *     2. call Tako /api/v1/api_token/ with the JWT as a Cookie header
+ *     3. encrypt the Tako token, mint our own session JWT
+ *     4. set `tako_oauth_session` cookie, 302 back to /authorize
+ *      │
+ *      ▼
+ *   GET /authorize ──with session──▶ render consent page (Allow / Deny)
+ *      │
+ *      ▼
+ *   POST /authorize ──Allow──▶ mint auth code, 302 back to client
+ *      │
+ *      ▼
+ *   POST /token ──swap auth code for access + refresh JWTs──▶ client done
+ *
+ * State the Worker holds:
+ *   • `tako_oauth_state` cookie  — short JWT, OAuth params across Stytch
+ *   • `tako_oauth_session` cookie — short JWT, user identity + enc Tako token
+ *   • Auth codes / access tokens / refresh tokens — all signed JWTs, no DB
+ */
+
+import type { Env } from "../env.js";
+import {
+  encryptAesGcm,
+  sha256B64Url,
+  signJwt,
+  verifyJwt,
+} from "./jwt.js";
+import {
+  authenticateStytchToken,
+  primaryEmail,
+  StytchError,
+  type StytchTokenKind,
+} from "./stytch.js";
+import { fetchTakoApiToken, IdentityError } from "./identity.js";
+import {
+  buildClearCookie,
+  buildSetCookie,
+  readCookie,
+  SESSION_COOKIE,
+  SESSION_COOKIE_MAX_AGE_S,
+  STATE_COOKIE,
+  STATE_COOKIE_MAX_AGE_S,
+} from "./cookies.js";
+import type {
+  AccessTokenClaims,
+  AuthCodeClaims,
+  ClientIdClaims,
+  RefreshTokenClaims,
+  SessionCookieClaims,
+  StateCookieClaims,
+} from "./types.js";
+
+/* --------------------------- TTLs --------------------------- */
+
+const ACCESS_TOKEN_TTL_S = 15 * 60;
+const REFRESH_TOKEN_TTL_S = 14 * 24 * 60 * 60;
+const AUTH_CODE_TTL_S = 60;
+
+/* --------------------------- Config helpers --------------------------- */
+
+interface OAuthConfig {
+  signKey: string;
+  encKey: string;
+  stytch: {
+    projectId: string;
+    secret: string;
+    publicToken: string;
+    baseUrl: string;
+  };
+}
+
+/**
+ * Pull the OAuth config bundle out of `Env`, returning `null` if any
+ * required field is missing. Every handler that touches OAuth state
+ * gates on this so the Worker still serves the static-Bearer Claude
+ * Code path when OAuth is intentionally disabled in an env.
+ */
+function readConfig(env: Env): OAuthConfig | null {
+  const signKey = env.OAUTH_SIGN_KEY;
+  const encKey = env.OAUTH_ENC_KEY;
+  const projectId = env.STYTCH_PROJECT_ID;
+  const secret = env.STYTCH_SECRET;
+  const publicToken = env.STYTCH_PUBLIC_TOKEN;
+  const baseUrl = env.STYTCH_BASE_URL;
+  if (
+    typeof signKey !== "string" ||
+    signKey.length === 0 ||
+    typeof encKey !== "string" ||
+    encKey.length === 0 ||
+    typeof projectId !== "string" ||
+    projectId.length === 0 ||
+    typeof secret !== "string" ||
+    secret.length === 0 ||
+    typeof publicToken !== "string" ||
+    publicToken.length === 0 ||
+    typeof baseUrl !== "string" ||
+    baseUrl.length === 0
+  ) {
+    return null;
+  }
+  return {
+    signKey,
+    encKey,
+    stytch: { projectId, secret, publicToken, baseUrl },
+  };
+}
+
+function oauthDisabledResponse(): Response {
+  return jsonError(
+    "service_unavailable",
+    "OAuth is not configured on this Worker (missing OAUTH_*/STYTCH_* secrets)",
+    503,
+  );
+}
+
+function jsonError(
+  error: string,
+  description: string,
+  status: number,
+): Response {
+  return new Response(
+    JSON.stringify({ error, error_description: description }),
+    {
+      status,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    },
+  );
+}
+
+function htmlResponse(
+  html: string,
+  status = 200,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  return new Response(html, {
+    status,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      ...extraHeaders,
+    },
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/* --------------------------- Discovery --------------------------- */
+
+export function handleProtectedResourceMetadata(req: Request): Response {
+  const origin = new URL(req.url).origin;
+  return Response.json({
+    resource: `${origin}/mcp`,
+    authorization_servers: [origin],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["mcp"],
+  });
+}
+
+export function handleAuthServerMetadata(req: Request): Response {
+  const origin = new URL(req.url).origin;
+  return Response.json({
+    issuer: origin,
+    authorization_endpoint: `${origin}/authorize`,
+    token_endpoint: `${origin}/token`,
+    registration_endpoint: `${origin}/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: ["mcp"],
+  });
+}
+
+/* --------------------------- Dynamic Client Registration --------------------------- */
+
+export async function handleRegister(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  const cfg = readConfig(env);
+  if (cfg === null) return oauthDisabledResponse();
+  if (req.method !== "POST") {
+    return jsonError("invalid_request", "POST required", 405);
+  }
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError("invalid_request", "body must be JSON", 400);
+  }
+  if (typeof body !== "object" || body === null) {
+    return jsonError("invalid_request", "body must be a JSON object", 400);
+  }
+  const obj = body as Record<string, unknown>;
+  const redirect_uris = obj["redirect_uris"];
+  if (
+    !Array.isArray(redirect_uris) ||
+    redirect_uris.length === 0 ||
+    !redirect_uris.every((u): u is string => typeof u === "string")
+  ) {
+    return jsonError(
+      "invalid_redirect_uri",
+      "redirect_uris must be a non-empty array of strings",
+      400,
+    );
+  }
+  const client_name =
+    typeof obj["client_name"] === "string"
+      ? (obj["client_name"] as string).slice(0, 200)
+      : "unknown";
+
+  const claims: ClientIdClaims = {
+    type: "client_id",
+    client_name,
+    redirect_uris,
+    iat: Math.floor(Date.now() / 1000),
+  };
+  const client_id = await signJwt(claims, cfg.signKey);
+
+  return Response.json(
+    {
+      client_id,
+      client_id_issued_at: claims.iat,
+      redirect_uris,
+      client_name,
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    },
+    { status: 201 },
+  );
+}
+
+/* --------------------------- Authorize --------------------------- */
+
+interface AuthorizeQuery {
+  client_id: string;
+  redirect_uri: string;
+  response_type: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  state: string | null;
+  scope: string | null;
+}
+
+function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
+  const p = url.searchParams;
+  const client_id = p.get("client_id");
+  const redirect_uri = p.get("redirect_uri");
+  const response_type = p.get("response_type");
+  const code_challenge = p.get("code_challenge");
+  const code_challenge_method = p.get("code_challenge_method");
+  if (!client_id) return "missing client_id";
+  if (!redirect_uri) return "missing redirect_uri";
+  if (response_type !== "code") return "response_type must be `code`";
+  if (!code_challenge) return "missing code_challenge (PKCE required)";
+  if (code_challenge_method !== "S256") {
+    return "code_challenge_method must be `S256`";
+  }
+  return {
+    client_id,
+    redirect_uri,
+    response_type,
+    code_challenge,
+    code_challenge_method,
+    state: p.get("state"),
+    scope: p.get("scope"),
+  };
+}
+
+async function clientFromClientId(
+  client_id: string,
+  signKey: string,
+): Promise<ClientIdClaims | null> {
+  const claims = await verifyJwt<ClientIdClaims>(client_id, signKey);
+  if (!claims || claims.type !== "client_id") return null;
+  return claims;
+}
+
+export async function handleAuthorize(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  const cfg = readConfig(env);
+  if (cfg === null) return oauthDisabledResponse();
+
+  const url = new URL(req.url);
+  const parsed = readAuthorizeQuery(url);
+  if (typeof parsed === "string") {
+    return new Response(parsed, { status: 400 });
+  }
+  const client = await clientFromClientId(parsed.client_id, cfg.signKey);
+  if (!client) {
+    return new Response("invalid_client", { status: 401 });
+  }
+  if (!client.redirect_uris.includes(parsed.redirect_uri)) {
+    return new Response("redirect_uri not registered for this client_id", {
+      status: 400,
+    });
+  }
+
+  // Fetch the user's session, if any. We accept it on either GET
+  // (rendering consent) or POST (issuing the auth code).
+  const sessionRaw = readCookie(req, SESSION_COOKIE);
+  const session =
+    sessionRaw === null
+      ? null
+      : await verifyJwt<SessionCookieClaims>(sessionRaw, cfg.signKey);
+  const sessionValid = session !== null && session.type === "session";
+
+  if (req.method === "GET") {
+    if (!sessionValid) {
+      // Stash original OAuth params in a state cookie so /oauth/stytch_callback
+      // can resume the flow after the Stytch round-trip. Then bounce to /login.
+      const stateClaims: StateCookieClaims = {
+        type: "state",
+        client_id: parsed.client_id,
+        redirect_uri: parsed.redirect_uri,
+        response_type: parsed.response_type,
+        code_challenge: parsed.code_challenge,
+        code_challenge_method: parsed.code_challenge_method,
+        state: parsed.state,
+        scope: parsed.scope,
+        exp: Math.floor(Date.now() / 1000) + STATE_COOKIE_MAX_AGE_S,
+      };
+      const stateJwt = await signJwt(stateClaims, cfg.signKey);
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: "/login",
+          "set-cookie": buildSetCookie(STATE_COOKIE, stateJwt, {
+            maxAgeSeconds: STATE_COOKIE_MAX_AGE_S,
+          }),
+        },
+      });
+    }
+    // Already authenticated — render the consent page.
+    return htmlResponse(
+      consentPage({
+        clientName: client.client_name,
+        userEmail: session!.user_email,
+        formAction: url.pathname + url.search,
+      }),
+    );
+  }
+
+  if (req.method !== "POST") {
+    return new Response("method not allowed", { status: 405 });
+  }
+
+  // POST = user clicked Allow. Must have a valid session — otherwise
+  // someone is replaying the form across an expired cookie.
+  if (!sessionValid) {
+    return new Response(
+      "session expired — restart the connect flow from your client",
+      { status: 401 },
+    );
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const codeClaims: AuthCodeClaims = {
+    type: "auth_code",
+    client_id: parsed.client_id,
+    redirect_uri: parsed.redirect_uri,
+    code_challenge: parsed.code_challenge,
+    scope: parsed.scope ?? "mcp",
+    user_id: session!.user_id,
+    user_email: session!.user_email,
+    enc_tako_token: session!.enc_tako_token,
+    exp: now + AUTH_CODE_TTL_S,
+  };
+  const code = await signJwt(codeClaims, cfg.signKey);
+
+  const redirect = new URL(parsed.redirect_uri);
+  redirect.searchParams.set("code", code);
+  if (parsed.state !== null) redirect.searchParams.set("state", parsed.state);
+  return new Response(null, {
+    status: 302,
+    headers: { location: redirect.toString() },
+  });
+}
+
+function consentPage(args: {
+  clientName: string;
+  userEmail: string;
+  formAction: string;
+}): string {
+  const safeName = escapeHtml(args.clientName);
+  const safeEmail = escapeHtml(args.userEmail);
+  const safeAction = escapeHtml(args.formAction);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Authorize — Tako</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --bg: #fff; --muted: #555; --border: #ddd; --accent: #111; --on-accent: #fff; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #f5f5f5; --bg: #0b0b0b; --muted: #aaa; --border: #2a2a2a; --accent: #fff; --on-accent: #111; }
+  }
+  body { font-family: -apple-system, system-ui, "Segoe UI", sans-serif; margin: 0; padding: 3rem 1.5rem; max-width: 28rem; margin-inline: auto; color: var(--fg); background: var(--bg); }
+  h1 { font-size: 1.4rem; margin: 0 0 0.5rem; }
+  p { color: var(--muted); line-height: 1.55; }
+  .who { display: flex; align-items: center; gap: 0.6rem; padding: 0.75rem 1rem; border: 1px solid var(--border); border-radius: 0.5rem; margin-top: 1.25rem; font-size: 0.9rem; }
+  .who-dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; background: #2da44e; }
+  form { margin-top: 1.5rem; display: flex; gap: 0.75rem; }
+  button { flex: 1; padding: 0.75rem 1rem; font-size: 1rem; font-weight: 500; border-radius: 0.5rem; border: 1px solid var(--border); background: transparent; color: var(--fg); cursor: pointer; }
+  button[type=submit] { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
+  button:hover { opacity: 0.85; }
+</style>
+</head>
+<body>
+<h1>Connect ${safeName} to Tako</h1>
+<p>${safeName} is requesting access to your Tako account. Approving will let it call the Tako MCP server on your behalf.</p>
+<div class="who"><span class="who-dot"></span> Signed in as <strong>${safeEmail}</strong></div>
+<form method="POST" action="${safeAction}">
+  <button type="button" onclick="window.history.back()">Cancel</button>
+  <button type="submit">Allow</button>
+</form>
+</body>
+</html>`;
+}
+
+/* --------------------------- Token --------------------------- */
+
+export async function handleToken(req: Request, env: Env): Promise<Response> {
+  const cfg = readConfig(env);
+  if (cfg === null) return oauthDisabledResponse();
+  if (req.method !== "POST") {
+    return jsonError("invalid_request", "POST required", 405);
+  }
+  const ct = req.headers.get("content-type") ?? "";
+  if (!ct.includes("application/x-www-form-urlencoded")) {
+    return jsonError(
+      "invalid_request",
+      "content-type must be application/x-www-form-urlencoded",
+      400,
+    );
+  }
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(await req.text());
+  } catch {
+    return jsonError("invalid_request", "could not parse form body", 400);
+  }
+
+  const grant_type = params.get("grant_type");
+  if (grant_type === "authorization_code") {
+    return handleAuthorizationCodeGrant(params, cfg);
+  }
+  if (grant_type === "refresh_token") {
+    return handleRefreshGrant(params, cfg);
+  }
+  return jsonError(
+    "unsupported_grant_type",
+    `grant_type \`${grant_type}\` is not supported`,
+    400,
+  );
+}
+
+async function handleAuthorizationCodeGrant(
+  params: URLSearchParams,
+  cfg: OAuthConfig,
+): Promise<Response> {
+  const code = params.get("code");
+  const redirect_uri = params.get("redirect_uri");
+  const code_verifier = params.get("code_verifier");
+  if (!code || !redirect_uri || !code_verifier) {
+    return jsonError(
+      "invalid_request",
+      "code, redirect_uri, code_verifier are required",
+      400,
+    );
+  }
+  const claims = await verifyJwt<AuthCodeClaims>(code, cfg.signKey);
+  if (!claims || claims.type !== "auth_code") {
+    return jsonError("invalid_grant", "auth code is invalid or expired", 400);
+  }
+  if (claims.redirect_uri !== redirect_uri) {
+    return jsonError(
+      "invalid_grant",
+      "redirect_uri does not match authorization request",
+      400,
+    );
+  }
+  const expectedChallenge = await sha256B64Url(code_verifier);
+  if (claims.code_challenge !== expectedChallenge) {
+    return jsonError("invalid_grant", "PKCE verifier does not match", 400);
+  }
+  return issueTokens(
+    {
+      scope: claims.scope,
+      user_id: claims.user_id,
+      user_email: claims.user_email,
+      enc_tako_token: claims.enc_tako_token,
+    },
+    cfg,
+  );
+}
+
+async function handleRefreshGrant(
+  params: URLSearchParams,
+  cfg: OAuthConfig,
+): Promise<Response> {
+  const refresh_token = params.get("refresh_token");
+  if (!refresh_token) {
+    return jsonError("invalid_request", "refresh_token is required", 400);
+  }
+  const claims = await verifyJwt<RefreshTokenClaims>(refresh_token, cfg.signKey);
+  if (!claims || claims.type !== "refresh") {
+    return jsonError(
+      "invalid_grant",
+      "refresh token is invalid or expired",
+      400,
+    );
+  }
+  return issueTokens(
+    {
+      scope: claims.scope,
+      user_id: claims.user_id,
+      user_email: claims.user_email,
+      enc_tako_token: claims.enc_tako_token,
+    },
+    cfg,
+  );
+}
+
+interface IdentityForToken {
+  scope: string;
+  user_id: string;
+  user_email: string;
+  enc_tako_token: string;
+}
+
+async function issueTokens(
+  identity: IdentityForToken,
+  cfg: OAuthConfig,
+): Promise<Response> {
+  const now = Math.floor(Date.now() / 1000);
+  const accessClaims: AccessTokenClaims = {
+    type: "access",
+    scope: identity.scope,
+    user_id: identity.user_id,
+    user_email: identity.user_email,
+    enc_tako_token: identity.enc_tako_token,
+    exp: now + ACCESS_TOKEN_TTL_S,
+  };
+  const refreshClaims: RefreshTokenClaims = {
+    type: "refresh",
+    scope: identity.scope,
+    user_id: identity.user_id,
+    user_email: identity.user_email,
+    enc_tako_token: identity.enc_tako_token,
+    exp: now + REFRESH_TOKEN_TTL_S,
+  };
+  const access_token = await signJwt(accessClaims, cfg.signKey);
+  const refresh_token = await signJwt(refreshClaims, cfg.signKey);
+  return Response.json({
+    access_token,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_S,
+    refresh_token,
+    scope: identity.scope,
+  });
+}
+
+/* --------------------------- Login --------------------------- */
+
+/**
+ * Render the login page. The page is a static HTML document that
+ * embeds Stytch's vanilla-js SDK over CDN, configures it with the
+ * `STYTCH_PUBLIC_TOKEN`, and offers Sign-in-with-Google + email
+ * magic-link entry points.
+ *
+ * On successful authentication Stytch will redirect the user to the
+ * URL we pass as `login_redirect_url`, with a `?token=...` query and
+ * a `&stytch_token_type=oauth|magic_links` discriminator. We point
+ * that at our `/oauth/stytch_callback` endpoint.
+ */
+export function handleLogin(req: Request, env: Env): Response {
+  const cfg = readConfig(env);
+  if (cfg === null) return oauthDisabledResponse();
+  if (req.method !== "GET") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const origin = new URL(req.url).origin;
+  const callbackUrl = `${origin}/oauth/stytch_callback`;
+  return htmlResponse(loginPage(cfg.stytch.publicToken, callbackUrl));
+}
+
+function loginPage(stytchPublicToken: string, callbackUrl: string): string {
+  // The Stytch SDK is loaded over their CDN; the `data-stytch-public-token`
+  // and `callbackUrl` constants below are the only Worker-side data the
+  // page needs. Keep this page minimal — its only job is to drive Stytch
+  // to redirect to /oauth/stytch_callback.
+  const safeToken = escapeHtml(stytchPublicToken);
+  const safeCallback = escapeHtml(callbackUrl);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in — Tako</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --bg: #fff; --muted: #555; --border: #ddd; --accent: #111; --on-accent: #fff; --error: #c1121f; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #f5f5f5; --bg: #0b0b0b; --muted: #aaa; --border: #2a2a2a; --accent: #fff; --on-accent: #111; --error: #ff6b6b; }
+  }
+  body { font-family: -apple-system, system-ui, "Segoe UI", sans-serif; margin: 0; padding: 3rem 1.5rem; max-width: 24rem; margin-inline: auto; color: var(--fg); background: var(--bg); }
+  h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
+  p { color: var(--muted); margin: 0 0 1.5rem; line-height: 1.55; }
+  button { width: 100%; padding: 0.75rem 1rem; font-size: 1rem; font-weight: 500; border-radius: 0.5rem; border: 1px solid var(--border); background: transparent; color: var(--fg); cursor: pointer; }
+  button.primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
+  button:hover { opacity: 0.85; }
+  .row { margin-bottom: 0.75rem; }
+  .or { text-align: center; color: var(--muted); margin: 1rem 0; font-size: 0.9rem; }
+  input[type=email] { width: 100%; padding: 0.7rem 0.9rem; font-size: 1rem; border-radius: 0.5rem; border: 1px solid var(--border); background: transparent; color: var(--fg); box-sizing: border-box; margin-bottom: 0.5rem; }
+  .err { color: var(--error); font-size: 0.85rem; min-height: 1.2rem; margin-top: 0.5rem; }
+</style>
+</head>
+<body>
+<h1>Sign in to Tako</h1>
+<p>Use your Tako account to authorize this connection.</p>
+<div class="row">
+  <button class="primary" id="google">Continue with Google</button>
+</div>
+<div class="or">or</div>
+<form id="magic">
+  <input type="email" name="email" placeholder="you@example.com" required autocomplete="email">
+  <button type="submit">Email me a sign-in link</button>
+</form>
+<div class="err" id="err"></div>
+
+<script src="https://js.stytch.com/stytch.js"></script>
+<script>
+  (function() {
+    var publicToken = ${JSON.stringify(safeToken)};
+    var callbackUrl = ${JSON.stringify(safeCallback)};
+    var errEl = document.getElementById("err");
+    function showError(msg) { errEl.textContent = msg || ""; }
+
+    var client;
+    try {
+      client = Stytch(publicToken);
+    } catch (e) {
+      showError("Could not initialize Stytch: " + (e && e.message ? e.message : e));
+      return;
+    }
+
+    document.getElementById("google").addEventListener("click", function() {
+      showError("");
+      try {
+        client.oauth.google.start({
+          login_redirect_url: callbackUrl,
+          signup_redirect_url: callbackUrl
+        });
+      } catch (e) {
+        showError("Google sign-in failed to start: " + (e && e.message ? e.message : e));
+      }
+    });
+
+    document.getElementById("magic").addEventListener("submit", function(ev) {
+      ev.preventDefault();
+      showError("");
+      var email = ev.target.email.value.trim();
+      if (!email) { showError("Enter an email address."); return; }
+      client.magicLinks.email.loginOrCreate(email, {
+        login_magic_link_url: callbackUrl,
+        signup_magic_link_url: callbackUrl
+      }).then(function() {
+        ev.target.innerHTML = "<p>Check your email for a sign-in link.</p>";
+      }).catch(function(e) {
+        showError("Could not send magic link: " + (e && e.message ? e.message : e));
+      });
+    });
+  })();
+</script>
+</body>
+</html>`;
+}
+
+/* --------------------------- Stytch callback --------------------------- */
+
+export async function handleStytchCallback(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  const cfg = readConfig(env);
+  if (cfg === null) return oauthDisabledResponse();
+  if (req.method !== "GET") {
+    return new Response("method not allowed", { status: 405 });
+  }
+
+  const url = new URL(req.url);
+  const token = url.searchParams.get("token");
+  const tokenType = url.searchParams.get("stytch_token_type");
+  if (!token) {
+    return errorPage(400, "Stytch did not return a token in the redirect.");
+  }
+  let kind: StytchTokenKind;
+  if (tokenType === "oauth") kind = "oauth";
+  else if (tokenType === "magic_links") kind = "magic_links";
+  else {
+    return errorPage(
+      400,
+      `Unsupported stytch_token_type: ${tokenType ?? "(missing)"}`,
+    );
+  }
+
+  // Step 1 — exchange Stytch's redirect-token for a session JWT + user info.
+  let stytchResult;
+  try {
+    stytchResult = await authenticateStytchToken(cfg.stytch, token, kind);
+  } catch (err) {
+    if (err instanceof StytchError) {
+      console.error("Stytch authenticate failed:", err.message, err.errorType);
+      return errorPage(
+        502,
+        `Stytch authentication failed (${err.errorType ?? err.status}). ` +
+          "Please try signing in again.",
+      );
+    }
+    throw err;
+  }
+
+  // Step 2 — fetch the user's Tako API token using their freshly-minted
+  // Stytch session JWT. This is server-to-server, the JWT travels in a
+  // Cookie header (see identity.ts).
+  let takoToken: string;
+  try {
+    takoToken = await fetchTakoApiToken(env, stytchResult.session_jwt);
+  } catch (err) {
+    if (err instanceof IdentityError) {
+      if (err.kind === "no_token") {
+        return errorPage(
+          400,
+          "Your Tako account does not have an API token yet. " +
+            "Visit trytako.com → settings → API tokens to mint one, " +
+            "then retry the connection.",
+        );
+      }
+      if (err.kind === "unauthorized") {
+        return errorPage(
+          502,
+          "Tako rejected the Stytch session. This usually means the " +
+            "Stytch project on the Worker doesn't match Tako's project. " +
+            "Contact support.",
+        );
+      }
+      console.error("Tako identity lookup failed:", err.kind, err.message);
+      return errorPage(
+        502,
+        "Could not retrieve your Tako API token. Please try again.",
+      );
+    }
+    throw err;
+  }
+
+  // Step 3 — encrypt the Tako token (so it can travel in our session
+  // cookie + future OAuth tokens) and mint our own session JWT.
+  const enc_tako_token = await encryptAesGcm(takoToken, cfg.encKey);
+  const userEmail = primaryEmail(stytchResult.user);
+  const sessionClaims: SessionCookieClaims = {
+    type: "session",
+    user_id: stytchResult.user.user_id,
+    user_email: userEmail,
+    enc_tako_token,
+    exp: Math.floor(Date.now() / 1000) + SESSION_COOKIE_MAX_AGE_S,
+  };
+  const sessionJwt = await signJwt(sessionClaims, cfg.signKey);
+
+  // Step 4 — read the tako_oauth_state cookie, which carries the
+  // original OAuth params Claude.ai sent to /authorize. If absent
+  // we have no idea where to send the user; surface a friendly error.
+  const stateRaw = readCookie(req, STATE_COOKIE);
+  if (stateRaw === null) {
+    return errorPage(
+      400,
+      "Login completed, but the original authorization request was lost " +
+        "(missing state cookie). Please restart the connect flow from " +
+        "your client.",
+    );
+  }
+  const stateClaims = await verifyJwt<StateCookieClaims>(stateRaw, cfg.signKey);
+  if (!stateClaims || stateClaims.type !== "state") {
+    return errorPage(
+      400,
+      "Login completed, but the original authorization request expired " +
+        "or was tampered with. Please restart the connect flow from your client.",
+    );
+  }
+
+  // Step 5 — rebuild the /authorize URL from the state claims and
+  // redirect there. The session cookie will be picked up automatically
+  // and /authorize will render the consent page with the user's email.
+  const authorizeUrl = new URL("/authorize", url.origin);
+  authorizeUrl.searchParams.set("client_id", stateClaims.client_id);
+  authorizeUrl.searchParams.set("redirect_uri", stateClaims.redirect_uri);
+  authorizeUrl.searchParams.set("response_type", stateClaims.response_type);
+  authorizeUrl.searchParams.set("code_challenge", stateClaims.code_challenge);
+  authorizeUrl.searchParams.set(
+    "code_challenge_method",
+    stateClaims.code_challenge_method,
+  );
+  if (stateClaims.state !== null)
+    authorizeUrl.searchParams.set("state", stateClaims.state);
+  if (stateClaims.scope !== null)
+    authorizeUrl.searchParams.set("scope", stateClaims.scope);
+
+  // Multiple Set-Cookie headers — modern Workers fetch API handles this
+  // by accepting a Headers instance with repeated entries (single string
+  // separated by `, ` would not work for cookies whose values contain
+  // commas, which JWTs don't but cookies-with-Date attributes do).
+  const headers = new Headers({ location: authorizeUrl.toString() });
+  headers.append(
+    "set-cookie",
+    buildSetCookie(SESSION_COOKIE, sessionJwt, {
+      maxAgeSeconds: SESSION_COOKIE_MAX_AGE_S,
+    }),
+  );
+  // Clear the state cookie — it served its purpose.
+  headers.append("set-cookie", buildClearCookie(STATE_COOKIE));
+  return new Response(null, { status: 302, headers });
+}
+
+function errorPage(status: number, message: string): Response {
+  // Use simple HTML rather than JSON because the user is in a browser
+  // tab during the OAuth dance. They need a readable message, not a
+  // machine-parseable error.
+  const safe = escapeHtml(message);
+  return htmlResponse(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>Tako — sign-in error</title>
+<style>body{font-family:-apple-system,system-ui,sans-serif;margin:0;padding:3rem 1.5rem;max-width:32rem;margin-inline:auto;color-scheme:light dark}
+h1{font-size:1.3rem;margin:0 0 0.5rem}p{line-height:1.55;color:#555}@media(prefers-color-scheme:dark){body{background:#0b0b0b;color:#f5f5f5}p{color:#aaa}}</style>
+</head><body><h1>Couldn't complete sign-in</h1><p>${safe}</p></body></html>`,
+    status,
+  );
+}

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -76,6 +76,18 @@ import type {
 const ACCESS_TOKEN_TTL_S = 15 * 60;
 const REFRESH_TOKEN_TTL_S = 14 * 24 * 60 * 60;
 const AUTH_CODE_TTL_S = 60;
+/** DCR registrations expire after a year. Without expiry the only way
+ *  to invalidate an abandoned client is to rotate `OAUTH_SIGN_KEY`,
+ *  which nukes every registration at once. A 1-year TTL means a
+ *  long-running connector re-registers periodically (Claude.ai/ChatGPT
+ *  do this automatically on first use after expiry) while leaked /
+ *  abandoned client_ids age out. */
+const REGISTRATION_TTL_S = 365 * 24 * 60 * 60;
+/** Scopes we advertise in the discovery doc. Any scope value not on
+ *  this list is rejected at /authorize so we don't echo unexpected
+ *  values into issued tokens. Keep in sync with the
+ *  `scopes_supported` field in `handleAuthServerMetadata`. */
+const SUPPORTED_SCOPES = new Set(["mcp"]);
 
 /* --------------------------- Config helpers --------------------------- */
 
@@ -161,6 +173,24 @@ function htmlResponse(
     status,
     headers: {
       "content-type": "text/html; charset=utf-8",
+      // Clickjacking defense: every HTML page we serve carries
+      // user-identifying or grant-authorizing UI. Framing them in a
+      // hostile parent enables click-jacked consent. `frame-ancestors
+      // 'none'` (CSP) plus the legacy `X-Frame-Options: DENY` covers
+      // both modern and old browsers.
+      "x-frame-options": "DENY",
+      "content-security-policy": "frame-ancestors 'none'",
+      // Prevent intermediate caches from storing pages that embed
+      // `user_email` (consent) or any auth-flow artifact. Belt-and-
+      // suspenders Pragma covers ancient HTTP/1.0 caches.
+      "cache-control": "no-store, no-cache, must-revalidate, private",
+      pragma: "no-cache",
+      // MIME-sniffing defense — ensures browsers never reinterpret
+      // these HTML responses as another type.
+      "x-content-type-options": "nosniff",
+      // Don't leak the full URL (which carries OAuth params + cookies)
+      // when users click out from /login or /authorize.
+      "referrer-policy": "no-referrer",
       ...extraHeaders,
     },
   });
@@ -177,17 +207,42 @@ function escapeHtml(s: string): string {
 
 /* --------------------------- Discovery --------------------------- */
 
-export function handleProtectedResourceMetadata(req: Request): Response {
+/**
+ * RFC 9728 — OAuth 2.0 Protected Resource Metadata.
+ *
+ * Gated on OAuth configuration: when the secrets are unset the Worker
+ * should not advertise an OAuth surface, since following discovery would
+ * just take the client to a 503 from /register. Returning 404 lets
+ * clients fall back cleanly to static-Bearer mode.
+ */
+export function handleProtectedResourceMetadata(
+  req: Request,
+  env: Env,
+): Response {
+  if (readConfig(env) === null) {
+    return new Response("not found", { status: 404 });
+  }
   const origin = new URL(req.url).origin;
   return Response.json({
     resource: `${origin}/mcp`,
     authorization_servers: [origin],
     bearer_methods_supported: ["header"],
-    scopes_supported: ["mcp"],
+    scopes_supported: [...SUPPORTED_SCOPES],
   });
 }
 
-export function handleAuthServerMetadata(req: Request): Response {
+/**
+ * RFC 8414 — OAuth 2.0 Authorization Server Metadata.
+ *
+ * Same env-gating rationale as the protected-resource metadata above.
+ */
+export function handleAuthServerMetadata(
+  req: Request,
+  env: Env,
+): Response {
+  if (readConfig(env) === null) {
+    return new Response("not found", { status: 404 });
+  }
   const origin = new URL(req.url).origin;
   return Response.json({
     issuer: origin,
@@ -198,11 +253,20 @@ export function handleAuthServerMetadata(req: Request): Response {
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
     token_endpoint_auth_methods_supported: ["none"],
-    scopes_supported: ["mcp"],
+    scopes_supported: [...SUPPORTED_SCOPES],
   });
 }
 
 /* --------------------------- Dynamic Client Registration --------------------------- */
+
+/**
+ * `/register` is intentionally unauthenticated, per RFC 7591 conventions
+ * for public-client DCR. Cloudflare WAF / rate-limit rules in front of
+ * the Worker are expected to bound abuse — every registration is a small
+ * HMAC sign + JSON response, but a sustained flood would still burn CPU.
+ * Document the assumption in infra; don't add app-level rate limiting
+ * here unless we observe abuse.
+ */
 
 /** Cap registration body size to keep the resulting `client_id` JWT
  *  (which echoes the redirect_uris and client_name) from blowing past
@@ -311,11 +375,13 @@ export async function handleRegister(
   }
   const client_name = rawName.slice(0, 200);
 
+  const now = Math.floor(Date.now() / 1000);
   const claims: ClientIdClaims = {
     type: "client_id",
     client_name,
     redirect_uris,
-    iat: Math.floor(Date.now() / 1000),
+    iat: now,
+    exp: now + REGISTRATION_TTL_S,
   };
   const client_id = await signJwt(claims, cfg.signKey);
 
@@ -359,6 +425,17 @@ function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
   if (code_challenge_method !== "S256") {
     return "code_challenge_method must be `S256`";
   }
+  // Validate `scope`: only values in SUPPORTED_SCOPES are accepted.
+  // Empty / null defaults to "mcp" downstream. This fails-closed instead
+  // of silently echoing unknown scope strings into issued tokens — which
+  // matters once any downstream system starts gating behavior on scope.
+  const scope = p.get("scope");
+  if (scope !== null && scope.length > 0) {
+    const requested = scope.split(/\s+/).filter((s) => s.length > 0);
+    if (!requested.every((s) => SUPPORTED_SCOPES.has(s))) {
+      return `scope contains unsupported values; supported: ${[...SUPPORTED_SCOPES].join(", ")}`;
+    }
+  }
   return {
     client_id,
     redirect_uri,
@@ -366,7 +443,7 @@ function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
     code_challenge,
     code_challenge_method,
     state: p.get("state"),
-    scope: p.get("scope"),
+    scope,
   };
 }
 
@@ -661,6 +738,13 @@ async function handleRefreshGrant(
       400,
     );
   }
+  // KNOWN GAP (TAKO-2679 follow-up): refresh tokens are not single-use.
+  // OAuth 2.1 §4.3.1 recommends rotation-with-replay-detection — when a
+  // previously-rotated refresh token is re-presented, all derived tokens
+  // for that user/client should be revoked. The JWT-stateless design
+  // has no persistent store to mark tokens spent; the same KV-backed
+  // `jti` mitigation that would close the auth-code reuse gap closes
+  // this one too.
   return issueTokens(
     {
       scope: claims.scope,
@@ -790,6 +874,12 @@ function loginPage(stytchPublicToken: string, callbackUrl: string): string {
 </form>
 <div class="err" id="err"></div>
 
+<!-- Stytch's vanilla JS SDK. Loaded over their CDN without Subresource
+     Integrity because Stytch publishes a rolling URL and breaks SRI
+     pins on every revision. Trade-off: a compromise of js.stytch.com
+     would let an attacker run JS on this page (which only handles
+     login redirects — no Tako tokens are touched here). Revisit if
+     Stytch publishes versioned URLs with stable hashes. -->
 <script src="https://js.stytch.com/stytch.js"></script>
 <script>
   (function() {

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -127,8 +127,12 @@ function readConfig(env: Env): OAuthConfig | null {
 }
 
 function oauthDisabledResponse(): Response {
+  // RFC 6749 §5.2 — `temporarily_unavailable` is the spec-conformant
+  // value when the authorization server is configured but cannot
+  // service requests. Used here for "OAuth subsystem disabled in this
+  // env" too, since that's the closest match in the standard set.
   return jsonError(
-    "service_unavailable",
+    "temporarily_unavailable",
     "OAuth is not configured on this Worker (missing OAUTH_*/STYTCH_* secrets)",
     503,
   );
@@ -200,6 +204,46 @@ export function handleAuthServerMetadata(req: Request): Response {
 
 /* --------------------------- Dynamic Client Registration --------------------------- */
 
+/** Cap registration body size to keep the resulting `client_id` JWT
+ *  (which echoes the redirect_uris and client_name) from blowing past
+ *  reasonable HTTP header limits. 4 KB is comfortably above any sane
+ *  consumer-host registration. */
+const REGISTER_MAX_BODY_BYTES = 4 * 1024;
+/** Limit on a single redirect_uri so a malicious registration can't
+ *  bake an enormous URL into every signed `client_id`. */
+const REDIRECT_URI_MAX_LEN = 2048;
+/** Reject control characters in `client_name` to prevent log-line
+ *  injection / display corruption when we echo the name back on the
+ *  consent page. The `\x00-\x1f\x7f` range covers ASCII control codes. */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_RE = /[\x00-\x1f\x7f]/;
+
+function isValidRedirectUri(s: string): boolean {
+  if (s.length === 0 || s.length > REDIRECT_URI_MAX_LEN) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(s);
+  } catch {
+    return false;
+  }
+  // Only http/https. Reject `javascript:`, `data:`, `file:`, `vbscript:`
+  // etc. — even though redirect_uris are looked up against the registered
+  // list before being used, this is a defense-in-depth check at the
+  // entry point so a malicious `/register` can't seed the system with
+  // exotic-scheme URIs that some downstream code path might honor.
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return false;
+  }
+  // `http:` only for `localhost` (and `127.0.0.1`) — production OAuth
+  // clients must use https. Any non-loopback `http:` redirect_uri is a
+  // strong signal of either misconfiguration or attack.
+  if (parsed.protocol === "http:") {
+    const host = parsed.hostname;
+    if (host !== "localhost" && host !== "127.0.0.1") return false;
+  }
+  return true;
+}
+
 export async function handleRegister(
   req: Request,
   env: Env,
@@ -209,9 +253,25 @@ export async function handleRegister(
   if (req.method !== "POST") {
     return jsonError("invalid_request", "POST required", 405);
   }
+  // Read at most REGISTER_MAX_BODY_BYTES of body. Anything larger gets
+  // rejected before we try to parse it — a 100 MB JSON blob would
+  // otherwise pin a Worker until the body finishes streaming.
+  let bodyText: string;
+  try {
+    bodyText = await req.text();
+  } catch {
+    return jsonError("invalid_request", "could not read request body", 400);
+  }
+  if (bodyText.length > REGISTER_MAX_BODY_BYTES) {
+    return jsonError(
+      "invalid_request",
+      `body too large (max ${REGISTER_MAX_BODY_BYTES} bytes)`,
+      413,
+    );
+  }
   let body: unknown;
   try {
-    body = await req.json();
+    body = JSON.parse(bodyText);
   } catch {
     return jsonError("invalid_request", "body must be JSON", 400);
   }
@@ -231,10 +291,25 @@ export async function handleRegister(
       400,
     );
   }
-  const client_name =
+  if (!redirect_uris.every(isValidRedirectUri)) {
+    return jsonError(
+      "invalid_redirect_uri",
+      "every redirect_uri must be a valid https URL (http only allowed for localhost)",
+      400,
+    );
+  }
+  const rawName =
     typeof obj["client_name"] === "string"
-      ? (obj["client_name"] as string).slice(0, 200)
+      ? (obj["client_name"] as string)
       : "unknown";
+  if (CONTROL_CHARS_RE.test(rawName)) {
+    return jsonError(
+      "invalid_request",
+      "client_name must not contain control characters",
+      400,
+    );
+  }
+  const client_name = rawName.slice(0, 200);
 
   const claims: ClientIdClaims = {
     type: "client_id",
@@ -339,6 +414,15 @@ export async function handleAuthorize(
     if (!sessionValid) {
       // Stash original OAuth params in a state cookie so /oauth/stytch_callback
       // can resume the flow after the Stytch round-trip. Then bounce to /login.
+      //
+      // KNOWN GAP (TAKO-2679 follow-up): the cookie's only binding to the
+      // user-agent is the cookie itself (HttpOnly + Secure + SameSite=Lax,
+      // which prevents network attackers from reading or planting it under
+      // HTTPS). RFC 9700 (OAuth 2.0 Security BCP) recommends a nonce
+      // round-tripped via Stytch's `state` parameter for belt-and-suspenders
+      // session-fixation defense. Defer to the OAuth-hardening follow-up
+      // ticket; the cookie alone is adequate for the threat model where
+      // an attacker has neither XSS on mcp.tako.com nor an active MITM.
       const stateClaims: StateCookieClaims = {
         type: "state",
         client_id: parsed.client_id,
@@ -362,11 +446,27 @@ export async function handleAuthorize(
       });
     }
     // Already authenticated — render the consent page.
+    // Rebuild the form-action URL deterministically from validated
+    // params instead of echoing `url.search` back into HTML. Echoing
+    // the raw search string would mean an attacker-supplied unknown
+    // query param survives into the form post; rebuilding gates the
+    // round-trip on values we already validated.
+    const formActionUrl = new URL(url.pathname, url.origin);
+    formActionUrl.searchParams.set("client_id", parsed.client_id);
+    formActionUrl.searchParams.set("redirect_uri", parsed.redirect_uri);
+    formActionUrl.searchParams.set("response_type", parsed.response_type);
+    formActionUrl.searchParams.set("code_challenge", parsed.code_challenge);
+    formActionUrl.searchParams.set(
+      "code_challenge_method",
+      parsed.code_challenge_method,
+    );
+    if (parsed.state !== null) formActionUrl.searchParams.set("state", parsed.state);
+    if (parsed.scope !== null) formActionUrl.searchParams.set("scope", parsed.scope);
     return htmlResponse(
       consentPage({
         clientName: client.client_name,
         userEmail: session!.user_email,
-        formAction: url.pathname + url.search,
+        formAction: formActionUrl.pathname + formActionUrl.search,
       }),
     );
   }
@@ -511,10 +611,29 @@ async function handleAuthorizationCodeGrant(
       400,
     );
   }
+  // Belt-and-suspenders against confused-deputy / token-leak scenarios:
+  // PKCE alone is sufficient per the spec for public clients, but if
+  // the form body carries a `client_id` it MUST match the one bound to
+  // the auth code. A mismatch is a strong signal worth surfacing.
+  const formClientId = params.get("client_id");
+  if (formClientId !== null && formClientId !== claims.client_id) {
+    return jsonError(
+      "invalid_grant",
+      "client_id does not match authorization request",
+      400,
+    );
+  }
   const expectedChallenge = await sha256B64Url(code_verifier);
   if (claims.code_challenge !== expectedChallenge) {
     return jsonError("invalid_grant", "PKCE verifier does not match", 400);
   }
+  // KNOWN GAP (TAKO-2679 follow-up): auth codes are not single-use.
+  // The 60s TTL bounds replay risk, but a code captured in that window
+  // can be redeemed multiple times until it expires. The JWT-stateless
+  // architecture (per /tmp/oauth-real-impl-comparison.md) means we have
+  // no persistent storage to mark a code as consumed. Adding a small
+  // KV-backed `jti` revocation set would close this; tracking under
+  // the OAuth-hardening follow-up ticket.
   return issueTokens(
     {
       scope: claims.scope,
@@ -616,13 +735,25 @@ export function handleLogin(req: Request, env: Env): Response {
   return htmlResponse(loginPage(cfg.stytch.publicToken, callbackUrl));
 }
 
+/**
+ * Encode a string as a JS string literal safe to embed inside a
+ * `<script>` block. `JSON.stringify` is the standard JS escape, but a
+ * literal `</script>` sequence inside the resulting string would still
+ * close the surrounding tag — replace `<` with `<` to suppress
+ * that. Do NOT pass the value through `escapeHtml` first: the
+ * resulting `&amp;`/`&#39;` would corrupt the JS literal at runtime
+ * and the Stytch SDK would receive garbage tokens / URLs.
+ */
+function jsStringLiteral(s: string): string {
+  return JSON.stringify(s).replace(/</g, "\\u003c");
+}
+
 function loginPage(stytchPublicToken: string, callbackUrl: string): string {
-  // The Stytch SDK is loaded over their CDN; the `data-stytch-public-token`
-  // and `callbackUrl` constants below are the only Worker-side data the
-  // page needs. Keep this page minimal — its only job is to drive Stytch
-  // to redirect to /oauth/stytch_callback.
-  const safeToken = escapeHtml(stytchPublicToken);
-  const safeCallback = escapeHtml(callbackUrl);
+  // The Stytch SDK is loaded over their CDN; `publicToken` and
+  // `callbackUrl` are the only Worker-side data the page needs.
+  // Both are embedded as JS string literals via `jsStringLiteral`,
+  // not HTML-escaped — they live inside <script>, not in HTML
+  // attributes / text.
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -662,8 +793,8 @@ function loginPage(stytchPublicToken: string, callbackUrl: string): string {
 <script src="https://js.stytch.com/stytch.js"></script>
 <script>
   (function() {
-    var publicToken = ${JSON.stringify(safeToken)};
-    var callbackUrl = ${JSON.stringify(safeCallback)};
+    var publicToken = ${jsStringLiteral(stytchPublicToken)};
+    var callbackUrl = ${jsStringLiteral(callbackUrl)};
     var errEl = document.getElementById("err");
     function showError(msg) { errEl.textContent = msg || ""; }
 

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -41,6 +41,7 @@
 
 import type { Env } from "../env.js";
 import {
+  decryptAesGcm,
   encryptAesGcm,
   sha256B64Url,
   signJwt,
@@ -52,7 +53,10 @@ import {
   StytchError,
   type StytchTokenKind,
 } from "./stytch.js";
-import { fetchTakoApiToken, IdentityError } from "./identity.js";
+import {
+  fetchTakoApiToken,
+  IdentityError,
+} from "./identity.js";
 import {
   buildClearCookie,
   buildSetCookie,
@@ -561,6 +565,68 @@ export async function handleAuthorize(
     );
   }
 
+  // Re-fetch the Tako API token at consent time so token rotations on
+  // trytako.com are always reflected in newly-issued OAuth grants. The
+  // session cookie carries an encrypted Stytch session JWT (not a cached
+  // Tako token), so we decrypt it, present it to Tako, and use whatever
+  // current token Tako returns.
+  const stytchSessionJwt = await decryptAesGcm(
+    session!.enc_stytch_session_jwt,
+    cfg.encKey,
+  );
+  if (stytchSessionJwt === null) {
+    // Cookie was tampered, OAUTH_ENC_KEY rotated, or otherwise unreadable.
+    // Force the user back through /login for a fresh Stytch round-trip.
+    return htmlResponse(
+      sessionExpiredPage(
+        "Your session is no longer valid. Please sign in again.",
+      ),
+      401,
+      { "set-cookie": buildClearCookie(SESSION_COOKIE) },
+    );
+  }
+  let takoToken: string;
+  try {
+    takoToken = await fetchTakoApiToken(env, stytchSessionJwt);
+  } catch (err) {
+    if (err instanceof IdentityError) {
+      if (err.kind === "no_token") {
+        return htmlResponse(
+          sessionExpiredPage(
+            "Your Tako account does not have an API token yet. " +
+              "Visit trytako.com → settings → API tokens to mint one, " +
+              "then retry the connection.",
+          ),
+          400,
+        );
+      }
+      if (err.kind === "unauthorized") {
+        // Stytch session was revoked or expired — force re-login by
+        // clearing the now-useless session cookie.
+        return htmlResponse(
+          sessionExpiredPage(
+            "Your Tako sign-in expired. Please sign in again.",
+          ),
+          401,
+          { "set-cookie": buildClearCookie(SESSION_COOKIE) },
+        );
+      }
+      console.error(
+        "Tako identity lookup failed at /authorize POST:",
+        err.kind,
+        err.message,
+      );
+      return htmlResponse(
+        sessionExpiredPage(
+          "Could not retrieve your Tako API token. Please try again.",
+        ),
+        502,
+      );
+    }
+    throw err;
+  }
+  const enc_tako_token = await encryptAesGcm(takoToken, cfg.encKey);
+
   const now = Math.floor(Date.now() / 1000);
   const codeClaims: AuthCodeClaims = {
     type: "auth_code",
@@ -570,7 +636,7 @@ export async function handleAuthorize(
     scope: parsed.scope ?? "mcp",
     user_id: session!.user_id,
     user_email: session!.user_email,
-    enc_tako_token: session!.enc_tako_token,
+    enc_tako_token,
     exp: now + AUTH_CODE_TTL_S,
   };
   const code = await signJwt(codeClaims, cfg.signKey);
@@ -582,6 +648,42 @@ export async function handleAuthorize(
     status: 302,
     headers: { location: redirect.toString() },
   });
+}
+
+/**
+ * Friendly HTML page shown when /authorize POST cannot complete because
+ * of a session-or-Tako-side error. Reuses the same look as the consent
+ * page; clears the session cookie inline if the session is unrecoverable.
+ */
+function sessionExpiredPage(message: string): string {
+  const safe = escapeHtml(message);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Tako — sign-in required</title>
+<style>
+  :root { color-scheme: light dark; --fg: #111; --bg: #fff; --muted: #555; --border: #ddd; --accent: #111; --on-accent: #fff; }
+  @media (prefers-color-scheme: dark) {
+    :root { --fg: #f5f5f5; --bg: #0b0b0b; --muted: #aaa; --border: #2a2a2a; --accent: #fff; --on-accent: #111; }
+  }
+  body { font-family: -apple-system, system-ui, "Segoe UI", sans-serif; margin: 0; padding: 3rem 1.5rem; max-width: 28rem; margin-inline: auto; color: var(--fg); background: var(--bg); }
+  h1 { font-size: 1.3rem; margin: 0 0 0.5rem; }
+  p { color: var(--muted); line-height: 1.55; }
+  .actions { margin-top: 1.5rem; display: flex; gap: 0.75rem; }
+  a.btn { flex: 1; text-align: center; padding: 0.75rem 1rem; font-size: 1rem; font-weight: 500; border-radius: 0.5rem; border: 1px solid var(--accent); background: var(--accent); color: var(--on-accent); text-decoration: none; }
+  a.btn:hover { opacity: 0.85; }
+</style>
+</head>
+<body>
+<h1>Sign-in required</h1>
+<p>${safe}</p>
+<div class="actions">
+  <a class="btn" href="javascript:history.back()">Go back</a>
+</div>
+</body>
+</html>`;
 }
 
 function consentPage(args: {
@@ -972,48 +1074,23 @@ export async function handleStytchCallback(
     throw err;
   }
 
-  // Step 2 — fetch the user's Tako API token using their freshly-minted
-  // Stytch session JWT. This is server-to-server, the JWT travels in a
-  // Cookie header (see identity.ts).
-  let takoToken: string;
-  try {
-    takoToken = await fetchTakoApiToken(env, stytchResult.session_jwt);
-  } catch (err) {
-    if (err instanceof IdentityError) {
-      if (err.kind === "no_token") {
-        return errorPage(
-          400,
-          "Your Tako account does not have an API token yet. " +
-            "Visit trytako.com → settings → API tokens to mint one, " +
-            "then retry the connection.",
-        );
-      }
-      if (err.kind === "unauthorized") {
-        return errorPage(
-          502,
-          "Tako rejected the Stytch session. This usually means the " +
-            "Stytch project on the Worker doesn't match Tako's project. " +
-            "Contact support.",
-        );
-      }
-      console.error("Tako identity lookup failed:", err.kind, err.message);
-      return errorPage(
-        502,
-        "Could not retrieve your Tako API token. Please try again.",
-      );
-    }
-    throw err;
-  }
-
-  // Step 3 — encrypt the Tako token (so it can travel in our session
-  // cookie + future OAuth tokens) and mint our own session JWT.
-  const enc_tako_token = await encryptAesGcm(takoToken, cfg.encKey);
+  // Step 2 — encrypt the Stytch session JWT and stash it in our own
+  // session cookie. We deliberately do NOT fetch the Tako API token
+  // here. Caching the Tako token in the session cookie would mean
+  // a token rotation at trytako.com followed by a connector-reconnect
+  // within the cookie's TTL would re-use the stale cached token. By
+  // keeping the Stytch JWT instead and re-fetching the Tako token on
+  // every POST /authorize, rotations are always reflected.
+  const enc_stytch_session_jwt = await encryptAesGcm(
+    stytchResult.session_jwt,
+    cfg.encKey,
+  );
   const userEmail = primaryEmail(stytchResult.user);
   const sessionClaims: SessionCookieClaims = {
     type: "session",
     user_id: stytchResult.user.user_id,
     user_email: userEmail,
-    enc_tako_token,
+    enc_stytch_session_jwt,
     exp: Math.floor(Date.now() / 1000) + SESSION_COOKIE_MAX_AGE_S,
   };
   const sessionJwt = await signJwt(sessionClaims, cfg.signKey);

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -433,8 +433,10 @@ function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
   // Empty / null defaults to "mcp" downstream. This fails-closed instead
   // of silently echoing unknown scope strings into issued tokens — which
   // matters once any downstream system starts gating behavior on scope.
-  const scope = p.get("scope");
-  if (scope !== null && scope.length > 0) {
+  // Normalize `?scope=` (present but empty) to null so the downstream
+  // `?? "mcp"` default applies consistently — `??` doesn't trigger on "".
+  const scope = p.get("scope") || null;
+  if (scope !== null) {
     const requested = scope.split(/\s+/).filter((s) => s.length > 0);
     if (!requested.every((s) => SUPPORTED_SCOPES.has(s))) {
       return `scope contains unsupported values; supported: ${[...SUPPORTED_SCOPES].join(", ")}`;
@@ -752,6 +754,9 @@ export async function handleToken(req: Request, env: Env): Promise<Response> {
   }
 
   const grant_type = params.get("grant_type");
+  if (grant_type === null) {
+    return jsonError("invalid_request", "grant_type is required", 400);
+  }
   if (grant_type === "authorization_code") {
     return handleAuthorizationCodeGrant(params, cfg);
   }

--- a/workers/src/oauth/identity.ts
+++ b/workers/src/oauth/identity.ts
@@ -1,0 +1,158 @@
+/**
+ * Bridge between Stytch authentication and Tako API tokens.
+ *
+ * After a successful Stytch redirect-callback the Worker has a Stytch
+ * session JWT identifying the user. Tako's existing `StytchAuthBackend`
+ * accepts that same JWT — but only when it arrives in the
+ * `stytch_session_jwt` cookie (`request.COOKIES.get(...)` in Django's
+ * middleware). The Worker is calling server-to-server, so we send the
+ * cookie ourselves via the `Cookie` request header. Django can't tell
+ * the difference between a cookie set by a real browser and one set in
+ * a server-side request — JWT signature is what authenticates.
+ *
+ * The endpoint we hit is `GET /api/v1/api_token/` (read-only — never
+ * `POST /api/v1/generate_api_token/`, which rotates and would break
+ * existing Claude Code users every time they OAuth-connect a new host).
+ */
+
+import type { Env } from "../env.js";
+
+const TAKO_API_TOKEN_PATH = "/api/v1/api_token/";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export type IdentityErrorKind =
+  /** Tako returned 401/403 — Stytch JWT was rejected. */
+  | "unauthorized"
+  /** User has no API token yet (Tako returned 404 or empty). User must
+   *  mint one at trytako.com → settings before OAuth-connecting. */
+  | "no_token"
+  /** Network / timeout / unexpected non-2xx. Caller should 500. */
+  | "transport"
+  /** 2xx but body shape was unexpected. */
+  | "parse";
+
+export class IdentityError extends Error {
+  readonly kind: IdentityErrorKind;
+  readonly status: number | undefined;
+
+  constructor(kind: IdentityErrorKind, message: string, status?: number) {
+    super(message);
+    this.name = "IdentityError";
+    this.kind = kind;
+    this.status = status;
+  }
+}
+
+/**
+ * Fetch the user's Tako API token by calling `GET /api/v1/api_token/`
+ * with the Stytch session JWT in a `Cookie` header. Returns the raw
+ * token string. Throws `IdentityError` with a kind discriminator on
+ * any failure — callers are expected to map kinds to user-visible
+ * error pages (e.g. `no_token` → "go mint a token first").
+ */
+export async function fetchTakoApiToken(
+  env: Env,
+  stytchSessionJwt: string,
+): Promise<string> {
+  const base = env.DJANGO_BASE_URL;
+  if (typeof base !== "string" || base.length === 0 || base.endsWith("/")) {
+    throw new IdentityError(
+      "transport",
+      "DJANGO_BASE_URL is missing or has a trailing slash",
+    );
+  }
+  const url = `${base}${TAKO_API_TOKEN_PATH}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "GET",
+      headers: {
+        // `cookie` is a forbidden request header in browser fetches, but
+        // Workers' fetch implementation allows setting it because the
+        // Worker is acting as a server proxy. Django reads it via
+        // `request.COOKIES.get("stytch_session_jwt")`.
+        cookie: `stytch_session_jwt=${stytchSessionJwt}`,
+        accept: "application/json",
+      },
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+  } catch (err) {
+    if (
+      err instanceof DOMException &&
+      (err.name === "AbortError" || err.name === "TimeoutError")
+    ) {
+      throw new IdentityError(
+        "transport",
+        `Tako ${TAKO_API_TOKEN_PATH} timed out after ${DEFAULT_TIMEOUT_MS}ms`,
+      );
+    }
+    throw new IdentityError(
+      "transport",
+      `Tako ${TAKO_API_TOKEN_PATH} fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // 401/403 = Stytch session rejected by Django. Should be rare since we
+  // just minted the JWT, but possible if Stytch and Django have skewed
+  // clocks or the project ID/secret pair is mismatched between the
+  // Worker's Stytch credentials and Django's.
+  if (response.status === 401 || response.status === 403) {
+    throw new IdentityError(
+      "unauthorized",
+      `Tako rejected the Stytch session JWT (status ${response.status})`,
+      response.status,
+    );
+  }
+
+  // 404 = user has no Token row yet. The user-facing fix is to visit
+  // trytako.com → API tokens to mint one. We never call the generate
+  // endpoint from here because it rotates, which would invalidate any
+  // existing Claude Code wiring.
+  if (response.status === 404) {
+    throw new IdentityError(
+      "no_token",
+      "user has no Tako API token; must mint one at trytako.com first",
+      404,
+    );
+  }
+
+  if (!response.ok) {
+    throw new IdentityError(
+      "transport",
+      `Tako ${TAKO_API_TOKEN_PATH} returned ${response.status}`,
+      response.status,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new IdentityError(
+      "parse",
+      `Tako ${TAKO_API_TOKEN_PATH} returned 2xx with non-JSON body`,
+      response.status,
+    );
+  }
+
+  if (typeof body !== "object" || body === null) {
+    throw new IdentityError(
+      "parse",
+      `Tako ${TAKO_API_TOKEN_PATH} response was not an object`,
+      response.status,
+    );
+  }
+  const token = (body as Record<string, unknown>)["token"];
+  if (typeof token !== "string" || token.length === 0) {
+    // 200 with empty/missing token field — treat as "user has no token"
+    // rather than a parse error. Some Django implementations return 200
+    // with `{"token": null}` for this case.
+    throw new IdentityError(
+      "no_token",
+      "user has no Tako API token (server returned empty/missing token field)",
+      response.status,
+    );
+  }
+  return token;
+}

--- a/workers/src/oauth/identity.ts
+++ b/workers/src/oauth/identity.ts
@@ -44,6 +44,15 @@ export class IdentityError extends Error {
 }
 
 /**
+ * Strict JWT-shape regex: three base64url segments separated by dots.
+ * Used to gate the value before we interpolate it into a `Cookie`
+ * header — a stytch JWT containing `\r` or `\n` (theoretically
+ * impossible from Stytch, but worth the cheap defense) would otherwise
+ * inject headers into the upstream Tako request.
+ */
+const STYTCH_JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+/**
  * Fetch the user's Tako API token by calling `GET /api/v1/api_token/`
  * with the Stytch session JWT in a `Cookie` header. Returns the raw
  * token string. Throws `IdentityError` with a kind discriminator on
@@ -59,6 +68,15 @@ export async function fetchTakoApiToken(
     throw new IdentityError(
       "transport",
       "DJANGO_BASE_URL is missing or has a trailing slash",
+    );
+  }
+  if (!STYTCH_JWT_SHAPE.test(stytchSessionJwt)) {
+    // Stytch should never return a non-JWT-shaped session token; if it
+    // does, treat it as a transport-level breakage rather than blindly
+    // forwarding to Django where it could splice the Cookie header.
+    throw new IdentityError(
+      "transport",
+      "stytch session JWT is malformed (failed shape check)",
     );
   }
   const url = `${base}${TAKO_API_TOKEN_PATH}`;

--- a/workers/src/oauth/jwt.test.ts
+++ b/workers/src/oauth/jwt.test.ts
@@ -111,8 +111,15 @@ describe("AES-GCM encrypt / decrypt", () => {
   it("returns null for tampered ciphertext", async () => {
     const key = freshEncKey();
     const ciphertext = await encryptAesGcm("secret", key);
-    // Flip the last character of the ciphertext (the auth tag region).
-    const tampered = ciphertext.slice(0, -1) + (ciphertext.endsWith("A") ? "B" : "A");
+    // Flip a character in the middle of the encoded value rather than the
+    // last char. base64url's last char can carry unused bits (depending on
+    // the encoded length), so a single-char flip there sometimes decodes
+    // to identical bytes — the tamper would be invisible to AES-GCM.
+    // Mid-string the bits land squarely inside the ciphertext + tag.
+    const mid = Math.floor(ciphertext.length / 2);
+    const flip = ciphertext[mid] === "A" ? "B" : "A";
+    const tampered =
+      ciphertext.slice(0, mid) + flip + ciphertext.slice(mid + 1);
     expect(await decryptAesGcm(tampered, key)).toBeNull();
   });
 

--- a/workers/src/oauth/jwt.test.ts
+++ b/workers/src/oauth/jwt.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  b64url,
+  b64urlDecode,
+  decryptAesGcm,
+  encryptAesGcm,
+  sha256B64Url,
+  signJwt,
+  verifyJwt,
+} from "./jwt.js";
+
+const SIGN_KEY = "test-sign-key-for-jwt-tests-do-not-ship";
+
+// 32-byte key, base64-encoded — what `OAUTH_ENC_KEY` should look like.
+function freshEncKey(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s);
+}
+
+describe("b64url", () => {
+  it("round-trips arbitrary bytes", () => {
+    const input = new Uint8Array([0, 1, 254, 255, 100, 50]);
+    const encoded = b64url(input);
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+    const decoded = b64urlDecode(encoded);
+    expect(Array.from(decoded)).toEqual(Array.from(input));
+  });
+
+  it("round-trips ASCII strings", () => {
+    const encoded = b64url("hello world");
+    const decoded = new TextDecoder().decode(b64urlDecode(encoded));
+    expect(decoded).toBe("hello world");
+  });
+});
+
+describe("sha256B64Url", () => {
+  it("matches a known PKCE vector", async () => {
+    // RFC 7636 §4.2 vector: code_verifier "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    // → S256 challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+    const actual = await sha256B64Url(verifier);
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("HS256 signJwt / verifyJwt", () => {
+  it("round-trips claims", async () => {
+    const token = await signJwt({ sub: "alice", scope: "mcp" }, SIGN_KEY);
+    expect(token.split(".").length).toBe(3);
+    const claims = await verifyJwt<{ sub: string; scope: string }>(
+      token,
+      SIGN_KEY,
+    );
+    expect(claims).not.toBeNull();
+    expect(claims!.sub).toBe("alice");
+    expect(claims!.scope).toBe("mcp");
+  });
+
+  it("returns null for tampered payload", async () => {
+    const token = await signJwt({ sub: "alice" }, SIGN_KEY);
+    const [h, p, s] = token.split(".");
+    // Flip a payload character — signature should now mismatch.
+    const tampered = `${h}.${p}A.${s}`;
+    expect(await verifyJwt(tampered, SIGN_KEY)).toBeNull();
+  });
+
+  it("returns null for wrong signing key", async () => {
+    const token = await signJwt({ sub: "alice" }, SIGN_KEY);
+    expect(await verifyJwt(token, "different-key")).toBeNull();
+  });
+
+  it("returns null for malformed token", async () => {
+    expect(await verifyJwt("not-a-jwt", SIGN_KEY)).toBeNull();
+    expect(await verifyJwt("only.two", SIGN_KEY)).toBeNull();
+    expect(await verifyJwt("", SIGN_KEY)).toBeNull();
+  });
+
+  it("returns null for expired claims", async () => {
+    const token = await signJwt(
+      { sub: "alice", exp: Math.floor(Date.now() / 1000) - 60 },
+      SIGN_KEY,
+    );
+    expect(await verifyJwt(token, SIGN_KEY)).toBeNull();
+  });
+});
+
+describe("AES-GCM encrypt / decrypt", () => {
+  it("round-trips a Tako-token-shaped string", async () => {
+    const key = freshEncKey();
+    const plaintext = "fake-tako-token-abc123def456ghi789";
+    const ciphertext = await encryptAesGcm(plaintext, key);
+    expect(ciphertext).not.toBe(plaintext);
+    expect(ciphertext).not.toContain(plaintext);
+    const recovered = await decryptAesGcm(ciphertext, key);
+    expect(recovered).toBe(plaintext);
+  });
+
+  it("returns null for wrong key", async () => {
+    const key1 = freshEncKey();
+    const key2 = freshEncKey();
+    const ciphertext = await encryptAesGcm("secret", key1);
+    expect(await decryptAesGcm(ciphertext, key2)).toBeNull();
+  });
+
+  it("returns null for tampered ciphertext", async () => {
+    const key = freshEncKey();
+    const ciphertext = await encryptAesGcm("secret", key);
+    // Flip the last character of the ciphertext (the auth tag region).
+    const tampered = ciphertext.slice(0, -1) + (ciphertext.endsWith("A") ? "B" : "A");
+    expect(await decryptAesGcm(tampered, key)).toBeNull();
+  });
+
+  it("uses a fresh IV per encryption (different ciphertexts for same plaintext)", async () => {
+    const key = freshEncKey();
+    const plaintext = "stable-input";
+    const ct1 = await encryptAesGcm(plaintext, key);
+    const ct2 = await encryptAesGcm(plaintext, key);
+    expect(ct1).not.toBe(ct2);
+  });
+
+  it("rejects keys that aren't 32 bytes", async () => {
+    const shortKey = btoa("only-16-bytes-ok"); // 16 bytes
+    await expect(encryptAesGcm("secret", shortKey)).rejects.toThrow(
+      /must decode to 32 bytes/,
+    );
+  });
+});

--- a/workers/src/oauth/jwt.ts
+++ b/workers/src/oauth/jwt.ts
@@ -1,0 +1,219 @@
+/**
+ * Crypto primitives for the OAuth implementation: HS256 JWT signing/verifying
+ * and AES-GCM encryption of the per-user Tako API token that travels inside
+ * each OAuth access token's claims.
+ *
+ * Two distinct keys are used by callers:
+ * - `OAUTH_SIGN_KEY` — HMAC-SHA256 secret. Signs every JWT we emit
+ *   (auth codes, refresh tokens, access tokens, DCR client_ids,
+ *   short-lived state cookies).
+ * - `OAUTH_ENC_KEY` — 32-byte raw AES-256 key, base64-encoded. Used only
+ *   to encrypt the Tako API token claim. Kept separate so that a future
+ *   leak of the signing key (which can be hot-rotated by issuing new
+ *   tokens with the new key while honoring old ones for the TTL window)
+ *   cannot retroactively decrypt prior access tokens.
+ *
+ * The two keys are never combined; callers pass each one only to the
+ * function that needs it. Keep this module dependency-free — the moment
+ * it imports `Env` it becomes harder to unit-test in isolation.
+ */
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/* --------------------------- base64url --------------------------- */
+
+export function b64url(input: ArrayBuffer | Uint8Array | string): string {
+  let bytes: Uint8Array;
+  if (typeof input === "string") {
+    bytes = enc.encode(input);
+  } else if (input instanceof Uint8Array) {
+    bytes = input;
+  } else {
+    bytes = new Uint8Array(input);
+  }
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function b64urlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, "+").replace(/_/g, "/") +
+    "=".repeat((4 - (s.length % 4)) % 4);
+  const bin = atob(padded);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/* --------------------------- SHA-256 (b64url) --------------------------- */
+
+export async function sha256B64Url(s: string): Promise<string> {
+  const buf = await crypto.subtle.digest("SHA-256", enc.encode(s));
+  return b64url(buf);
+}
+
+/* --------------------------- HS256 JWT --------------------------- */
+
+export interface JwtClaims {
+  exp?: number;
+  [k: string]: unknown;
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+}
+
+export async function signJwt<T extends JwtClaims>(
+  payload: T,
+  secret: string,
+): Promise<string> {
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const data = `${header}.${body}`;
+  const key = await importHmacKey(secret);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(data));
+  return `${data}.${b64url(sig)}`;
+}
+
+export async function verifyJwt<T extends JwtClaims = JwtClaims>(
+  token: string,
+  secret: string,
+): Promise<T | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, sigB64] = parts;
+  if (
+    headerB64 === undefined ||
+    payloadB64 === undefined ||
+    sigB64 === undefined
+  ) {
+    return null;
+  }
+  const data = `${headerB64}.${payloadB64}`;
+  let key: CryptoKey;
+  try {
+    key = await importHmacKey(secret);
+  } catch {
+    return null;
+  }
+  let sig: Uint8Array;
+  try {
+    sig = b64urlDecode(sigB64);
+  } catch {
+    return null;
+  }
+  let valid: boolean;
+  try {
+    valid = await crypto.subtle.verify("HMAC", key, sig, enc.encode(data));
+  } catch {
+    return null;
+  }
+  if (!valid) return null;
+  let payload: T;
+  try {
+    payload = JSON.parse(dec.decode(b64urlDecode(payloadB64))) as T;
+  } catch {
+    return null;
+  }
+  if (payload.exp !== undefined && payload.exp * 1000 < Date.now()) {
+    return null;
+  }
+  return payload;
+}
+
+/* --------------------------- AES-GCM --------------------------- */
+
+const AES_IV_BYTES = 12;
+
+/**
+ * Decode a base64-encoded 32-byte AES-256 key into a `CryptoKey`. The key
+ * source format is base64 (not base64url) to match `openssl rand -base64 32`
+ * output, which is the most natural way to mint one. Length is enforced to
+ * fail loud on a misconfigured secret.
+ */
+async function importAesKey(b64Key: string): Promise<CryptoKey> {
+  const padded = b64Key.replace(/-/g, "+").replace(/_/g, "/") +
+    "=".repeat((4 - (b64Key.length % 4)) % 4);
+  const bin = atob(padded);
+  if (bin.length !== 32) {
+    throw new Error(
+      `OAUTH_ENC_KEY must decode to 32 bytes (AES-256); got ${bin.length}`,
+    );
+  }
+  const raw = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) raw[i] = bin.charCodeAt(i);
+  return crypto.subtle.importKey(
+    "raw",
+    raw,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Encrypt a string with AES-GCM under `OAUTH_ENC_KEY`. The output bundles
+ * the 12-byte IV with the ciphertext+tag (`iv || ct+tag`) into a single
+ * base64url-encoded payload — single-string format keeps it embeddable as
+ * a JWT claim value without nested JSON.
+ *
+ * The IV is freshly random per encryption (required for GCM security) and
+ * therefore safe to publish alongside the ciphertext.
+ */
+export async function encryptAesGcm(
+  plaintext: string,
+  b64Key: string,
+): Promise<string> {
+  const key = await importAesKey(b64Key);
+  const iv = crypto.getRandomValues(new Uint8Array(AES_IV_BYTES));
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    enc.encode(plaintext),
+  );
+  const ctBytes = new Uint8Array(ct);
+  const out = new Uint8Array(iv.length + ctBytes.length);
+  out.set(iv, 0);
+  out.set(ctBytes, iv.length);
+  return b64url(out);
+}
+
+/**
+ * Decrypt the output of `encryptAesGcm`. Returns `null` on any failure
+ * (wrong key, tampered ciphertext, bad encoding) — callers should treat
+ * a `null` return identically to "claim missing" to avoid leaking
+ * information about which key/payload component failed.
+ */
+export async function decryptAesGcm(
+  encoded: string,
+  b64Key: string,
+): Promise<string | null> {
+  let buf: Uint8Array;
+  try {
+    buf = b64urlDecode(encoded);
+  } catch {
+    return null;
+  }
+  if (buf.length <= AES_IV_BYTES) return null;
+  const iv = buf.slice(0, AES_IV_BYTES);
+  const ct = buf.slice(AES_IV_BYTES);
+  let key: CryptoKey;
+  try {
+    key = await importAesKey(b64Key);
+  } catch {
+    return null;
+  }
+  try {
+    const pt = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ct);
+    return dec.decode(pt);
+  } catch {
+    return null;
+  }
+}

--- a/workers/src/oauth/jwt.ts
+++ b/workers/src/oauth/jwt.ts
@@ -122,7 +122,17 @@ export async function verifyJwt<T extends JwtClaims = JwtClaims>(
   } catch {
     return null;
   }
-  if (payload.exp !== undefined && payload.exp * 1000 < Date.now()) {
+  // 30 seconds of clock-skew tolerance on `exp`. Stytch sessions, the
+  // Worker, and the requesting client may not share a time source; a
+  // strict-equality check at the second boundary spuriously fails for
+  // tokens minted within the last few hundred milliseconds of their
+  // TTL. The 60s auth-code TTL is short enough that a 30s window
+  // doesn't materially weaken replay protection.
+  const CLOCK_SKEW_MS = 30 * 1000;
+  if (
+    payload.exp !== undefined &&
+    payload.exp * 1000 + CLOCK_SKEW_MS < Date.now()
+  ) {
     return null;
   }
   return payload;

--- a/workers/src/oauth/stytch.ts
+++ b/workers/src/oauth/stytch.ts
@@ -1,0 +1,176 @@
+/**
+ * Stytch HTTP client. The Worker authenticates users by handing the Stytch
+ * redirect-token (received on `/oauth/stytch_callback`) to Stytch's
+ * authenticate API, which returns a session JWT we'll then use to call
+ * Tako on the user's behalf.
+ *
+ * Direct HTTP rather than `@stytch/node`:
+ * - The SDK pulls in Node-specific deps that Workers' `nodejs_compat`
+ *   layer doesn't fully cover.
+ * - We use exactly two Stytch endpoints; pulling in the SDK is overkill.
+ *
+ * Authentication is HTTP Basic with `project_id:secret`. Both come from
+ * Worker secrets (see `env.ts`). The base URL switches between
+ * `test.stytch.com` and `api.stytch.com` depending on the project.
+ */
+
+import type { StytchAuthenticateResult } from "./types.js";
+
+export type StytchTokenKind = "oauth" | "magic_links";
+
+export class StytchError extends Error {
+  readonly status: number;
+  readonly errorType: string | undefined;
+
+  constructor(message: string, status: number, errorType?: string) {
+    super(message);
+    this.name = "StytchError";
+    this.status = status;
+    this.errorType = errorType;
+  }
+}
+
+export interface StytchConfig {
+  /** Stytch project ID. e.g. `project-test-...` (test) or `project-live-...`. */
+  projectId: string;
+  /** Stytch project secret. Treated as a Worker secret. */
+  secret: string;
+  /**
+   * Base URL of Stytch's API. `https://test.stytch.com` for test projects,
+   * `https://api.stytch.com` for live. No trailing slash.
+   */
+  baseUrl: string;
+}
+
+function authHeader(cfg: StytchConfig): string {
+  // btoa is available in Workers; no need for Buffer. Stytch expects
+  // the standard HTTP Basic encoding of `project_id:secret`.
+  return "Basic " + btoa(`${cfg.projectId}:${cfg.secret}`);
+}
+
+/**
+ * Exchange a Stytch redirect-token for a session JWT + user identity.
+ *
+ * Routes to the right Stytch endpoint based on the `stytch_token_type`
+ * query parameter we received on the redirect:
+ * - `oauth` → POST /v1/oauth/authenticate
+ * - `magic_links` → POST /v1/magic_links/authenticate
+ *
+ * Both endpoints take a `{ token }` body and return a similar response
+ * shape; we normalize to `StytchAuthenticateResult`.
+ */
+export async function authenticateStytchToken(
+  cfg: StytchConfig,
+  token: string,
+  kind: StytchTokenKind,
+): Promise<StytchAuthenticateResult> {
+  const path =
+    kind === "oauth"
+      ? "/v1/oauth/authenticate"
+      : "/v1/magic_links/authenticate";
+
+  const response = await fetch(`${cfg.baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: authHeader(cfg),
+    },
+    body: JSON.stringify({
+      token,
+      // 60 minutes is enough to walk through the rest of the OAuth
+      // dance (consent → /token call). The session is later wrapped
+      // into our own session cookie and the Stytch JWT is discarded
+      // immediately after we use it to fetch the Tako token.
+      session_duration_minutes: 60,
+    }),
+  });
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    throw new StytchError(
+      `Stytch ${path} returned ${response.status} with non-JSON body`,
+      response.status,
+    );
+  }
+
+  if (!response.ok) {
+    const errType =
+      typeof payload === "object" &&
+      payload !== null &&
+      typeof (payload as Record<string, unknown>)["error_type"] === "string"
+        ? ((payload as Record<string, unknown>)["error_type"] as string)
+        : undefined;
+    throw new StytchError(
+      `Stytch ${path} failed with ${response.status}`,
+      response.status,
+      errType,
+    );
+  }
+
+  const obj = payload as Record<string, unknown>;
+  const session_jwt = obj["session_jwt"];
+  const user = obj["user"];
+  if (typeof session_jwt !== "string" || session_jwt.length === 0) {
+    throw new StytchError(
+      `Stytch ${path} response missing session_jwt`,
+      response.status,
+    );
+  }
+  if (typeof user !== "object" || user === null) {
+    throw new StytchError(
+      `Stytch ${path} response missing user`,
+      response.status,
+    );
+  }
+  const userObj = user as Record<string, unknown>;
+  const user_id = userObj["user_id"];
+  const emails = userObj["emails"];
+  if (typeof user_id !== "string") {
+    throw new StytchError(
+      `Stytch ${path} user missing user_id`,
+      response.status,
+    );
+  }
+  if (!Array.isArray(emails)) {
+    throw new StytchError(
+      `Stytch ${path} user missing emails array`,
+      response.status,
+    );
+  }
+  const normalizedEmails = emails
+    .filter(
+      (e): e is { email: string } =>
+        typeof e === "object" &&
+        e !== null &&
+        typeof (e as Record<string, unknown>)["email"] === "string",
+    )
+    .map((e) => ({ email: e.email }));
+  if (normalizedEmails.length === 0) {
+    throw new StytchError(
+      `Stytch ${path} user has no email addresses`,
+      response.status,
+    );
+  }
+
+  return {
+    session_jwt,
+    user: {
+      user_id,
+      emails: normalizedEmails,
+    },
+  };
+}
+
+/**
+ * Pull the primary email out of a Stytch user record. Stytch users can
+ * have multiple emails; the first one is conventionally the primary.
+ */
+export function primaryEmail(user: StytchAuthenticateResult["user"]): string {
+  const first = user.emails[0];
+  if (first === undefined) {
+    throw new Error("Stytch user has no emails — should be unreachable");
+  }
+  return first.email;
+}

--- a/workers/src/oauth/types.ts
+++ b/workers/src/oauth/types.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared types for the OAuth implementation. Centralized so the JWT claim
+ * shapes have one source of truth — every handler that mints or verifies a
+ * given token type imports the same interface, preventing the
+ * "auth code claims drifted between mint and verify" class of bug.
+ */
+
+import type { JwtClaims } from "./jwt.js";
+
+/* --------------------------- Tokens --------------------------- */
+
+/**
+ * Stable string discriminator on every JWT we mint. Used in `verifyJwt`
+ * callsites so a stolen access token can't be reused as a refresh token
+ * (or vice versa) — even though both are signed by the same key.
+ */
+export type OAuthTokenType =
+  | "auth_code"
+  | "access"
+  | "refresh"
+  | "session" // worker-issued session cookie after Stytch login
+  | "state" // worker-issued cookie carrying OAuth params across the Stytch round-trip
+  | "client_id"; // signed JWT used as the DCR client_id (no PII, just registration metadata)
+
+interface BaseClaims extends JwtClaims {
+  type: OAuthTokenType;
+}
+
+/* --------------------------- DCR --------------------------- */
+
+export interface ClientIdClaims extends BaseClaims {
+  type: "client_id";
+  client_name: string;
+  redirect_uris: string[];
+  iat: number;
+}
+
+/* --------------------------- Authorization --------------------------- */
+
+/**
+ * The auth code minted on POST /authorize. Carries the user identity and
+ * encrypted Tako token forward to /token without persisting anything.
+ */
+export interface AuthCodeClaims extends BaseClaims {
+  type: "auth_code";
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  scope: string;
+  user_id: string;
+  user_email: string;
+  /** AES-GCM-encrypted Tako API token. See `encryptAesGcm` in `jwt.ts`. */
+  enc_tako_token: string;
+}
+
+/* --------------------------- Tokens issued to clients --------------------------- */
+
+export interface AccessTokenClaims extends BaseClaims {
+  type: "access";
+  scope: string;
+  user_id: string;
+  user_email: string;
+  enc_tako_token: string;
+}
+
+export interface RefreshTokenClaims extends BaseClaims {
+  type: "refresh";
+  scope: string;
+  user_id: string;
+  user_email: string;
+  enc_tako_token: string;
+}
+
+/* --------------------------- Worker-only cookies --------------------------- */
+
+/**
+ * `tako_oauth_state` cookie. Set on /authorize when the user has no
+ * worker session yet, carries the original OAuth query params across the
+ * Stytch round-trip so /oauth/stytch_callback can resume the flow.
+ */
+export interface StateCookieClaims extends BaseClaims {
+  type: "state";
+  client_id: string;
+  redirect_uri: string;
+  response_type: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  state: string | null;
+  scope: string | null;
+}
+
+/**
+ * `tako_oauth_session` cookie. Set on /oauth/stytch_callback after we
+ * exchange Stytch's redirect token for a session JWT, look up the user's
+ * Tako API token, and encrypt it for embedding. Lasts long enough to
+ * complete consent (default 30 min).
+ */
+export interface SessionCookieClaims extends BaseClaims {
+  type: "session";
+  user_id: string;
+  user_email: string;
+  enc_tako_token: string;
+}
+
+/* --------------------------- Stytch --------------------------- */
+
+/**
+ * Subset of Stytch's authenticate-response we actually consume. Stytch's
+ * full schema is large; we only need user identity + the session JWT
+ * that we'll later present to Django to mint a Tako API token.
+ */
+export interface StytchAuthenticateResult {
+  session_jwt: string;
+  user: {
+    user_id: string;
+    emails: Array<{ email: string }>;
+  };
+}

--- a/workers/src/oauth/types.ts
+++ b/workers/src/oauth/types.ts
@@ -55,6 +55,15 @@ export interface AuthCodeClaims extends BaseClaims {
 
 /* --------------------------- Tokens issued to clients --------------------------- */
 
+/**
+ * Note on plaintext claims: `user_id` and `user_email` are visible to
+ * anyone who decodes the JWT (clients store these tokens). The Tako API
+ * token is the only secret value; it lives encrypted in
+ * `enc_tako_token`. This is industry-standard for JWT access tokens
+ * (clients are expected to read certain claims), but if the user's
+ * email becomes a stricter PII boundary, replace `user_email` with an
+ * opaque ID and look up the email server-side at consent-render time.
+ */
 export interface AccessTokenClaims extends BaseClaims {
   type: "access";
   scope: string;

--- a/workers/src/oauth/types.ts
+++ b/workers/src/oauth/types.ts
@@ -100,15 +100,36 @@ export interface StateCookieClaims extends BaseClaims {
 
 /**
  * `tako_oauth_session` cookie. Set on /oauth/stytch_callback after we
- * exchange Stytch's redirect token for a session JWT, look up the user's
- * Tako API token, and encrypt it for embedding. Lasts long enough to
- * complete consent (default 30 min).
+ * exchange Stytch's redirect token for a session JWT and identify the
+ * user. Carries the (encrypted) Stytch session JWT itself — NOT a
+ * cached Tako API token. The Tako token is re-fetched on every
+ * `POST /authorize` so token rotations on trytako.com are always
+ * reflected in newly-issued OAuth grants.
+ *
+ * Why we cache the Stytch JWT instead of the Tako token: if a user
+ * rotates their Tako API token at trytako.com, every previously-issued
+ * OAuth grant becomes invalid (the embedded token no longer authenticates
+ * to Django — that's the documented kill switch). But on reconnect, the
+ * user expects the NEW connector to work. If we cached the Tako token
+ * here, the reconnect flow would reuse the stale cached token. By
+ * keeping the Stytch JWT and re-fetching the Tako token at consent
+ * time, we always issue grants with the user's current Tako token.
+ *
+ * Freshness is bounded by the Stytch session: if the user signs out of
+ * trytako.com (revoking the Stytch session), subsequent
+ * `POST /authorize` attempts will be rejected at the Tako call and
+ * force a fresh `/login` round-trip. This is a feature.
+ *
+ * The Stytch JWT is encrypted (not just signed) because, unlike a Tako
+ * API token, a Stytch session JWT can be replayed against any
+ * Stytch-protected resource for its lifetime; encryption ensures a
+ * SIGN_KEY-only leak doesn't expose it.
  */
 export interface SessionCookieClaims extends BaseClaims {
   type: "session";
   user_id: string;
   user_email: string;
-  enc_tako_token: string;
+  enc_stytch_session_jwt: string;
 }
 
 /* --------------------------- Stytch --------------------------- */


### PR DESCRIPTION
## Summary

Adds OAuth 2.1 + DCR + PKCE on the MCP Worker so consumer hosts (Claude.ai, ChatGPT) can connect to Tako with **per-user identity**. Each user authenticates via Tako's existing Stytch project on a Worker-hosted login page; the Worker then calls `/api/v1/api_token/` with the resulting Stytch session JWT to retrieve the user's Tako API token, encrypts it with AES-GCM, and embeds it in signed access tokens. Future MCP calls decrypt the token from the access JWT and forward to Django as `X-API-Key`, so each user's calls hit Tako as themselves.

Closes the loop on [TAKO-2679](https://linear.app/trytako/issue/TAKO-2679/oauth-shim-for-consumer-mcp-hosts-claudeai-chatgpt). Validated end-to-end against ChatGPT in staging — see screenshots in the Linear ticket.

## How it works

```
Claude.ai / ChatGPT
    │
    ▼
GET /authorize  ── no session cookie? ─▶  set state cookie, 302 to /login
    │
    ▼
GET /login  ── renders Stytch SDK ─▶  user picks Google or magic link
    │
    ▼
Stytch  ── redirect ─▶  GET /oauth/stytch_callback
    │
    ▼
/oauth/stytch_callback:
  1. exchange ?token for Stytch session JWT + user info
  2. call Tako /api/v1/api_token/ with the JWT as Cookie header
  3. encrypt the Tako token with OAUTH_ENC_KEY (AES-GCM 256)
  4. mint our own session JWT, set tako_oauth_session cookie
  5. 302 back to /authorize
    │
    ▼
GET /authorize  ── with session ─▶  render consent page (Allow / Deny)
    │
    ▼
POST /authorize  ── Allow ─▶  mint auth code, 302 back to client
    │
    ▼
POST /token  ── swap auth code for access + refresh JWTs
    │
    ▼
POST /mcp  with `Authorization: Bearer <access JWT>`
  ── verify signature, decrypt enc_tako_token from claims,
     forward to Django with X-API-Key: <user's Tako token>
```

The existing static-Bearer Claude Code path on `/mcp` is preserved unchanged: a non-JWT bearer falls through to raw-token forwarding.

## Architecture decisions

**JWT-stateless, not KV-backed** 
- Per-request hot path: HMAC verify + AES-GCM decrypt, no I/O.
- Tradeoff: no instant per-grant revocation (delayed up to TTL — 15min for access, 14d for refresh).
- Mitigation: rotating the user's Tako API token at trytako.com instantly invalidates every JWT we ever issued for them (Django returns 401 on the wrapped X-API-Key).
- Comparison doc: `/tmp/oauth-real-impl-comparison.md`.

**Two crypto keys, separate purposes:**
- `OAUTH_SIGN_KEY` (HS256) — signs every JWT.
- `OAUTH_ENC_KEY` (AES-256-GCM) — encrypts the Tako API token claim only.
- Held separately so a future signing-key rotation doesn't require coordinated re-encryption of in-flight tokens.

**Worker-only, no Django changes.**
- Stytch JWTs are signed by Stytch and validated by signature in Django's `StytchAuthBackend` — works whether the JWT arrives via a real browser cookie or via the Worker's server-side `Cookie:` header.
- Login page hosted on `mcp.tako.com` (not trytako.com) — slightly different brand surface, but skips ~2 weeks of cross-repo coordination.

## File layout

```
src/oauth/
├── jwt.ts          (HS256 + AES-GCM primitives, Web Crypto only)
├── types.ts        (shared claim shapes)
├── cookies.ts      (HttpOnly + Secure + SameSite=Lax cookie helpers)
├── stytch.ts       (Stytch REST API client — direct fetch, no SDK)
├── identity.ts     (Stytch JWT → Tako API token via /api/v1/api_token/)
├── handlers.ts     (all HTTP handlers — discovery, DCR, /authorize, /token, /login, /oauth/stytch_callback)
├── access.ts       (tryResolveOAuthAccessToken for /mcp integration)
└── *.test.ts       (focused unit tests per module)
```

Plus edits to `env.ts` (6 new optional secrets), `index.ts` (route the new endpoints), `mcp.ts` (try OAuth bearer first, fall through to raw token).

## Self-review

Two iterations of unbiased code review (no conversation context carried over).

| | Iteration 1 | Iteration 2 |
|---|---|---|
| Critical | 2 | **0** |
| Important | 6 | 6 |
| Minor | 9 | 6 |

Both critical issues from iteration 1 fixed in commit `181dc29`:
- Login page `escapeHtml`-then-`JSON.stringify` was double-escaping Stytch tokens.
- Single-use auth codes — design constraint of JWT-stateless, documented as TODO.

Iteration 2 produced **zero new critical issues**. The 6 important items were addressed in commit `78ca32c`:
- Clickjacking (`X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` on all HTML).
- `Cache-Control: no-store` on auth pages (don't cache consent's PII).
- `client_id` JWTs now expire after 1 year (no forever-valid registrations).
- `scope` validated against `SUPPORTED_SCOPES` — only `mcp` today.
- Discovery endpoints return 404 when OAuth unconfigured.
- Refresh-token rotation gap — same JWT-stateless constraint as auth-code reuse, parallel TODO comment.

Other security hardening from review:
- `redirect_uri` scheme validation in `/register` (rejects `javascript:`, `data:`, non-loopback `http:`).
- 4KB body cap + control-char rejection on `/register`.
- `client_id` cross-check at `/token` (belt-and-suspenders vs PKCE).
- Stytch JWT shape validation before injecting into `Cookie:` header (header-injection guard).
- Form-action on consent rebuilt from validated params instead of echoing raw `url.search`.
- 30s clock-skew tolerance on JWT `exp`.
- `temporarily_unavailable` (RFC 6749) instead of ad-hoc `service_unavailable`.

## Known gaps deferred to a follow-up ticket

All flagged in code with `KNOWN GAP (TAKO-2679 follow-up)` comments:

1. **Single-use auth codes** — 60s TTL + PKCE bound replay risk; KV-backed `jti` set would close it.
2. **Refresh-token rotation with replay detection** — same constraint, same fix.
3. **State-cookie nonce via Stytch `state` param** — RFC 9700 belt-and-suspenders; cookie alone is adequate under the threat model (no XSS on `mcp.tako.com` + HTTPS-only).

## Tests

- **138 tests pass** (71 existing + 67 new across the OAuth modules).
- Coverage spans: HS256 round-trip, RFC 7636 PKCE vector, AES-GCM tamper detection, key rotation behavior, cookie helpers, DCR happy path + scheme rejection (javascript:/data:/non-loopback http:) + control-char rejection + oversized body, /authorize redirect-to-login flow, consent rendering with HTML-injection safety, /token PKCE mismatch + redirect_uri mismatch + client_id mismatch + refresh grant, scope validation, expired client_id rejection, discovery 404 when disabled, security headers on HTML responses, OAuth-disabled fall-through.
- `npm run typecheck` ✅
- `npm run registry:check` ✅

## Deploy checklist

Worker secrets (per env):
- `OAUTH_SIGN_KEY` — `openssl rand -base64 48`
- `OAUTH_ENC_KEY` — `openssl rand -base64 32` (must decode to exactly 32 bytes for AES-256)
- `STYTCH_PROJECT_ID` — from Stytch dashboard
- `STYTCH_SECRET` — from Stytch dashboard
- `STYTCH_PUBLIC_TOKEN` — from Stytch dashboard
- `STYTCH_BASE_URL` — `https://test.stytch.com` or `https://api.stytch.com`

Stytch dashboard:
- Add `https://mcp.tako.com/oauth/stytch_callback` and `https://mcp.staging.tako.com/oauth/stytch_callback` to Redirect URLs, with both **Login** and **Signup** enabled.

Without these set, the OAuth endpoints return 503 and the Worker still serves the static-Bearer Claude Code path on `/mcp` unchanged.

## Test plan

- [ ] Set staging secrets per the checklist above
- [ ] `npx wrangler deploy --env staging`
- [ ] `curl https://tako-mcp-staging.bobby-118.workers.dev/.well-known/oauth-authorization-server | jq` → expect full metadata
- [ ] In ChatGPT (Pro/Business + Developer Mode): add custom connector `https://tako-mcp-staging.bobby-118.workers.dev/mcp`
- [ ] Walk through Sign-in-with-Google → consent page should show your Tako email → click Allow
- [ ] In a new chat: ask for a Tako tool call (`knowledge_search`, `get_credit_balance`); verify it succeeds
- [ ] Verify Claude Code with a raw Tako API token still works (backwards-compat smoke test)
- [ ] Repeat in production after staging is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)