### PR TITLE
fix(oauth): publish bare-origin `resource` per OpenAI Apps SDK docs

### DIFF
--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -181,7 +181,10 @@ describe("discovery", () => {
       resource: string;
       authorization_servers: string[];
     };
-    expect(body.resource).toBe("https://mcp.example.com/mcp");
+    // Bare origin (not /mcp-suffixed) per OpenAI Apps SDK auth docs:
+    // "ChatGPT sends this exact value as the `resource` query parameter
+    // during OAuth." The classifier rejects path-suffixed values.
+    expect(body.resource).toBe("https://mcp.example.com");
     expect(body.authorization_servers).toEqual(["https://mcp.example.com"]);
   });
 

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -228,7 +228,13 @@ export function handleProtectedResourceMetadata(
   }
   const origin = new URL(req.url).origin;
   return Response.json({
-    resource: `${origin}/mcp`,
+    // OpenAI Apps SDK auth docs explicitly state: "ChatGPT sends this
+    // exact value as the `resource` query parameter during OAuth." Their
+    // example uses the bare origin, not a path-suffixed URL — and the
+    // App Review classifier appears to require this shape. We previously
+    // advertised `${origin}/mcp` (RFC 9728 allows either) but that trips
+    // their "unsupported OAuth config type" rejection during submission.
+    resource: origin,
     authorization_servers: [origin],
     bearer_methods_supported: ["header"],
     scopes_supported: [...SUPPORTED_SCOPES],


### PR DESCRIPTION
## Summary

OpenAI's Apps SDK auth docs are explicit:

> *"\`resource\`: the canonical HTTPS identifier for your MCP server. **ChatGPT sends this exact value as the \`resource\` query parameter during OAuth.**"*

Their example shows the bare origin:

\`\`\`json
{ "resource": "https://your-mcp.example.com", ... }
\`\`\`

We've been publishing \`\${origin}/mcp\` (e.g. \`https://mcp.tako.com/mcp\`). RFC 9728 allows either form, but **ChatGPT's App Review classifier appears to require the bare-origin shape.** Every metadata-shape variant we tried in PR #72 was rejected with the same generic \`"unsupported OAuth config type"\` while our metadata otherwise matched every published spec. The bare-origin \`resource\` is the only material difference between our doc and the documented OpenAI example.

## Change

\`workers/src/oauth/handlers.ts\` — one line:

\`\`\`diff
- resource: \`\${origin}/mcp\`,
+ resource: origin,
\`\`\`

## Notes

- Per RFC 9728 either form is spec-conformant; this just narrows our value to match what the OpenAI classifier expects.
- No \`/mcp\` route changes — the actual MCP endpoint is still served at \`POST /mcp\`. The \`resource\` field is metadata, not routing.
- Independent of PR #73 (RFC 8707 resource-indicator validation). PR #73's validator currently expects \`\${origin}/mcp\` as the canonical resource value; if this PR lands first, PR #73 will need its validator updated to accept the bare origin instead. Filing as a separate small PR so it can deploy independently and quickly.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 220/220 passing (test for protected-resource metadata updated to expect bare origin)
- [ ] Deploy to staging, then retry the App Review wizard publish flow
- [ ] Re-test Claude.ai connect (Claude.ai uses the \`resource\` value from protected-resource metadata; should be unaffected since we still serve a valid resource URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)