### PR TITLE
feat(oauth): RFC 8707 resource indicator support

### DIFF
--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -967,6 +967,227 @@ describe("/token", () => {
     expect(body.error).toBe("invalid_grant");
     expect(body.error_description).toBe("refresh token already redeemed");
   });
+
+  /* --------------------------- RFC 8707 resource indicators --------------------------- */
+
+  // Helper — read a JWT's claims without verifying. Tests only.
+  function decodeJwtClaims(jwt: string): Record<string, unknown> {
+    const seg = jwt.split(".")[1]!;
+    const padded = seg + "===".slice((seg.length + 3) % 4);
+    const b64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+    return JSON.parse(atob(b64)) as Record<string, unknown>;
+  }
+
+  it("RFC 8707: /authorize binds resource to the auth code and /token echoes it as aud", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { verifier, challenge } = await pkcePair();
+    const RESOURCE = "https://mcp.example.com/mcp";
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("resource", RESOURCE);
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    expect(decodeJwtClaims(code).resource).toBe(RESOURCE);
+
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          resource: RESOURCE,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(decodeJwtClaims(body.access_token).aud).toBe(RESOURCE);
+    expect(decodeJwtClaims(body.refresh_token).aud).toBe(RESOURCE);
+  });
+
+  it("RFC 8707: /authorize rejects a resource that doesn't match the canonical MCP URL", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("resource", "https://attacker.example.com/mcp");
+    const res = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("RFC 8707: /token rejects when the auth code's resource is omitted in the token request", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { verifier, challenge } = await pkcePair();
+    const RESOURCE = "https://mcp.example.com/mcp";
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("resource", RESOURCE);
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          // No `resource` form param.
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(400);
+    expect(((await tokenRes.json()) as { error: string }).error).toBe(
+      "invalid_target",
+    );
+  });
+
+  it("backward compat: /authorize without resource still works; tokens carry no aud", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { verifier, challenge } = await pkcePair();
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    // No `resource` — Claude.ai today does not send it.
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    expect(decodeJwtClaims(code).resource).toBeUndefined();
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+        }).toString(),
+      }),
+      env,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(decodeJwtClaims(body.access_token).aud).toBeUndefined();
+    expect(decodeJwtClaims(body.refresh_token).aud).toBeUndefined();
+  });
+
+  it("RFC 8707: refresh_token grant rejects mismatched resource", async () => {
+    const env = envWith();
+    const clientId = await mintClientId(env, "https://client.example.com/cb");
+    const sessionJwt = await mintSessionCookie(env);
+    const { verifier, challenge } = await pkcePair();
+    const RESOURCE = "https://mcp.example.com/mcp";
+    const url = new URL("https://mcp.example.com/authorize");
+    url.searchParams.set("client_id", clientId);
+    url.searchParams.set("redirect_uri", "https://client.example.com/cb");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("resource", RESOURCE);
+    const authorizeRes = await handleAuthorize(
+      new Request(url.toString(), {
+        method: "POST",
+        headers: { cookie: `${SESSION_COOKIE}=${sessionJwt}` },
+      }),
+      env,
+    );
+    const code = new URL(authorizeRes.headers.get("location")!)
+      .searchParams.get("code")!;
+    const tokenRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: "https://client.example.com/cb",
+          code_verifier: verifier,
+          resource: RESOURCE,
+        }).toString(),
+      }),
+      env,
+    );
+    const refreshToken = ((await tokenRes.json()) as { refresh_token: string })
+      .refresh_token;
+    const refreshRes = await handleToken(
+      new Request("https://mcp.example.com/token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+          resource: "https://attacker.example.com/mcp",
+        }).toString(),
+      }),
+      env,
+    );
+    expect(refreshRes.status).toBe(400);
+    expect(((await refreshRes.json()) as { error: string }).error).toBe(
+      "invalid_target",
+    );
+  });
 });
 
 /* --------------------------- /login --------------------------- */

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -443,6 +443,18 @@ interface AuthorizeQuery {
   code_challenge_method: string;
   state: string | null;
   scope: string | null;
+  /** RFC 8707 resource indicator. `null` means the client did not send one
+   *  (fine — the parameter is OPTIONAL); a non-null value MUST equal the
+   *  canonical MCP resource URL on this origin. */
+  resource: string | null;
+}
+
+/** RFC 8707 §2 — the only resource we host. Centralized here so
+ *  /authorize, /token, and /.well-known/oauth-protected-resource agree
+ *  on the canonical URL. Including a fragment in `resource` is a SHOULD-
+ *  reject per the RFC; we reject anything that doesn't byte-match. */
+function canonicalResource(origin: string): string {
+  return `${origin}/mcp`;
 }
 
 function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
