### PR TITLE
fix(workers): make OAuth surface compatible with browser-based MCP clients

### DIFF
--- a/workers/src/cors.ts
+++ b/workers/src/cors.ts
@@ -1,0 +1,52 @@
+/**
+ * CORS for the OAuth discovery + DCR + token surface.
+ *
+ * Browser-based MCP clients (notably the OpenAI Apps SDK submission
+ * wizard at platform.openai.com) auto-detect OAuth via fetch() from
+ * a different origin. Without ACAO the browser blocks the response
+ * body and the wizard reports "couldn't detect OAuth metadata."
+ *
+ * Wildcard origin is correct here: every endpoint we expose CORS on
+ * is either a public discovery doc or a stateless OAuth endpoint that
+ * never reads or sets cookies. The cookie-bearing surface (/authorize,
+ * /login, /oauth/stytch_callback) is reached by top-level browser
+ * navigation, not CORS fetches, so it deliberately stays uncovered.
+ */
+
+const CORS_HEADERS: Record<string, string> = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+  "access-control-allow-headers": "Content-Type, Authorization, MCP-Protocol-Version",
+  "access-control-max-age": "86400",
+};
+
+/** Paths that browser-based MCP clients hit cross-origin and therefore
+ *  need CORS headers on both the response and the OPTIONS preflight. */
+export const CORS_PATHS = new Set<string>([
+  "/.well-known/oauth-protected-resource",
+  "/.well-known/oauth-authorization-server",
+  "/register",
+  "/token",
+]);
+
+/** Returns a new Response with CORS headers merged in. The original
+ *  response's body, status, and existing headers are preserved. */
+export function withCors(res: Response): Response {
+  const headers = new Headers(res.headers);
+  for (const [k, v] of Object.entries(CORS_HEADERS)) {
+    headers.set(k, v);
+  }
+  // Wildcard ACAO + Vary: Origin keeps shared caches honest if any get
+  // inserted between us and the browser later.
+  headers.append("vary", "Origin");
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
+}
+
+/** 204 preflight response with the CORS headers attached. */
+export function corsPreflight(): Response {
+  return withCors(new Response(null, { status: 204 }));
+}

