### PR TITLE
feat(registry): publish tako-mcp to the official MCP Registry as a remote server

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,46 @@
+name: Publish to MCP Registry
+
+# Publishes ./server.json (the io.github.TakoData/tako-mcp remote-server
+# descriptor) to the official MCP Registry (registry.modelcontextprotocol.io)
+# via GitHub OIDC. OIDC needs NO secret: the io.github.TakoData/* namespace is
+# authorized because this repo lives in the TakoData GitHub org.
+#
+# NOTE: ./server.json is the official-registry descriptor (remote streamable-http
+# at mcp.tako.com/mcp; tools are discovered at runtime). It is distinct from
+# registry/server.json, which is the in-repo generated tool catalog used by
+# `npm run registry:gen`/`registry:check`.
+
+on:
+  push:
+    tags: ["v*"] # publish on a release tag, e.g. v0.2.0
+  workflow_dispatch: {} # or publish on demand
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for OIDC authentication
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # On a release tag, stamp server.json's version from the tag so the
+      # published version matches the tag (the registry rejects re-publishing an
+      # already-published version). On workflow_dispatch, the checked-in version
+      # is published as-is.
+      - name: Sync server.json version to the release tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+
+      - name: Authenticate to the MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to the MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -5,15 +5,23 @@ name: Publish to MCP Registry
 # via GitHub OIDC. OIDC needs NO secret: the io.github.TakoData/* namespace is
 # authorized because this repo lives in the TakoData GitHub org.
 #
+# Trigger model: the version lives in code (server.json's "version"), so a merge
+# to main that BUMPS that version publishes automatically. A merge that touches
+# server.json without changing the version (e.g. editing the description) is a
+# no-op — the guard step below skips publishing so the registry never sees a
+# duplicate-version republish. workflow_dispatch publishes the checked-in
+# version on demand.
+#
 # NOTE: ./server.json is the official-registry descriptor (remote streamable-http
 # at mcp.tako.com/mcp; tools are discovered at runtime). It is distinct from
-# registry/server.json, which is the in-repo generated tool catalog used by
+# registry/server.json, the in-repo generated tool catalog used by
 # `npm run registry:gen`/`registry:check`.
 
 on:
   push:
-    tags: ["v*"] # publish on a release tag, e.g. v0.2.0
-  workflow_dispatch: {} # or publish on demand
+    branches: [main]
+    paths: ["server.json"]
+  workflow_dispatch: {}
 
 jobs:
   publish:
@@ -24,23 +32,42 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2 # need the previous commit to diff server.json's version
+
+      # Publish only when server.json's "version" changed in this push (or on a
+      # manual dispatch). Compares the version at HEAD against the version at the
+      # commit before the push (github.event.before). The registry also rejects a
+      # duplicate version as a backstop, but skipping here keeps runs quiet.
+      - name: Detect version bump
+        id: ver
+        run: |
+          CURRENT="$(jq -r .version server.json)"
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch -> publishing version $CURRENT"
+            exit 0
+          fi
+          PREVIOUS="$(git show '${{ github.event.before }}:server.json' 2>/dev/null | jq -r .version 2>/dev/null || echo '')"
+          echo "previous=$PREVIOUS current=$CURRENT"
+          if [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version bump $PREVIOUS -> $CURRENT; publishing."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version unchanged ($CURRENT); skipping publish."
+          fi
 
       - name: Install mcp-publisher
+        if: steps.ver.outputs.changed == 'true'
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
-      # On a release tag, stamp server.json's version from the tag so the
-      # published version matches the tag (the registry rejects re-publishing an
-      # already-published version). On workflow_dispatch, the checked-in version
-      # is published as-is.
-      - name: Sync server.json version to the release tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
-
       - name: Authenticate to the MCP Registry (GitHub OIDC)
+        if: steps.ver.outputs.changed == 'true'
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to the MCP Registry
+        if: steps.ver.outputs.changed == 'true'
         run: ./mcp-publisher publish

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          fetch-depth: 2 # need the previous commit to diff server.json's version
+          # Full history so github.event.before is always present, even on a
+          # multi-commit (non-squash) push — a shallow fetch can leave the
+          # pre-push tip out of history, making the version-diff below misfire.
+          fetch-depth: 0
 
       # Publish only when server.json's "version" changed in this push (or on a
       # manual dispatch). Compares the version at HEAD against the version at the

--- a/README.md
+++ b/README.md
@@ -456,9 +456,11 @@ as a remote server under the name `io.github.TakoData/tako-mcp`.
 - **Publishing** is automated by `.github/workflows/publish-mcp.yml`. It
   authenticates with the registry via **GitHub OIDC** (no secret — the
   `io.github.TakoData/*` namespace is authorized because this repo lives in the
-  TakoData org) and runs `mcp-publisher publish`. It triggers on a `v*` release
-  tag (stamping `server.json`'s version from the tag) or via manual
-  `workflow_dispatch`.
+  TakoData org) and runs `mcp-publisher publish`. **The version lives in code:**
+  bump `server.json`'s `version` and merge to `main` and it publishes
+  automatically. A merge that touches `server.json` without changing the version
+  is a no-op (the workflow skips, so the registry never sees a duplicate). Manual
+  `workflow_dispatch` publishes the checked-in version on demand.
 - **Branded namespace (`com.tako/tako-mcp`)** is an optional future upgrade. It
   requires DNS authentication: generate an Ed25519 key, add a `TXT` record on
   `tako.com`, and swap the workflow's `login github-oidc` step for

--- a/README.md
+++ b/README.md
@@ -443,6 +443,27 @@ The `open_chart_ui` tool returns an MCP-UI resource that clients can render as a
 
 Clients that support MCP-UI (like CopilotKit) will automatically render these resources.
 
+## MCP Registry (maintainers)
+
+Tako is published to the official [MCP Registry](https://registry.modelcontextprotocol.io)
+as a remote server under the name `io.github.TakoData/tako-mcp`.
+
+- **`server.json`** (repo root) is the registry descriptor: a remote
+  `streamable-http` entry pointing at `https://mcp.tako.com/mcp`. The registry
+  schema does not list tools — hosts discover them at runtime via `tools/list`.
+  (This is distinct from `registry/server.json`, the generated in-repo tool
+  catalog used by `npm run registry:gen` / `registry:check`.)
+- **Publishing** is automated by `.github/workflows/publish-mcp.yml`. It
+  authenticates with the registry via **GitHub OIDC** (no secret — the
+  `io.github.TakoData/*` namespace is authorized because this repo lives in the
+  TakoData org) and runs `mcp-publisher publish`. It triggers on a `v*` release
+  tag (stamping `server.json`'s version from the tag) or via manual
+  `workflow_dispatch`.
+- **Branded namespace (`com.tako/tako-mcp`)** is an optional future upgrade. It
+  requires DNS authentication: generate an Ed25519 key, add a `TXT` record on
+  `tako.com`, and swap the workflow's `login github-oidc` step for
+  `login dns --domain tako.com --private-key ${{ secrets.MCP_PRIVATE_KEY }}`.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.

--- a/agent.json
+++ b/agent.json
@@ -2,16 +2,19 @@
   "name": "Tako",
   "description": "Data visualization agent that creates, discovers, and analyzes interactive charts. Searches a knowledge base of 100K+ charts and creates custom visualizations from raw data using 15+ chart types.",
   "url": "https://mcp.tako.com",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "capabilities": {
     "streaming": true,
     "pushNotifications": false
   },
   "authentication": {
-    "schemes": ["apiKey"],
+    "schemes": ["oauth2", "apiKey"],
     "credentials": {
+      "oauth2": {
+        "description": "Web hosts (Claude.ai, ChatGPT) authenticate via the server's OAuth flow."
+      },
       "apiKey": {
-        "description": "Tako API token from tako.com"
+        "description": "CLI/desktop hosts pass a Tako API token from tako.com as a Bearer credential."
       }
     }
   },

--- a/registry/metadata.json
+++ b/registry/metadata.json
@@ -4,13 +4,12 @@
   "name": "tako-mcp",
   "version": "0.2.0",
   "title": "Tako MCP Server",
-  "description": "Create and discover data visualizations. Search Tako's knowledge base of 100K+ charts covering economics, finance, demographics, and technology. Create custom charts from raw data using 15+ chart types including timeseries, bar charts, scatter plots, pie charts, maps, heatmaps, treemaps, and more.",
+  "description": "Search, answer, and fetch data from Tako's knowledge base of 100K+ charts covering economics, finance, demographics, sports, markets, and weather; run deep multi-step research agents; and create custom interactive visualizations using 15+ chart types.",
   "repository": {
     "url": "https://github.com/TakoData/tako-mcp",
     "source": "github"
   },
   "license": "MIT",
-  "runtime": "python",
   "categories": [
     "Data Visualization",
     "Charts",
@@ -31,31 +30,13 @@
       "url": "https://tako.com"
     }
   ],
-  "package": {
-    "type": "pip",
-    "name": "tako-mcp"
-  },
-  "installation": {
-    "pip": {
-      "command": "pip install tako-mcp",
-      "entrypoint": "tako-mcp"
-    },
-    "docker": {
-      "image": "ghcr.io/takodata/tako-mcp:latest",
-      "ports": ["8001:8001"],
-      "environment": {
-        "PUBLIC_BASE_URL": "https://tako.com"
-      }
-    }
-  },
   "transport": {
-    "type": "sse",
-    "endpoint": "/sse",
-    "port": 8001
+    "type": "streamable-http",
+    "url": "https://mcp.tako.com/mcp"
   },
   "authentication": {
-    "type": "api_key",
-    "description": "Tako API token. Sign up at tako.com and create a token in account settings.",
+    "type": "oauth2",
+    "description": "Web hosts (Claude.ai, ChatGPT) connect via the server's OAuth flow. CLI/desktop hosts pass a Tako API token (from tako.com account settings) as a Bearer credential.",
     "setup_url": "https://tako.com"
   },
   "links": {

--- a/registry/server.json
+++ b/registry/server.json
@@ -4,13 +4,12 @@
   "name": "tako-mcp",
   "version": "0.2.0",
   "title": "Tako MCP Server",
-  "description": "Create and discover data visualizations. Search Tako's knowledge base of 100K+ charts covering economics, finance, demographics, and technology. Create custom charts from raw data using 15+ chart types including timeseries, bar charts, scatter plots, pie charts, maps, heatmaps, treemaps, and more.",
+  "description": "Search, answer, and fetch data from Tako's knowledge base of 100K+ charts covering economics, finance, demographics, sports, markets, and weather; run deep multi-step research agents; and create custom interactive visualizations using 15+ chart types.",
   "repository": {
     "url": "https://github.com/TakoData/tako-mcp",
     "source": "github"
   },
   "license": "MIT",
-  "runtime": "python",
   "categories": [
     "Data Visualization",
     "Charts",
@@ -31,33 +30,13 @@
       "url": "https://tako.com"
     }
   ],
-  "package": {
-    "type": "pip",
-    "name": "tako-mcp"
-  },
-  "installation": {
-    "pip": {
-      "command": "pip install tako-mcp",
-      "entrypoint": "tako-mcp"
-    },
-    "docker": {
-      "image": "ghcr.io/takodata/tako-mcp:latest",
-      "ports": [
-        "8001:8001"
-      ],
-      "environment": {
-        "PUBLIC_BASE_URL": "https://tako.com"
-      }
-    }
-  },
   "transport": {
-    "type": "sse",
-    "endpoint": "/sse",
-    "port": 8001
+    "type": "streamable-http",
+    "url": "https://mcp.tako.com/mcp"
   },
   "authentication": {
-    "type": "api_key",
-    "description": "Tako API token. Sign up at tako.com and create a token in account settings.",
+    "type": "oauth2",
+    "description": "Web hosts (Claude.ai, ChatGPT) connect via the server's OAuth flow. CLI/desktop hosts pass a Tako API token (from tako.com account settings) as a Bearer credential.",
     "setup_url": "https://tako.com"
   },
   "tools": [

--- a/registry/smithery.yaml
+++ b/registry/smithery.yaml
@@ -4,11 +4,12 @@
 name: tako-mcp
 title: Tako MCP Server
 description: |
-  Create and discover data visualizations with Tako. Search a knowledge base
-  of 100K+ charts covering economics, finance, demographics, and technology.
-  Create custom charts from raw data using 15+ chart types.
+  Search, answer, and fetch data from Tako's knowledge base of 100K+ charts
+  covering economics, finance, demographics, sports, markets, and weather; run
+  deep multi-step research agents; and create custom interactive visualizations
+  using 15+ chart types.
 
-version: "0.1.0"
+version: "0.2.0"
 license: MIT
 
 author:
@@ -32,70 +33,69 @@ tags:
   - mcp-ui
   - knowledge-base
 
-# Server configuration
+# Hosted remote server: a single Streamable HTTP endpoint on Cloudflare Workers.
+# There is no package to install — clients connect to the URL directly.
 server:
-  transport: sse
-  command: tako-mcp
-  port: 8001
+  type: remote
+  transport: streamable-http
+  url: https://mcp.tako.com/mcp
 
-# Configuration schema (what users need to provide)
+# Authentication. Web hosts (Claude.ai, ChatGPT) connect via the server's OAuth
+# flow. CLI/desktop hosts pass a Tako API token as a Bearer credential.
+authentication:
+  type: oauth2
+  description: >
+    Web hosts authenticate via the server's OAuth flow. CLI/desktop hosts may
+    instead pass a Tako API token (from tako.com account settings) as a Bearer
+    credential — set the optional takoApiToken below.
+
+# Optional configuration (only needed for the Bearer/API-token path).
 configSchema:
   type: object
-  required:
-    - takoApiKey
+  required: []
   properties:
-    takoApiKey:
+    takoApiToken:
       type: string
-      title: Tako API Key
+      title: Tako API Token
       description: >
-        Your Tako API token for authentication. Sign up at tako.com
-        and create a token in your account settings.
+        Optional. A Tako API token for the Bearer auth path used by CLI/desktop
+        hosts. Sign up at tako.com and create a token in your account settings.
+        Web hosts can ignore this and use OAuth instead.
 
-# Docker support
-docker:
-  image: ghcr.io/takodata/tako-mcp:latest
-  ports:
-    - "8001:8001"
-  environment:
-    PUBLIC_BASE_URL: https://tako.com
-
-# Installation methods
-installation:
-  pip:
-    package: tako-mcp
-    command: tako-mcp
-  docker:
-    image: ghcr.io/takodata/tako-mcp:latest
-
-# Tool summary for marketplace listing
+# Tool summary for marketplace listing (primary user-facing tools).
 tools:
-  - name: knowledge_search
-    description: Search charts and data visualizations on any topic
-  - name: get_chart_image
-    description: Get static PNG preview of a chart
-  - name: get_card_insights
-    description: Get AI-generated chart analysis
-  - name: list_chart_schemas
-    description: List available chart templates
-  - name: get_chart_schema
-    description: Get chart type data format details
+  - name: tako_search
+    description: Search Tako's knowledge base for charts and data visualizations on any topic
+  - name: tako_answer
+    description: Get a synthesized answer with supporting Tako chart cards and web sources
+  - name: tako_contents
+    description: Fetch the content behind a result URL (a card's CSV or a page's extracted text)
+  - name: tako_agent
+    description: Run Tako's deep research agent for complex, multi-step data questions
   - name: create_chart
-    description: Create new chart from raw data
+    description: Create a new custom chart from raw data
   - name: open_chart_ui
-    description: Open interactive chart via MCP-UI
+    description: Open an interactive chart via MCP-UI
+  - name: get_chart_image
+    description: Get a static PNG preview of a chart
+  - name: get_credit_balance
+    description: Check the connected account's API credit balance
 
 # Screenshots / examples for marketplace
 examples:
   - title: Search for Charts
     description: Find existing visualizations on any topic
     input: |
-      {"query": "US GDP growth rate", "api_token": "your-token"}
+      {"query": "US GDP growth rate"}
+  - title: Answer a Data Question
+    description: Get a synthesized answer with supporting chart cards
+    input: |
+      {"query": "How have US mortgage rates moved over the past year?"}
   - title: Create a Bar Chart
     description: Create a custom bar chart from your data
     input: |
       {
         "schema_name": "bar_chart",
-        "api_token": "your-token",
         "components": [
           {"component_type": "header", "config": {"title": "Revenue by Region"}},
           {"component_type": "categorical_bar", "config": {"datasets": [{"label": "Revenue", "data": [{"x": "NA", "y": 120}, {"x": "EU", "y": 98}], "units": "$M"}]}}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.TakoData/tako-mcp",
+  "title": "Tako",
+  "description": "Search, answer, and fetch data from Tako's knowledge base of 100K+ charts (economics, finance, demographics, sports, markets, weather), run deep multi-step research agents, and render interactive visualizations — over MCP.",
+  "version": "0.2.0",
+  "repository": {
+    "url": "https://github.com/TakoData/tako-mcp",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.tako.com/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Tako API token as a Bearer credential, e.g. `Bearer <token>` (CLI/desktop hosts such as Claude Code, Cursor, Windsurf). Get one at tako.com -> account settings -> API tokens. Web hosts (Claude.ai, ChatGPT) use the server's OAuth flow instead, so this header is optional.",
+          "isRequired": false,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the concrete repo pieces to list tako-mcp on the official [MCP Registry](https://registry.modelcontextprotocol.io) as a hosted remote server, and automates publishing. This is the discoverability follow-up to the GA tool-parity work (#79) and part of TAKO-3221.

## What this does

- **`server.json`** (repo root) — the official-registry descriptor, conforming to the current `2025-12-11` server schema. A remote `streamable-http` entry pointing at `https://mcp.tako.com/mcp`. The registry schema does **not** list tools; hosts discover them at runtime via `tools/list`. This is intentionally **distinct** from `registry/server.json`, the generated in-repo tool catalog (different schema, includes a `tools[]` array, consumed by `registry:gen`/`registry:check` and Smithery).
- **`.github/workflows/publish-mcp.yml`** — publishes `server.json` via `mcp-publisher`, authenticating with **GitHub OIDC** (no secret). **The version lives in code:** the workflow triggers on a **push to `main` that bumps `server.json`'s `version`** (a guard step compares the version at HEAD vs the pre-push commit and skips publishing when it's unchanged, so non-version edits never trigger a duplicate-version republish). Manual `workflow_dispatch` publishes the checked-in version on demand. No `v*` tag required.
- **`registry/metadata.json` + regenerated `registry/server.json`** — corrects the stale legacy-Python catalog (`runtime: python` / pip / `sse:8001` / `api_key`) to the live remote Worker (`streamable-http` at `mcp.tako.com/mcp`, OAuth + Bearer auth) and refreshes the description for the GA tool surface. `npm run registry:check` is green.
- **`registry/smithery.yaml`** — same staleness fix: remote `streamable-http` server, OAuth + optional Bearer token, GA tool surface, refreshed examples (no more connection-level `api_token`).
- **`agent.json`** — bumped to `0.2.0`; advertises OAuth (web hosts) alongside the API-key Bearer path (CLI/desktop).
- **README** — maintainer section covering the listing, the OIDC publish flow, and the `com.tako`/DNS upgrade path.

## Decisions

- **Namespace `io.github.TakoData/tako-mcp`** (not `com.tako/tako-mcp`). GitHub OIDC authorizes the `io.github.<org>/*` namespace automatically because this repo lives in the TakoData org — **zero secrets, CI-native**. Casing confirmed against the registry source: the OIDC grant is built verbatim from `repository_owner` (`io.github.<owner>/*`) and matched case-sensitively (`strings.HasPrefix`), with no name normalization on publish — so the mixed-case `TakoData` is required to match the grant (lowercasing would break it). The branded `com.tako/*` name needs DNS auth (Ed25519 key + apex `TXT` on tako.com); documented in the README as a future upgrade (swap one workflow step).
- **Two `server.json` files on purpose.** Root = official registry (no tools, remote URL). `registry/server.json` = generated internal/Smithery catalog (tools array). They serve different consumers; the README and workflow comments call this out.

## Lines changed
- Logic/config: ~125 (root `server.json`, workflow, `registry/*`, `agent.json`)
- Tests: 0 (metadata/CI only — no runtime code touched; `registry:check` + `typecheck` are the gates)
- Docs: ~20 (README)

## Test plan
- [x] `npm run registry:gen` regenerates cleanly; `npm run registry:check` → `ok (16 tools)`
- [x] `npm run typecheck` passes
- [x] All JSON parses; workflow YAML sanity-checked
- [ ] **First publish:** merge this PR, then bump `server.json`'s `version` and merge (or run the workflow manually) → confirm the entry appears in the registry. **The MCP Registry is in preview** — verify `mcp-publisher`'s latest CLI flags before the first real publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)