@@ -472,6 +484,14 @@ function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
       return `scope contains unsupported values; supported: ${[...SUPPORTED_SCOPES].join(", ")}`;
     }
   }
+  // RFC 8707 — accept the resource indicator if present and require it
+  // to match this server's canonical resource URL. We reject anything
+  // else with `invalid_target` (RFC 8707 §3) so confused-deputy clients
+  // can't get an auth code bound to a resource they don't host.
+  const resource = p.get("resource");
+  if (resource !== null && resource !== canonicalResource(url.origin)) {
+    return `resource must equal ${canonicalResource(url.origin)} (RFC 8707)`;
+  }
   return {
     client_id,
     redirect_uri,
@@ -480,6 +500,7 @@ function readAuthorizeQuery(url: URL): AuthorizeQuery | string {
     code_challenge_method,
     state: p.get("state"),
     scope,
+    resource,
   };
 }
 
@@ -545,6 +566,7 @@ export async function handleAuthorize(
         code_challenge_method: parsed.code_challenge_method,
         state: parsed.state,
         scope: parsed.scope,
+        ...(parsed.resource !== null ? { resource: parsed.resource } : {}),
         exp: Math.floor(Date.now() / 1000) + STATE_COOKIE_MAX_AGE_S,
       };
       const stateJwt = await signJwt(stateClaims, cfg.signKey);
@@ -575,6 +597,8 @@ export async function handleAuthorize(
     );
     if (parsed.state !== null) formActionUrl.searchParams.set("state", parsed.state);
     if (parsed.scope !== null) formActionUrl.searchParams.set("scope", parsed.scope);