--- a/workers/src/cors.ts
+++ b/workers/src/cors.ts
@@ -27,6 +27,7 @@ export const CORS_PATHS = new Set<string>([
   "/.well-known/oauth-authorization-server",
   "/register",
   "/token",
+  "/revoke",
 ]);
 
 /** Returns a new Response with CORS headers merged in. The original

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -20,6 +20,17 @@ describe("worker routing", () => {
     expect(res.status).toBe(404);
   });
 
+  // Strict OIDC clients (notably ChatGPT App Review) reject our OAuth
+  // metadata when it's served at the OIDC discovery path because we omit
+  // OIDC-only fields. 404 here lets them fall back to the OAuth metadata
+  // path per the MCP spec.
+  it("GET /.well-known/openid-configuration returns 404 (we are not an OIDC IdP)", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/.well-known/openid-configuration",
+    );
+    expect(res.status).toBe(404);
+  });
+
   it("POST /mcp accepts an initialize request and returns serverInfo matching registry", async () => {
     const initializeRequest = {
       jsonrpc: "2.0",

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -31,6 +31,57 @@ describe("worker routing", () => {
     expect(res.status).toBe(404);
   });
 
+  // Browser-based MCP clients (OpenAI Apps SDK wizard, etc.) auto-detect
+  // OAuth via cross-origin fetch. Without ACAO the browser blocks the
+  // body and detection silently fails — see `cors.ts` for the rationale.
+  describe("CORS on the OAuth surface", () => {
+    const CORS_PATHS = [
+      "/.well-known/oauth-protected-resource",
+      "/.well-known/oauth-authorization-server",
+      "/register",
+      "/token",
+    ];
+
+    for (const path of CORS_PATHS) {
+      it(`OPTIONS ${path} returns 204 with CORS headers`, async () => {
+        const res = await SELF.fetch(`https://example.com${path}`, {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://platform.openai.com",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "content-type",
+          },
+        });
+        expect(res.status).toBe(204);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+        expect(res.headers.get("access-control-allow-headers")).toContain(
+          "Content-Type",
+        );
+      });
+    }
+
+    it("GET /.well-known/oauth-protected-resource carries ACAO on the response", async () => {
+      const res = await SELF.fetch(
+        "https://example.com/.well-known/oauth-protected-resource",
+        { headers: { origin: "https://platform.openai.com" } },
+      );
+      // Response status depends on whether OAuth is configured in the test
+      // env (404 vs 200); CORS must be present either way so browser-side
+      // discovery surfaces the underlying error instead of an opaque CORS
+      // failure.
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    });
+
+    it("GET /.well-known/oauth-authorization-server carries ACAO on the response", async () => {
+      const res = await SELF.fetch(
+        "https://example.com/.well-known/oauth-authorization-server",
+        { headers: { origin: "https://platform.openai.com" } },
+      );
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    });
+  });
+
   it("POST /mcp accepts an initialize request and returns serverInfo matching registry", async () => {
     const initializeRequest = {
       jsonrpc: "2.0",

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -20,15 +20,21 @@ describe("worker routing", () => {
     expect(res.status).toBe(404);
   });
 
-  // Strict OIDC clients (notably ChatGPT App Review) reject our OAuth
-  // metadata when it's served at the OIDC discovery path because we omit
-  // OIDC-only fields. 404 here lets them fall back to the OAuth metadata
-  // path per the MCP spec.
-  it("GET /.well-known/openid-configuration returns 404 (we are not an OIDC IdP)", async () => {
-    const res = await SELF.fetch(
+  // ChatGPT's App Review classifier rejects servers that only expose
+  // `oauth-authorization-server`. The OIDC path is aliased to the same
+  // OAuth metadata to satisfy classifiers that expect both paths to
+  // resolve. We are not a full OIDC IdP — strict OIDC clients will
+  // notice the missing OIDC-only fields and (correctly) decline.
+  it("GET /.well-known/openid-configuration aliases the OAuth metadata", async () => {
+    const oidcRes = await SELF.fetch(
       "https://example.com/.well-known/openid-configuration",
     );
-    expect(res.status).toBe(404);
+    const oauthRes = await SELF.fetch(
+      "https://example.com/.well-known/oauth-authorization-server",
+    );
+    // Both paths return the same metadata — body byte-for-byte identical.
+    expect(oidcRes.status).toBe(oauthRes.status);
+    expect(await oidcRes.text()).toBe(await oauthRes.text());
   });
 
   // Browser-based MCP clients (OpenAI Apps SDK wizard, etc.) auto-detect

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -20,21 +20,16 @@ describe("worker routing", () => {
     expect(res.status).toBe(404);
   });
 
-  // ChatGPT's App Review classifier rejects servers that only expose
-  // `oauth-authorization-server`. The OIDC path is aliased to the same
-  // OAuth metadata to satisfy classifiers that expect both paths to
-  // resolve. We are not a full OIDC IdP — strict OIDC clients will
-  // notice the missing OIDC-only fields and (correctly) decline.
-  it("GET /.well-known/openid-configuration aliases the OAuth metadata", async () => {
-    const oidcRes = await SELF.fetch(
+  // We deliberately do not alias the OIDC discovery path. ChatGPT's App
+  // Review wizard auto-locks the OIDC form fields once the URL resolves,
+  // and the resulting half-OIDC / half-OAuth shape trips its classifier.
+  // Pure OAuth + DCR is the safer path for MCP Apps; strict OIDC clients
+  // (correctly) fall back to OAuth on 404.
+  it("GET /.well-known/openid-configuration returns 404 (pure OAuth, not OIDC)", async () => {
+    const res = await SELF.fetch(
       "https://example.com/.well-known/openid-configuration",
     );
-    const oauthRes = await SELF.fetch(
-      "https://example.com/.well-known/oauth-authorization-server",
-    );
-    // Both paths return the same metadata — body byte-for-byte identical.
-    expect(oidcRes.status).toBe(oauthRes.status);
-    expect(await oidcRes.text()).toBe(await oauthRes.text());
+    expect(res.status).toBe(404);
   });
 
   // Browser-based MCP clients (OpenAI Apps SDK wizard, etc.) auto-detect

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -73,21 +73,18 @@ export default {
     ) {
       return withCors(handleProtectedResourceMetadata(request, env));
     }
-    // `/.well-known/openid-configuration` is aliased to the OAuth
-    // metadata path. ChatGPT's App Review classifier rejects servers
-    // that only expose `oauth-authorization-server` with "unsupported
-    // OAuth config type" — guidance from outside this codebase says
-    // public Apps expect a discoverable OIDC URL even when the server
-    // is not a full OIDC IdP. Our metadata satisfies OIDC discovery's
-    // *required* fields (issuer, authorization_endpoint, token_endpoint,
-    // response_types_supported); we deliberately omit OIDC-only fields
-    // (jwks_uri, id_token_signing_alg_values_supported,
-    // subject_types_supported) — strict OIDC clients will (correctly)
-    // decline.
+    // We deliberately do NOT alias `/.well-known/openid-configuration`.
+    // Two rounds of external advice converged on the same conclusion:
+    // ChatGPT's App Review classifier dislikes a "half-OIDC / half-OAuth"
+    // shape, where the OIDC URL resolves but the doc lacks OIDC-only
+    // fields (jwks_uri, id_token_signing_alg_values_supported,
+    // subject_types_supported). Once the wizard discovers the OIDC URL,
+    // it locks the OIDC fields on the form, and `OIDC enabled` cannot be
+    // cleared cleanly. Pure OAuth + DCR is the safer shape for MCP Apps.
+    // Strict OIDC clients will (correctly) fall back to OAuth on 404.
     if (
       request.method === "GET" &&
-      (url.pathname === "/.well-known/oauth-authorization-server" ||
-        url.pathname === "/.well-known/openid-configuration")
+      url.pathname === "/.well-known/oauth-authorization-server"
     ) {
       return withCors(handleAuthServerMetadata(request, env));
     }

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -9,6 +9,7 @@ import {
   handleLogin,
   handleProtectedResourceMetadata,
   handleRegister,
+  handleRevoke,
   handleStytchCallback,
   handleToken,
 } from "./oauth/handlers.js";
@@ -95,6 +96,9 @@ export default {
     }
     if (url.pathname === "/token") {
       return withCors(await handleToken(request, env));
+    }
+    if (url.pathname === "/revoke") {
+      return withCors(handleRevoke(request, env));
     }
     if (url.pathname === "/login") {
       return handleLogin(request, env);

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -63,20 +63,18 @@ export default {
     ) {
       return handleProtectedResourceMetadata(request, env);
     }
-    // `/.well-known/openid-configuration` is aliased to the OAuth
-    // metadata path (TAKO-2700). Some MCP hosts (observed: ChatGPT)
-    // probe OIDC discovery first and only fall back to OAuth on 404 —
-    // serving identical JSON saves a round-trip and stops emitting a
-    // spurious 404 in our logs. Our OAuth metadata happens to satisfy
-    // OIDC discovery's *required* fields (issuer, authorization_endpoint,
-    // token_endpoint, response_types_supported), but we deliberately
-    // omit OIDC-specific fields (jwks_uri, id_token_signing_alg_values,
-    // subject_types_supported) — strict OIDC clients will (correctly)
-    // decline; we are not an OIDC IdP.
+    // We deliberately do NOT alias `/.well-known/openid-configuration`
+    // to this OAuth metadata. TAKO-2700 added that alias to silence a
+    // spurious 404 in staging logs, but ChatGPT's App Review submission
+    // flow probes the OIDC path, parses the response strictly as OIDC,
+    // and rejects it with "unsupported OAuth config type" because we
+    // omit OIDC-only fields (jwks_uri, id_token_signing_alg_values,
+    // subject_types_supported). We are not an OIDC IdP, so the correct
+    // behaviour is to 404 the OIDC path and let strict clients fall
+    // back to OAuth discovery per the MCP spec.
     if (
       request.method === "GET" &&
-      (url.pathname === "/.well-known/oauth-authorization-server" ||
-        url.pathname === "/.well-known/openid-configuration")
+      url.pathname === "/.well-known/oauth-authorization-server"
     ) {
       return handleAuthServerMetadata(request, env);
     }

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -1,3 +1,4 @@
+import { CORS_PATHS, corsPreflight, withCors } from "./cors.js";
 import type { Env } from "./env.js";
 import { handleExportRequest } from "./exports.js";
 import { handleIconRequest } from "./icons.js";
@@ -25,6 +26,14 @@ export default {
 
     if (request.method === "POST" && url.pathname === "/mcp") {
       return handleMcpRequest(request, env);
+    }
+
+    // CORS preflight for the discovery + DCR + token endpoints. Browser-
+    // based MCP submission flows (e.g. OpenAI Apps SDK at
+    // platform.openai.com) preflight POST /register and POST /token, and
+    // need ACAO on the metadata GETs. See `cors.ts` for the full rationale.
+    if (request.method === "OPTIONS" && CORS_PATHS.has(url.pathname)) {
+      return corsPreflight();
     }
 
     // Brand-icon proxy. Connector cards in Claude / ChatGPT fetch these
@@ -61,7 +70,7 @@ export default {
       request.method === "GET" &&
       url.pathname === "/.well-known/oauth-protected-resource"
     ) {
-      return handleProtectedResourceMetadata(request, env);
+      return withCors(handleProtectedResourceMetadata(request, env));
     }
     // We deliberately do NOT alias `/.well-known/openid-configuration`
     // to this OAuth metadata. TAKO-2700 added that alias to silence a
@@ -76,16 +85,16 @@ export default {
       request.method === "GET" &&
       url.pathname === "/.well-known/oauth-authorization-server"
     ) {
-      return handleAuthServerMetadata(request, env);
+      return withCors(handleAuthServerMetadata(request, env));
     }
     if (url.pathname === "/register") {
-      return handleRegister(request, env);
+      return withCors(await handleRegister(request, env));
     }
     if (url.pathname === "/authorize") {
       return handleAuthorize(request, env);
     }
     if (url.pathname === "/token") {
-      return handleToken(request, env);
+      return withCors(await handleToken(request, env));
     }
     if (url.pathname === "/login") {
       return handleLogin(request, env);

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -73,18 +73,21 @@ export default {
     ) {
       return withCors(handleProtectedResourceMetadata(request, env));
     }
-    // We deliberately do NOT alias `/.well-known/openid-configuration`
-    // to this OAuth metadata. TAKO-2700 added that alias to silence a
-    // spurious 404 in staging logs, but ChatGPT's App Review submission
-    // flow probes the OIDC path, parses the response strictly as OIDC,
-    // and rejects it with "unsupported OAuth config type" because we
-    // omit OIDC-only fields (jwks_uri, id_token_signing_alg_values,
-    // subject_types_supported). We are not an OIDC IdP, so the correct
-    // behaviour is to 404 the OIDC path and let strict clients fall
-    // back to OAuth discovery per the MCP spec.
+    // `/.well-known/openid-configuration` is aliased to the OAuth
+    // metadata path. ChatGPT's App Review classifier rejects servers
+    // that only expose `oauth-authorization-server` with "unsupported
+    // OAuth config type" — guidance from outside this codebase says
+    // public Apps expect a discoverable OIDC URL even when the server
+    // is not a full OIDC IdP. Our metadata satisfies OIDC discovery's
+    // *required* fields (issuer, authorization_endpoint, token_endpoint,
+    // response_types_supported); we deliberately omit OIDC-only fields
+    // (jwks_uri, id_token_signing_alg_values_supported,
+    // subject_types_supported) — strict OIDC clients will (correctly)
+    // decline.
     if (
       request.method === "GET" &&
-      url.pathname === "/.well-known/oauth-authorization-server"
+      (url.pathname === "/.well-known/oauth-authorization-server" ||
+        url.pathname === "/.well-known/openid-configuration")
     ) {
       return withCors(handleAuthServerMetadata(request, env));
     }

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -205,25 +205,6 @@ describe("discovery", () => {
     expect(body.code_challenge_methods_supported).toContain("S256");
   });
 
-  it("/.well-known/openid-configuration returns identical metadata (OIDC alias, TAKO-2700)", async () => {
-    const env = envWith();
-    const oauthRes = handleAuthServerMetadata(
-      new Request(
-        "https://mcp.example.com/.well-known/oauth-authorization-server",
-      ),
-      env,
-    );
-    const oidcRes = handleAuthServerMetadata(
-      new Request("https://mcp.example.com/.well-known/openid-configuration"),
-      env,
-    );
-    expect(oidcRes.status).toBe(200);
-    // Byte-for-byte identical body — the alias serves the OAuth metadata
-    // verbatim so the "we are not an OIDC IdP" caveat is preserved by
-    // omission of OIDC-specific fields (jwks_uri, id_token_signing_alg_*).
-    expect(await oidcRes.text()).toBe(await oauthRes.text());
-  });
-
   it("returns 404 when OAuth is disabled (no metadata advertised)", async () => {
     const res1 = handleProtectedResourceMetadata(
       new Request("https://mcp.example.com/.well-known/oauth-protected-resource"),
@@ -237,12 +218,6 @@ describe("discovery", () => {
       ENV_NO_OAUTH,
     );
     expect(res2.status).toBe(404);
-    // OIDC alias inherits the same env-gating (TAKO-2700).
-    const res3 = handleAuthServerMetadata(
-      new Request("https://mcp.example.com/.well-known/openid-configuration"),
-      ENV_NO_OAUTH,
-    );
-    expect(res3.status).toBe(404);
   });
 });
 

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -257,15 +257,10 @@ export function handleAuthServerMetadata(
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    // Controlled experiment for ChatGPT App Review classifier:
-    // `["none"]` alone may be too uncommon for strict OAuth validators;
-    // `client_secret_basic` was previously flagged as a breaking value;
-    // `client_secret_post` is the middle-ground that's both common in
-    // discovery docs and not in the rejected list. We still only accept
-    // public clients (PKCE, no secret) at /token — RFC 8414 lets a
-    // client pick whichever method it can support, and ChatGPT uses
-    // PKCE per their docs, so they'll prefer `"none"`.
-    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+    // Public clients (PKCE, no secret) — the only auth method we
+    // actually accept at /token. ChatGPT uses PKCE per their published
+    // guidance, Claude.ai uses PKCE, the MCP spec uses PKCE.
+    token_endpoint_auth_methods_supported: ["none"],
     revocation_endpoint_auth_methods_supported: ["none"],
     scopes_supported: [...SUPPORTED_SCOPES],
   });

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -253,6 +253,7 @@ export function handleAuthServerMetadata(
     authorization_endpoint: `${origin}/authorize`,
     token_endpoint: `${origin}/token`,
     registration_endpoint: `${origin}/register`,
+    revocation_endpoint: `${origin}/revoke`,
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
@@ -269,8 +270,34 @@ export function handleAuthServerMetadata(
       "client_secret_post",
       "client_secret_basic",
     ],
+    revocation_endpoint_auth_methods_supported: ["none"],
     scopes_supported: [...SUPPORTED_SCOPES],
   });
+}
+
+/**
+ * RFC 7009 OAuth 2.0 Token Revocation — stub endpoint.
+ *
+ * Our access + refresh tokens are stateless JWTs, so there is no
+ * server-side state to invalidate; revocation is genuinely a no-op
+ * unless we add a deny list. RFC 7009 §2.2 explicitly allows: "Note:
+ * invalid tokens do not cause an error response since the client
+ * cannot handle such an error in a reasonable way." So returning 200
+ * regardless of the token's validity is spec-compliant.
+ *
+ * Why advertise it at all: ChatGPT's App Review classifier rejects
+ * metadata it labels as "unsupported OAuth config type"; a richer,
+ * more conventional discovery doc (with `revocation_endpoint`) helps
+ * us look like the OAuth servers their classifier already accepts.
+ */
+export function handleRevoke(req: Request, env: Env): Response {
+  if (readConfig(env) === null) {
+    return new Response("not found", { status: 404 });
+  }
+  if (req.method !== "POST") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  return new Response(null, { status: 200 });
 }
 
 /* --------------------------- Dynamic Client Registration --------------------------- */

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -256,7 +256,19 @@ export function handleAuthServerMetadata(
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    token_endpoint_auth_methods_supported: ["none"],
+    // We only actually accept public clients (PKCE, no secret) at /token.
+    // The two `client_secret_*` methods are advertised because ChatGPT's
+    // App Review backend classifies metadata that advertises only
+    // `"none"` as "unsupported OAuth config type" and refuses to save —
+    // even though we expose `registration_endpoint` and the wizard's
+    // discovery UI auto-selects DCR. Per RFC 8414 a client picks the
+    // method it can support; ChatGPT explicitly uses PKCE per their
+    // docs, so they'll prefer `"none"` and never send a secret.
+    token_endpoint_auth_methods_supported: [
+      "none",
+      "client_secret_post",
+      "client_secret_basic",
+    ],
     scopes_supported: [...SUPPORTED_SCOPES],
   });
 }

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -257,19 +257,12 @@ export function handleAuthServerMetadata(
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    // We only actually accept public clients (PKCE, no secret) at /token.
-    // The two `client_secret_*` methods are advertised because ChatGPT's
-    // App Review backend classifies metadata that advertises only
-    // `"none"` as "unsupported OAuth config type" and refuses to save —
-    // even though we expose `registration_endpoint` and the wizard's
-    // discovery UI auto-selects DCR. Per RFC 8414 a client picks the
-    // method it can support; ChatGPT explicitly uses PKCE per their
-    // docs, so they'll prefer `"none"` and never send a secret.
-    token_endpoint_auth_methods_supported: [
-      "none",
-      "client_secret_post",
-      "client_secret_basic",
-    ],
+    // PKCE-only public clients per ChatGPT's published guidance:
+    // `["none"]` is what their DCR + PKCE flow expects, and external
+    // advice flagged `client_secret_basic` / `client_secret_post` /
+    // `private_key_jwt` as "common breaking values" that trip the App
+    // Review classifier into "unsupported OAuth config type".
+    token_endpoint_auth_methods_supported: ["none"],
     revocation_endpoint_auth_methods_supported: ["none"],
     scopes_supported: [...SUPPORTED_SCOPES],
   });

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -257,12 +257,15 @@ export function handleAuthServerMetadata(
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    // PKCE-only public clients per ChatGPT's published guidance:
-    // `["none"]` is what their DCR + PKCE flow expects, and external
-    // advice flagged `client_secret_basic` / `client_secret_post` /
-    // `private_key_jwt` as "common breaking values" that trip the App
-    // Review classifier into "unsupported OAuth config type".
-    token_endpoint_auth_methods_supported: ["none"],
+    // Controlled experiment for ChatGPT App Review classifier:
+    // `["none"]` alone may be too uncommon for strict OAuth validators;
+    // `client_secret_basic` was previously flagged as a breaking value;
+    // `client_secret_post` is the middle-ground that's both common in
+    // discovery docs and not in the rejected list. We still only accept
+    // public clients (PKCE, no secret) at /token — RFC 8414 lets a
+    // client pick whichever method it can support, and ChatGPT uses
+    // PKCE per their docs, so they'll prefer `"none"`.
+    token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
     revocation_endpoint_auth_methods_supported: ["none"],
     scopes_supported: [...SUPPORTED_SCOPES],
   });


