### PR TITLE
test(exports): de-flake expired-token test with fake timers

### DIFF
--- a/workers/src/exports.test.ts
+++ b/workers/src/exports.test.ts
@@ -230,21 +230,25 @@ describe("handleExportRequest", () => {
   });
 
   it("returns 401 for an expired token", async () => {
-    const { token } = await mintExportToken(
-      "sk",
-      "rep",
-      "pdf",
-      ENV_A,
-      // 1-second TTL — by the time we call the route below, it'll be
-      // expired. Wait one second to be safe.
-      1,
-    );
-    await new Promise((r) => setTimeout(r, 1100));
-    const res = await handleExportRequest(
-      new Request(`https://mcp.staging.tako.com/exports/${token}`),
-      ENV_A,
-    );
-    expect(res.status).toBe(401);
+    // Expiry is compared at whole-second granularity with a strict
+    // `<`, so a 1s-TTL token only reads as expired once the clock is
+    // two whole seconds past the mint second. Drive that with fake
+    // timers instead of a real sleep — a real sleep of ~1.1s lands on
+    // the wrong side of the second boundary most of the time (the
+    // token still validates, the handler then hits real Django and
+    // returns 404 instead of 401), which made this test flaky in CI.
+    vi.useFakeTimers();
+    try {
+      const { token } = await mintExportToken("sk", "rep", "pdf", ENV_A, 1);
+      vi.setSystemTime(Date.now() + 2000);
+      const res = await handleExportRequest(
+        new Request(`https://mcp.staging.tako.com/exports/${token}`),
+        ENV_A,
+      );
+      expect(res.status).toBe(401);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns 400 when the token segment is empty", async () => {


### PR DESCRIPTION
## What

The `returns 401 for an expired token` test in `workers/src/exports.test.ts` was flaky in CI (e.g. [this run](https://github.com/TakoData/tako-mcp/actions/runs/26481731749/job/77980271320)), failing with `expected 404 to be 401`.

## Root cause

The test minted a 1-second-TTL token and slept **1100ms** before asserting a 401. But expiry is compared at **whole-second granularity** with a strict `<` (`exports.ts:266`):

- `exp = floor(now/1000) + 1` → mint second `S` gives `exp = S + 1`
- verify rejects only when `exp < nowSeconds`, i.e. needs `nowSeconds ≥ S + 2`
- after a ~1.1s sleep the floored second is usually still `S + 1` → token **not** expired

When the token still validated, the handler proceeded to the upstream Django fetch — and this test stubs no `fetch`, so it hit **real staging**, got a 404 HTML page, and returned 404 instead of 401.

## Fix

Drive the clock with `vi.useFakeTimers()` + `vi.setSystemTime(Date.now() + 2000)` (try/finally to restore real timers). Fully deterministic, no real sleep, no accidental network call.

## Verification

- `npx vitest run src/exports.test.ts` — 17/17 pass, run 3× for determinism
- Full suite green (222/222)
- File runtime dropped ~2.1s → ~60ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)