### PR TITLE
fix(security): bump fast-uri to 3.1.2 to patch CVEs

### DIFF
--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -2213,9 +2213,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
Patches two Dependabot alerts in `workers/`.

| Package | Was | Now | CVEs |
|---|---|---|---|
| fast-uri | 3.1.0 | 3.1.2 | CVE-2026-6321, CVE-2026-6322 |

Transitive dep via `ajv` (`^3.0.1`); 3.1.2 satisfies that range, so this is a lockfile-only update with no manifest change (`npm update fast-uri --package-lock-only`).

## Lines changed
- Logic: none (manifest unchanged)
- Lockfile: `workers/package-lock.json` (fast-uri version + integrity)
- Tests: none
- Docs: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)