### PR DESCRIPTION
## Summary

Three coordinated changes to make our OAuth + DCR surface work for browser-based MCP clients (specifically the OpenAI Apps SDK submission wizard at platform.openai.com).

### What ships

1. **CORS on the discovery + DCR + token + revoke endpoints.** Browser-based clients fetch these cross-origin; without `Access-Control-Allow-Origin` the browser blocks the body and discovery silently fails. New `workers/src/cors.ts` helper with `withCors()` + `corsPreflight()` and a `CORS_PATHS` set; `index.ts` short-circuits OPTIONS preflight and wraps GET/POST responses through it. Cookie-bearing surfaces (`/authorize`, `/login`, `/oauth/stytch_callback`) are deliberately uncovered — they're reached by top-level browser navigation, not CORS fetches.

2. **Drop the `/.well-known/openid-configuration` alias** that TAKO-2700 added (`38fcdbe`). The alias was put in to silence a spurious staging 404 in logs, but the half-OIDC / half-OAuth shape (URL resolves but doc lacks OIDC-only fields like `jwks_uri`, `id_token_signing_alg_values_supported`, `subject_types_supported`) trips ChatGPT's wizard into auto-locking OIDC form fields that can't then be cleared. We are not an OIDC IdP; pure OAuth + DCR is the right shape for MCP. Strict OIDC clients will (correctly) fall back to OAuth-AS metadata on 404.

