### PR TITLE
perf(workers): skip PNG fetch on ChatGPT — ~5.5s → ~1/2s on knowledge_search

### DIFF
--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -616,7 +616,7 @@ function registerTool(
         !inlinePngFallbackSuppressed
       ) {
         try {
-          const extra = await tool.extraContentBlocks(output, ctx);
+          const extra = await tool.extraContentBlocks(output, callCtx);
           content.push(...extra);
         } catch (err) {
           console.error(
@@ -645,7 +645,7 @@ function registerTool(
       let resultMeta: Record<string, unknown> | undefined;
       if (tool.extraMeta !== undefined && ui !== undefined) {
         try {
-          resultMeta = await tool.extraMeta(output, ctx);
+          resultMeta = await tool.extraMeta(output, callCtx);
         } catch (err) {
           console.error(`extraMeta hook failed for ${tool.name}:`, err);
         }

--- a/workers/src/tools/knowledge_search.ts
+++ b/workers/src/tools/knowledge_search.ts
@@ -335,8 +335,15 @@ const knowledge_search = {
 
     return buildResultsWithAutoChain(cards, ctx.env);
   },
-  async extraMeta(output, _ctx) {
-    void _ctx;
+  async extraMeta(output, ctx) {
+    // Skip the fetch on ChatGPT: its widget bundle takes the iframe
+    // path (`window.openai` defined → `shouldUseInteractiveIframe()`
+    // true in `_chart_widget.ts`), which renders `embed_url` directly
+    // and never reads `image_data_url` from `_meta`. Without this
+    // gate we pay the full chart-render latency
+    // (`PNG_FETCH_TIMEOUT_MS` = 8s upper bound) on every ChatGPT
+    // tool call just to populate a field the host throws away.
+    if (ctx.client === "chatgpt") return undefined;
     if (output.image_url === undefined) return undefined;
     const fetched = await fetchImageDataUrlAndDims(output.image_url);
     if (fetched === undefined) return undefined;

--- a/workers/src/tools/open_chart_ui.test.ts
+++ b/workers/src/tools/open_chart_ui.test.ts
@@ -222,6 +222,65 @@ describe("open_chart_ui extraContentBlocks", () => {
   });
 });
 
+describe("open_chart_ui extraMeta", () => {
+  // ChatGPT's widget bundle takes the iframe path (window.openai
+  // defined → shouldUseInteractiveIframe() === true in
+  // _chart_widget.ts), which renders `embed_url` directly and never
+  // reads `image_data_url` from `_meta`. Fetching the PNG just to
+  // throw the bytes away adds the rendered-chart latency (up to
+  // PNG_FETCH_TIMEOUT_MS = 8s) onto every tool call. Gate the fetch
+  // so ChatGPT skips it entirely.
+  it("skips the PNG fetch on ChatGPT (host uses iframe, _meta.image_data_url unused)", async () => {
+    const fetchSpy = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const meta = await open_chart_ui.extraMeta!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      { ...CTX, client: "chatgpt" },
+    );
+
+    expect(meta).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches and inlines the PNG on non-ChatGPT clients (widget consumes image_data_url)", async () => {
+    // Minimal valid PNG: 8-byte signature + IHDR chunk with width=2,
+    // height=1. parsePngDimensions needs ≥24 bytes with the 89 50 4E 47
+    // signature and width/height at offsets 16 and 20.
+    const png = new Uint8Array(24);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    // width = 2 (at offset 16, big-endian uint32)
+    png[19] = 2;
+    // height = 1 (at offset 20, big-endian uint32)
+    png[23] = 1;
+    mockFetchOnce(pngResponse(png));
+
+    const meta = await open_chart_ui.extraMeta!(
+      {
+        pub_id: "abc123",
+        embed_url: "https://example.com/embed/abc123/?dark_mode=auto",
+        image_url: "https://example.com/api/v1/image/abc123/?dark_mode=true",
+        dark_mode: true,
+        width: 900,
+        height: 600,
+      },
+      { ...CTX, client: "unknown" },
+    );
+
+    expect(meta).toBeDefined();
+    expect(meta!.image_data_url).toMatch(/^data:image\/png;base64,/);
+    expect(meta!.image_natural_width).toBe(2);
+    expect(meta!.image_natural_height).toBe(1);
+  });
+});
+
 describe("open_chart_ui appUiResource", () => {
   it("returns a stable URI, the MCP Apps mimeType-bound bundle, and the env's web base as the only allowed frame domain", () => {
     const ui = open_chart_ui.appUiResource!(ENV);

--- a/workers/src/tools/open_chart_ui.ts
+++ b/workers/src/tools/open_chart_ui.ts
@@ -113,7 +113,7 @@ const open_chart_ui = {
       height: input.height,
     };
   },
-  async extraMeta(output, _ctx): Promise<Record<string, unknown> | undefined> {
+  async extraMeta(output, ctx): Promise<Record<string, unknown> | undefined> {
     // Inline the chart PNG as a `data:image/...;base64,...` URI for
     // the widget, plus the source PNG's natural pixel dimensions.
     // Routed through `_meta` (not `structuredContent`) because the
@@ -121,7 +121,15 @@ const open_chart_ui = {
     // `structuredContent` blows past claude.ai's per-tool-result
     // context budget — Claude then offloads the whole result to a
     // file and skips widget delivery.
-    void _ctx;
+    //
+    // Skip the fetch on ChatGPT: its widget bundle takes the iframe
+    // path (`window.openai` defined → `shouldUseInteractiveIframe()`
+    // true in `_chart_widget.ts`), which renders `embed_url` directly
+    // and never reads `image_data_url` from `_meta`. Without this
+    // gate we pay the full chart-render latency
+    // (`PNG_FETCH_TIMEOUT_MS` = 8s upper bound) on every ChatGPT
+    // tool call just to populate a field the host throws away.
+    if (ctx.client === "chatgpt") return undefined;
     const fetched = await fetchImageDataUrlAndDims(output.image_url);
     if (fetched === undefined) return undefined;
     return {


### PR DESCRIPTION
## Summary

ChatGPT's widget bundle takes the iframe path (`window.openai` defined → `shouldUseInteractiveIframe()` true in `_chart_widget.ts`) and renders `embed_url` directly. It never reads `_meta.image_data_url`, but the worker was fetching the chart PNG anyway and base64-inlining it — paying up to `PNG_FETCH_TIMEOUT_MS` (8 s) of dead latency on every `knowledge_search` / `open_chart_ui` call.

Reported as: ChatGPT seeing ~10 s tool-call latency on queries that take ~1 s in the Tako web app.

### Changes

1. **`1f4927a perf(workers): skip PNG fetch on ChatGPT in extraMeta`** — gate `extraMeta` on `ctx.client !== "chatgpt"` in both `knowledge_search.ts` and `open_chart_ui.ts`. claude.ai (widget on / custom connectors) is unchanged — its inline `<img>` path at `_chart_widget.ts:467` actually consumes `image_data_url`, so the fetch is still needed there.
2. **`9227005 fix(workers): pass per-call client to extraMeta / extraContentBlocks`** — wiring fix that makes the gate above actually fire. The base `ctx` constructed in `handleMcpRequest` pins `client` to `"unknown"` and never gets updated; `registerTool` builds a `callCtx` with the detected `options.client` spliced in and passes it to the tool's `handler`, but `extraMeta` / `extraContentBlocks` were still being called with the original `ctx`. Result: `ctx.client === "chatgpt"` was always false inside the hooks, silently disabling the gate. The unit tests in commit 1 passed because they called `extraMeta` directly with a synthetic `{ ...CTX, client: "chatgpt" }` and didn't exercise the mcp.ts plumbing.

### Measured impact (staging, knowledge_search on ChatGPT)

Tool-call duration captured via temporary `[mcp:done] ...` logs (now removed):

| metric | before (gate dead) | after (gate firing) |
|---|---|---|
| `total_ms` | 5527 | **1051** |
| `handler_ms` (Tako search) | 2435 | 1051 |
| `extra_meta_ms` (PNG fetch) | 3092 | **0** |
| `extra_content_ms` | 0 | 0 |

Net: ~4.5 s removed from every ChatGPT tool call. The remaining `total_ms` is now ≈ `handler_ms` (Tako-side floor); MCP-layer overhead is negligible.

## Test plan
- [x] `npm test` → 222/222 passing
- [x] `npm run typecheck` → clean
- [x] Smoke against staging on a ChatGPT session: `knowledge_search` returns in ~1 s instead of ~5.5 s, chart still renders interactively
- [x] Smoke on claude.ai web: confirm the static chart image still renders inline (regression check on the path that still needs the PNG bytes)
- [ ] Smoke on claude.ai custom connector: unchanged path (`extraContentBlocks`), confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)