### PR TITLE
fix(registry): shorten server.json description to <=100 chars (first-publish blocker)

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.TakoData/tako-mcp",
   "title": "Tako",
-  "description": "Search, answer, and fetch data from Tako's knowledge base of 100K+ charts (economics, finance, demographics, sports, markets, weather), run deep multi-step research agents, and render interactive visualizations — over MCP.",
+  "description": "Search, answer, and fetch Tako's knowledge base of 100K+ data charts, plus deep research agents.",
   "version": "0.2.0",
   "repository": {
     "url": "https://github.com/TakoData/tako-mcp",


### PR DESCRIPTION
The publish workflow auto-fired on the #80 merge and reached the registry — OIDC login succeeded and the `io.github.TakoData/tako-mcp` namespace was accepted. It failed validation on a single rule:

```
422 Unprocessable Entity — body.description: expected length <= 100
```

Our description was ~222 chars. This trims it to 96:

> Search, answer, and fetch Tako's knowledge base of 100K+ data charts, plus deep research agents.

No other validation errors were returned, so this should clear the first publish. Version stays `0.2.0` (the earlier attempt 422'd before persistence, so nothing was published).

After merge, `0.2.0` does **not** auto-publish (the guard only fires on a version change), so the first publish is a one-time manual `workflow_dispatch` of the Publish workflow. Subsequent releases publish automatically on a `server.json` version bump.

## Lines changed
- Logic/config: 1 (server.json description)
- Tests: 0
- Docs: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)