3. **Advertise `revocation_endpoint` + add a stub `/revoke` route.** Our access + refresh tokens are stateless JWTs, so there's no server-side state to invalidate; RFC 7009 §2.2 explicitly allows returning 200 unconditionally. Richer discovery brings the metadata closer to the OAuth servers that ChatGPT's classifier already accepts (Auth0, Okta, Cognito-style).

### Files

- `workers/src/cors.ts` (new) — CORS helper + path set
- `workers/src/index.ts` — OPTIONS preflight, `withCors()` wrappers, `/revoke` route, OIDC alias removed
- `workers/src/oauth/handlers.ts` — `revocation_endpoint` in AS metadata, `revocation_endpoint_auth_methods_supported`, new `handleRevoke`
- `workers/src/index.test.ts` — routing tests for CORS + OPTIONS + 404 on OIDC path
- `workers/src/oauth/handlers.test.ts` — drops the openid-configuration alias-equivalence tests

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 220/220 passing (added 6 new CORS routing tests)
- [x] Verified live on staging:
  - `GET /.well-known/oauth-authorization-server` → 200 + ACAO + `revocation_endpoint`
  - `GET /.well-known/oauth-protected-resource` → 200 + ACAO
  - `GET /.well-known/openid-configuration` → 404
  - `OPTIONS` on the four CORS paths → 204 + full CORS headers
- [x] OpenAI Apps wizard now auto-discovers DCR + all endpoints from the metadata (was failing on "couldn't detect OAuth metadata" without CORS)
- [ ] Re-test Claude.ai connect flow against prod after merge — fall-through to OAuth-AS should still work; nothing in the OAuth surface that Claude touches has changed semantically

## Note on commit history

This branch went through ~8 commits while we triangulated the ChatGPT App Review behaviour with two rounds of external advice. The net change is coherent (the three points above) but the intermediate commits zig-zag. Worth squashing on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)