+    if (parsed.resource !== null)
+      formActionUrl.searchParams.set("resource", parsed.resource);
     return htmlResponse(
       consentPage({
         clientName: client.client_name,
@@ -671,6 +695,7 @@ export async function handleAuthorize(
     enc_tako_token,
     exp: now + AUTH_CODE_TTL_S,
     jti: crypto.randomUUID(),
+    ...(parsed.resource !== null ? { resource: parsed.resource } : {}),
   };
   const code = await signJwt(codeClaims, cfg.signKey);
 
@@ -907,6 +932,19 @@ async function handleAuthorizationCodeGrant(
   if (claims.code_challenge !== expectedChallenge) {
     return jsonError("invalid_grant", "PKCE verifier does not match", 400);
   }
+  // RFC 8707 §2.2 — if the auth code was bound to a `resource`, the
+  // token request MUST present the same value. Mismatched / missing
+  // resource at /token is `invalid_target`. If the auth code carries no
+  // resource (legacy / didn't pass it at /authorize), accept whatever
+  // the client sends here for forward compat.
+  const formResource = params.get("resource");
+  if (claims.resource !== undefined && formResource !== claims.resource) {
+    return jsonError(
+      "invalid_target",
+      "resource does not match authorization request",
+      400,
+    );
+  }
   const replay = await checkAndMarkRedeemed(
     "auth-code",
     claims.jti,
@@ -921,6 +959,7 @@ async function handleAuthorizationCodeGrant(
       enc_tako_token: claims.enc_tako_token,
     },
     cfg,
+    claims.resource ?? formResource ?? undefined,
   );
 }
 
@@ -940,6 +979,19 @@ async function handleRefreshGrant(
       400,
     );
   }
+  // RFC 8707 §2.2 — refresh-token requests MAY include `resource` and
+  // the value MUST match the audience the refresh token was issued for.
+  // If the refresh token has no `aud` (legacy, pre-resource-indicators),
+  // accept whatever the client sends so newly-issued tokens can carry
+  // it forward.
+  const formResource = params.get("resource");
+  if (claims.aud !== undefined && formResource !== null && formResource !== claims.aud) {
+    return jsonError(
+      "invalid_target",
+      "resource does not match refresh token audience",
+      400,
+    );
+  }
   const replay = await checkAndMarkRedeemed(
     "refresh-token",
     claims.jti,
@@ -954,6 +1006,7 @@ async function handleRefreshGrant(
       enc_tako_token: claims.enc_tako_token,
     },
     cfg,
+    claims.aud ?? formResource ?? undefined,
   );
 }
 
@@ -967,6 +1020,7 @@ interface IdentityForToken {
 async function issueTokens(
   identity: IdentityForToken,
   cfg: OAuthConfig,
+  aud: string | undefined,
 ): Promise<Response> {
   const now = Math.floor(Date.now() / 1000);
   const accessClaims: AccessTokenClaims = {
@@ -976,6 +1030,7 @@ async function issueTokens(
     user_email: identity.user_email,
     enc_tako_token: identity.enc_tako_token,
     exp: now + ACCESS_TOKEN_TTL_S,
+    ...(aud !== undefined ? { aud } : {}),
   };
   const refreshClaims: RefreshTokenClaims = {
     type: "refresh",
@@ -985,6 +1040,7 @@ async function issueTokens(
     enc_tako_token: identity.enc_tako_token,
     exp: now + REFRESH_TOKEN_TTL_S,
     jti: crypto.randomUUID(),
+    ...(aud !== undefined ? { aud } : {}),
   };
   const access_token = await signJwt(accessClaims, cfg.signKey);
   const refresh_token = await signJwt(refreshClaims, cfg.signKey);
@@ -1232,6 +1288,8 @@ export async function handleStytchCallback(
     authorizeUrl.searchParams.set("state", stateClaims.state);
   if (stateClaims.scope !== null)
     authorizeUrl.searchParams.set("scope", stateClaims.scope);
+  if (stateClaims.resource !== undefined)
+    authorizeUrl.searchParams.set("resource", stateClaims.resource);
 
   // Multiple Set-Cookie headers — modern Workers fetch API handles this
   // by accepting a Headers instance with repeated entries (single string

--- a/workers/src/oauth/types.ts
+++ b/workers/src/oauth/types.ts
@@ -55,6 +55,12 @@ export interface AuthCodeClaims extends BaseClaims {
    *  redemption handler records this in Workers Cache after a successful
    *  exchange and rejects subsequent presentations with the same `jti`. */
   jti: string;
+  /** RFC 8707 §2 — the resource the authorization code is bound to.
+   *  Optional because the parameter is OPTIONAL per the RFC and legacy
+   *  clients (Claude.ai today) do not send it. When present, /token
+   *  MUST receive a matching `resource` and the issued access /
+   *  refresh tokens carry it as the `aud` claim. */
+  resource?: string;
 }
 
 /* --------------------------- Tokens issued to clients --------------------------- */
@@ -74,6 +80,12 @@ export interface AccessTokenClaims extends BaseClaims {
   user_id: string;
   user_email: string;
   enc_tako_token: string;
+  /** RFC 8707 §3 — the resource the token is intended for, propagated
+   *  from the authorization code's `resource` claim. Resource servers
+   *  SHOULD validate this matches their own canonical URL before
+   *  accepting the token. Optional for backward compat with tokens
+   *  minted before resource indicators landed. */
+  aud?: string;
 }
 
 export interface RefreshTokenClaims extends BaseClaims {
@@ -92,6 +104,10 @@ export interface RefreshTokenClaims extends BaseClaims {
    *  Tighten back to required `string` once the 14-day legacy window has
    *  passed and the bypass in `checkAndMarkRedeemed` is removed. */
   jti?: string;
+  /** RFC 8707 §3 — same semantics as on `AccessTokenClaims`. Carried on
+   *  the refresh token so subsequent refresh_token grants can re-issue
+   *  access tokens with the same `aud` without re-running /authorize. */
+  aud?: string;
 }
 
 /* --------------------------- Worker-only cookies --------------------------- */
@@ -110,6 +126,11 @@ export interface StateCookieClaims extends BaseClaims {
   code_challenge_method: string;
   state: string | null;
   scope: string | null;
+  /** RFC 8707 resource indicator carried across the Stytch login round-
+   *  trip so /oauth/stytch_callback can rebuild the original /authorize
+   *  request faithfully. Optional for backward compat with state cookies
+   *  minted before resource indicators landed. */
+  resource?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

ChatGPT Apps SDK auth docs explicitly require clients to *"echo the resource parameter throughout the OAuth flow"* (RFC 8707). Our `/authorize` and `/token` were silently ignoring it — discovery metadata looked right, but issued tokens carried no `aud` claim, which a strict resource server validator would (correctly) reject.

This PR threads `resource` through the entire OAuth flow.

## What changes

- **`/authorize`** accepts `?resource=…`, validates it equals \`\${origin}/mcp\`, and binds it into the auth code's claims. State cookie carries it across the Stytch login round-trip so `/oauth/stytch_callback` can rebuild the original `/authorize` request faithfully.
- **`/token`** accepts a `resource` form param. If the auth code was bound to a resource, the form value MUST match (RFC 8707 §2.2 — `invalid_target` on mismatch).
- **Issued access + refresh tokens** carry `aud` = the resource.
- **`refresh_token` grant** validates the form `resource` against the refresh token's `aud` claim and re-issues with the same `aud`.

## Backward compatibility

Every new claim field is optional:

- `AuthCodeClaims.resource?: string`
- `AccessTokenClaims.aud?: string`
- `RefreshTokenClaims.aud?: string`
- `StateCookieClaims.resource?: string`

Auth codes, refresh tokens, and state cookies that predate this change continue to work unchanged. Clients that don't send `resource` (Claude.ai today) get the same behaviour as before — no `aud` on issued tokens, no enforcement at `/token`.

Clients that DO send `resource` (ChatGPT per their docs, future MCP clients) get full RFC 8707 enforcement: the resource is bound to the code, validated at the token endpoint, and propagated into the issued tokens.

## Why now

Direct follow-up to PR #72 — that PR exhausted every metadata-shape variant for the ChatGPT App Review classifier with no success. While the App Review save error is now believed to be an OpenAI-side classifier regression (multiple devs in the [community thread](https://community.openai.com/t/oauth-mcp-server-works-in-chatgpt-developer-mode-create-app-but-fails-in-app-review-form-what-does-unsupported-oauth-config-type-really-mean/1380378) hit the same bug, no fix posted), runtime resource echoing is **independently required** by OpenAI's auth docs and is likely needed for Developer Mode to actually call tools end-to-end. Implementing it now closes a known correctness gap regardless of the App Review outcome.

## Files

- `workers/src/oauth/types.ts` — new optional claim fields on AuthCode / Access / Refresh / StateCookie
- `workers/src/oauth/handlers.ts` — query parsing, /authorize binding, /token validation, /refresh validation, `aud` on issued tokens, stytch callback forwarding
- `workers/src/oauth/handlers.test.ts` — 5 new tests:
  - /authorize binds resource → /token echoes as aud
  - /authorize rejects mismatched resource (e.g. attacker.example.com)
  - /token rejects when auth code has resource but token request omits it
  - backward compat: no resource → no aud, flow still works
  - refresh_token grant rejects mismatched resource

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 225/225 passing (5 new RFC 8707 tests)
- [ ] After deploy: ChatGPT Developer Mode connect against staging — verify access token decodes with \`aud: \"https://mcp.staging.tako.com/mcp\"\` and tool calls succeed
- [ ] Verify Claude.ai (which doesn't send \`resource\`) still connects normally — backward-compat path

🤖 Generated with [Claude Code](https://claude.com/claude-code)