### PR TITLE
fix(workers): emit ?dark_mode=auto on embed_url for live theme detection

### DIFF
--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -841,9 +841,13 @@ function parsePngDimensions(
  * exactly; `knowledge_search`'s auto-chain calls this for the top
  * card so a follow-up `open_chart_ui` produces identical URLs.
  *
- * `dark_mode` flips both the `?theme=` query on the embed URL and the
- * `?dark_mode=` query on the image URL — Tako's embed page reads the
- * former; the PNG endpoint reads the latter.
+ * `embed_url` always carries `?dark_mode=auto` — the embed page runs
+ * in the user's browser and resolves "auto" via
+ * `matchMedia('(prefers-color-scheme: dark)')`, so the chart picks up
+ * the user's actual OS theme regardless of whether MCP or the calling
+ * host knows it. `image_url` is a server-rendered PNG, where the
+ * backend can't read browser preferences, so it stays
+ * `true`/`false` driven by the `darkMode` arg.
  */
 export function buildChartUrls(
   env: Env,
@@ -852,11 +856,11 @@ export function buildChartUrls(
 ): { embed_url: string; image_url: string } {
   const webBase = resolvePublicBase(env);
   const apiBase = resolvePublicApiBase(env);
-  const theme = darkMode ? "dark" : "light";
+  const imageFlag = darkMode ? "true" : "false";
   const encoded = encodeURIComponent(pubId);
   return {
-    embed_url: `${webBase}/embed/${encoded}/?theme=${theme}`,
-    image_url: `${apiBase}/api/v1/image/${encoded}/?dark_mode=${darkMode ? "true" : "false"}`,
+    embed_url: `${webBase}/embed/${encoded}/?dark_mode=auto`,
+    image_url: `${apiBase}/api/v1/image/${encoded}/?dark_mode=${imageFlag}`,
   };
 }
 

--- a/workers/src/tools/knowledge_search.test.ts
+++ b/workers/src/tools/knowledge_search.test.ts
@@ -607,7 +607,7 @@ describe("knowledge_search auto-chain top-result chart fields", () => {
 
     expect(out.pub_id).toBe("aapl-price");
     expect(out.embed_url).toBe(
-      "https://staging.trytako.com/embed/aapl-price/?theme=dark",
+      "https://staging.trytako.com/embed/aapl-price/?dark_mode=auto",
     );
     expect(out.image_url).toBe(
       "https://staging.trytako.com/api/v1/image/aapl-price/?dark_mode=true",

--- a/workers/src/tools/open_chart_ui.test.ts
+++ b/workers/src/tools/open_chart_ui.test.ts
@@ -52,7 +52,7 @@ describe("open_chart_ui handler", () => {
 
     expect(out.pub_id).toBe("abc123");
     expect(out.embed_url).toBe(
-      "https://staging.trytako.com/embed/abc123/?theme=dark",
+      "https://staging.trytako.com/embed/abc123/?dark_mode=auto",
     );
     expect(out.image_url).toBe(
       "https://staging.trytako.com/api/v1/image/abc123/?dark_mode=true",
@@ -75,12 +75,16 @@ describe("open_chart_ui handler", () => {
     );
   });
 
-  it("light-mode flag flips the embed theme query and the image dark_mode flag", async () => {
+  it("light-mode flag flips the image dark_mode flag; embed_url stays auto", async () => {
+    // Embed URLs always carry `?dark_mode=auto` so the embed page can
+    // resolve the user's actual `prefers-color-scheme` at load time.
+    // The PNG image is server-rendered and can't introspect the
+    // browser, so its `dark_mode` flag still tracks the input.
     const out = await open_chart_ui.handler(
       { ...HANDLER_INPUT, dark_mode: false },
       CTX,
     );
-    expect(out.embed_url).toContain("?theme=light");
+    expect(out.embed_url).toContain("?dark_mode=auto");
     expect(out.image_url).toContain("dark_mode=false");
   });
 });
@@ -95,7 +99,7 @@ describe("open_chart_ui extraContentBlocks", () => {
     const blocks = await open_chart_ui.extraContentBlocks!(
       {
         pub_id: "abc123",
-        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
         image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
         dark_mode: true,
         width: 900,
@@ -120,7 +124,7 @@ describe("open_chart_ui extraContentBlocks", () => {
     const blocks = await open_chart_ui.extraContentBlocks!(
       {
         pub_id: "abc123",
-        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
         image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
         dark_mode: true,
         width: 900,
@@ -138,7 +142,7 @@ describe("open_chart_ui extraContentBlocks", () => {
     const blocks = await open_chart_ui.extraContentBlocks!(
       {
         pub_id: "missing",
-        embed_url: "https://example.com/embed/missing/?theme=dark",
+        embed_url: "https://example.com/embed/missing/?dark_mode=auto",
         image_url: "https://example.com/api/v1/image/missing/?dark_mode=true",
         dark_mode: true,
         width: 900,
@@ -164,7 +168,7 @@ describe("open_chart_ui extraContentBlocks", () => {
     const blocks = await open_chart_ui.extraContentBlocks!(
       {
         pub_id: "abc123",
-        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
         image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
         dark_mode: true,
         width: 900,
@@ -184,7 +188,7 @@ describe("open_chart_ui extraContentBlocks", () => {
     const blocks = await open_chart_ui.extraContentBlocks!(
       {
         pub_id: "abc123",
-        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
         image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
         dark_mode: true,
         width: 900,
@@ -206,7 +210,7 @@ describe("open_chart_ui extraContentBlocks", () => {
     const blocks = await open_chart_ui.extraContentBlocks!(
       {
         pub_id: "abc123",
-        embed_url: "https://example.com/embed/abc123/?theme=dark",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
         image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
         dark_mode: true,
         width: 900,


### PR DESCRIPTION
## Summary

- The MCP-generated `embed_url` carried `?theme=dark|light`, but Tako's embed page reads `?dark_mode=`. The mismatched param was silently ignored, so MCP charts always rendered with the embed page's default theme regardless of intent.
- Emit `?dark_mode=auto` on `embed_url` instead. The Tako frontend (separate PR: https://github.com/TakoData/tako/pulls — see companion branch) resolves `auto` client-side via `window.matchMedia('(prefers-color-scheme: dark)')`, so the chart picks up the user's actual OS theme — and re-themes live when they toggle it.
- `image_url` (server-rendered PNG, no browser introspection possible) keeps its existing `?dark_mode=true|false` flag.

## Deploy ordering

Deploy the **Tako frontend PR first** (so the embed page recognizes `?dark_mode=auto`), then this PR. Otherwise dark-mode users will see light charts until the frontend deploy lands — `auto` falls through the existing `lower === "true"` check and returns `false`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 208/208 pass (8 hardcoded URLs in `open_chart_ui.test.ts` and `knowledge_search.test.ts` updated; one "light-mode flag" test reframed since `embed_url` no longer tracks the flag)
- [x] End-to-end smoke against local Worker → staging Django → local Tako frontend (with companion PR applied): toggling macOS Appearance flips the embed chart between light and dark live without a page reload.
<img width="1509" height="656" alt="Screenshot 2026-05-05 at 16 56 01" src="https://github.com/user-attachments/assets/b2d8bd79-d1d2-46d8-85a2-0e1f5ba5b0e8" />
<img width="1512" height="797" alt="Screenshot 2026-05-05 at 16 56 16" src="https://github.com/user-attachments/assets/b4841f48-fadf-4d33-9c76-28991b6a4566" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)