### PR TITLE
fix(oauth): mint show-once key at consent instead of reading the deleted token endpoint (TAKO-3254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ Before connecting from Claude.ai or ChatGPT:
 1. **Sign up or sign in at [tako.com](https://tako.com).**
 2. **Mint an API token** at tako.com → settings → API tokens.
 
-Step 2 is mandatory: the consent flow looks up your existing token and surfaces a "Your Tako account does not have an API token yet" page if it doesn't find one. Tako does not auto-mint a token during the OAuth dance, because rotating an existing one would break any Claude Code / Cursor wiring you already have on the same account.
+Step 2 is no longer required: the consent flow mints a per-host Tako API key for
+you on first authorize (named "MCP: <client>", visible and revocable at
+trytako.com → settings → API tokens). Minting is additive — connecting a new
+host never rotates another host's key — and Tako trims your oldest MCP key once
+you exceed ten. You only see a "too many API keys" page if your account is at
+the overall key cap, in which case revoke one and reconnect.
 
 ![tako.com Settings → API Key with Regenerate button](docs/images/tako-api-token-generate.png)
 

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -104,10 +104,10 @@ async function mintSessionCookie(
 
 /**
  * Stub `globalThis.fetch` so a server-side call to Tako's
- * `/api/v1/api_token/` endpoint returns the supplied token value.
+ * `/api/v1/internal/mcp/api_key/` endpoint returns the supplied key value.
  * Used by tests that exercise POST /authorize, since that handler now
- * re-fetches the Tako token from the user's Stytch session at consent
- * time (see Option 2 in the OAuth design doc).
+ * mints a Tako API key from the user's Stytch session at consent
+ * time (TAKO-3254).
  */
 function mockTakoTokenFetch(token: string): void {
   vi.stubGlobal(
@@ -119,9 +119,9 @@ function mockTakoTokenFetch(token: string): void {
           : input instanceof URL
             ? input.toString()
             : input.url;
-      if (url.includes("/api/v1/api_token/")) {
-        return new Response(JSON.stringify({ token }), {
-          status: 200,
+      if (url.includes("/api/v1/internal/mcp/api_key/")) {
+        return new Response(JSON.stringify({ key: token }), {
+          status: 201,
           headers: { "content-type": "application/json" },
         });
       }
@@ -133,8 +133,8 @@ function mockTakoTokenFetch(token: string): void {
 }
 
 /**
- * Stub `globalThis.fetch` so Tako's `/api/v1/api_token/` returns the
- * given non-200 status. Used to test the error branches in POST /authorize.
+ * Stub `globalThis.fetch` so Tako's `/api/v1/internal/mcp/api_key/` returns the
+ * given non-201 status. Used to test the error branches in POST /authorize.
  */
 function mockTakoTokenFetchStatus(status: number): void {
   vi.stubGlobal(
@@ -146,7 +146,7 @@ function mockTakoTokenFetchStatus(status: number): void {
           : input instanceof URL
             ? input.toString()
             : input.url;
-      if (url.includes("/api/v1/api_token/")) {
+      if (url.includes("/api/v1/internal/mcp/api_key/")) {
         return new Response("error", { status });
       }
       return new Response(`unmocked fetch: ${url}`, { status: 599 });
@@ -1289,7 +1289,7 @@ describe("/authorize POST always re-fetches the Tako token (Option 2)", () => {
     expect(setCookie).toContain("Max-Age=0");
   });
 
-  it("returns a 400 'mint a Tako token' page when user has no Tako API token", async () => {
+  it("returns a 400 'too many API keys' page when user is at the key cap", async () => {
     const env = envWith();
     const clientId = await mintClientId(env, "https://client.example.com/cb");
     const sessionJwt = await mintSessionCookie(env);
@@ -1301,8 +1301,8 @@ describe("/authorize POST always re-fetches the Tako token (Option 2)", () => {
     url.searchParams.set("code_challenge", challenge);
     url.searchParams.set("code_challenge_method", "S256");
 
-    // 404 from Tako means user hasn't minted a token yet.
-    mockTakoTokenFetchStatus(404);
+    // 400 from Tako means user is at the API-key cap.
+    mockTakoTokenFetchStatus(400);
 
     const res = await handleAuthorize(
       new Request(url.toString(), {

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -156,7 +156,7 @@ function mockTakoTokenFetchStatus(status: number): void {
 
 beforeEach(() => {
   // Every test starts with a fetch stub that resolves Tako's
-  // `/api/v1/api_token/` to a generic token. Tests that need to
+  // `/api/v1/internal/mcp/api_key/` to a generic token. Tests that need to
   // verify a specific token value or test an error path call
   // `mockTakoTokenFetch(...)` / `mockTakoTokenFetchStatus(...)`
   // themselves to override.

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -54,8 +54,8 @@ import {
   type StytchTokenKind,
 } from "./stytch.js";
 import {
-  fetchTakoApiToken,
   IdentityError,
+  mintTakoApiKey,
 } from "./identity.js";
 import {
   buildClearCookie,
@@ -619,15 +619,14 @@ export async function handleAuthorize(
   }
   let takoToken: string;
   try {
-    takoToken = await fetchTakoApiToken(env, stytchSessionJwt);
+    takoToken = await mintTakoApiKey(env, stytchSessionJwt, client.client_name);
   } catch (err) {
     if (err instanceof IdentityError) {
-      if (err.kind === "no_token") {
+      if (err.kind === "at_cap") {
         return htmlResponse(
           sessionExpiredPage(
-            "Your Tako account does not have an API token yet. " +
-              "Visit trytako.com → settings → API tokens to mint one, " +
-              "then retry the connection.",
+            "You have too many active Tako API keys. Revoke one at " +
+              "trytako.com → settings → API tokens, then retry the connection.",
           ),
           400,
         );

--- a/workers/src/oauth/identity.test.ts
+++ b/workers/src/oauth/identity.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { IdentityError, mintTakoApiKey } from "./identity.js";
+
+const env = { DJANGO_BASE_URL: "https://api.example.com" } as never;
+const JWT = "aaa.bbb.ccc"; // passes the JWT-shape guard
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("mintTakoApiKey", () => {
+  it("posts client_name and returns the show-once key", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ key: "tako_sk_RAW" }), { status: 201 }));
+    const key = await mintTakoApiKey(env, JWT, "Claude");
+    expect(key).toBe("tako_sk_RAW");
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe("https://api.example.com/api/v1/internal/mcp/api_key/");
+    expect(init!.method).toBe("POST");
+    expect(JSON.parse(init!.body as string)).toEqual({ client_name: "Claude" });
+    expect((init!.headers as Record<string, string>).cookie).toContain(JWT);
+  });
+
+  it("maps 401 to unauthorized", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 401 }));
+    await expect(mintTakoApiKey(env, JWT, "Claude")).rejects.toMatchObject({ kind: "unauthorized" });
+  });
+
+  it("maps 400 (cap) to at_cap", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ detail: "too many" }), { status: 400 }));
+    await expect(mintTakoApiKey(env, JWT, "Claude")).rejects.toMatchObject({ kind: "at_cap" });
+  });
+
+  it("maps a non-2xx to transport", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 500 }));
+    await expect(mintTakoApiKey(env, JWT, "Claude")).rejects.toMatchObject({ kind: "transport" });
+  });
+
+  it("treats an empty/missing key field as a parse error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ key: "" }), { status: 201 }));
+    await expect(mintTakoApiKey(env, JWT, "Claude")).rejects.toMatchObject({ kind: "parse" });
+  });
+
+  it("rejects a malformed stytch JWT before fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(mintTakoApiKey(env, "not-a-jwt", "Claude")).rejects.toBeInstanceOf(IdentityError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/workers/src/oauth/identity.ts
+++ b/workers/src/oauth/identity.ts
@@ -1,31 +1,28 @@
 /**
- * Bridge between Stytch authentication and Tako API tokens.
+ * Bridge between Stytch authentication and Tako API keys.
  *
- * After a successful Stytch redirect-callback the Worker has a Stytch
- * session JWT identifying the user. Tako's existing `StytchAuthBackend`
- * accepts that same JWT — but only when it arrives in the
- * `stytch_session_jwt` cookie (`request.COOKIES.get(...)` in Django's
- * middleware). The Worker is calling server-to-server, so we send the
- * cookie ourselves via the `Cookie` request header. Django can't tell
- * the difference between a cookie set by a real browser and one set in
- * a server-side request — JWT signature is what authenticates.
+ * After a successful Stytch redirect-callback the Worker has a Stytch session
+ * JWT identifying the user. At OAuth consent we MINT a per-host, show-once Tako
+ * API key for that user and embed it (encrypted) in the issued access token.
  *
- * The endpoint we hit is `GET /api/v1/api_token/` (read-only — never
- * `POST /api/v1/generate_api_token/`, which rotates and would break
- * existing Claude Code users every time they OAuth-connect a new host).
+ * We mint (POST /api/v1/internal/mcp/api_key/) rather than read, because Tako
+ * API keys are hashed and shown exactly once (TAKO-3212) — there is no endpoint
+ * that returns an existing raw key. Minting is additive and the backend
+ * LRU-trims a user's MCP keys, so a fresh key per host never rotates another
+ * host's still-valid key. Django authenticates the call from the
+ * `stytch_session_jwt` cookie we set ourselves (server-to-server).
  */
 
 import type { Env } from "../env.js";
 
-const TAKO_API_TOKEN_PATH = "/api/v1/api_token/";
+const TAKO_MCP_KEY_MINT_PATH = "/api/v1/internal/mcp/api_key/";
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 export type IdentityErrorKind =
   /** Tako returned 401/403 — Stytch JWT was rejected. */
   | "unauthorized"
-  /** User has no API token yet (Tako returned 404 or empty). User must
-   *  mint one at trytako.com → settings before OAuth-connecting. */
-  | "no_token"
+  /** Tako returned 400 — the user is at the API-key cap and must prune keys. */
+  | "at_cap"
   /** Network / timeout / unexpected non-2xx. Caller should 500. */
   | "transport"
   /** 2xx but body shape was unexpected. */
@@ -44,133 +41,83 @@ export class IdentityError extends Error {
 }
 
 /**
- * Strict JWT-shape regex: three base64url segments separated by dots.
- * Used to gate the value before we interpolate it into a `Cookie`
- * header — a stytch JWT containing `\r` or `\n` (theoretically
- * impossible from Stytch, but worth the cheap defense) would otherwise
- * inject headers into the upstream Tako request.
+ * Strict JWT-shape regex: three base64url segments separated by dots. Gates the
+ * value before we interpolate it into a `Cookie` header so a JWT containing
+ * `\r`/`\n` cannot inject headers into the upstream Tako request.
  */
 const STYTCH_JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
 /**
- * Fetch the user's Tako API token by calling `GET /api/v1/api_token/`
- * with the Stytch session JWT in a `Cookie` header. Returns the raw
- * token string. Throws `IdentityError` with a kind discriminator on
- * any failure — callers are expected to map kinds to user-visible
- * error pages (e.g. `no_token` → "go mint a token first").
+ * Mint the user's Tako API key by calling POST /api/v1/internal/mcp/api_key/
+ * with the Stytch session JWT in a `Cookie` header. `clientName` (from the DCR
+ * registration) names the key on the developer page. Returns the raw key.
+ * Throws `IdentityError` with a kind discriminator on any failure.
  */
-export async function fetchTakoApiToken(
+export async function mintTakoApiKey(
   env: Env,
   stytchSessionJwt: string,
+  clientName: string | null,
 ): Promise<string> {
   const base = env.DJANGO_BASE_URL;
   if (typeof base !== "string" || base.length === 0 || base.endsWith("/")) {
-    throw new IdentityError(
-      "transport",
-      "DJANGO_BASE_URL is missing or has a trailing slash",
-    );
+    throw new IdentityError("transport", "DJANGO_BASE_URL is missing or has a trailing slash");
   }
   if (!STYTCH_JWT_SHAPE.test(stytchSessionJwt)) {
-    // Stytch should never return a non-JWT-shaped session token; if it
-    // does, treat it as a transport-level breakage rather than blindly
-    // forwarding to Django where it could splice the Cookie header.
-    throw new IdentityError(
-      "transport",
-      "stytch session JWT is malformed (failed shape check)",
-    );
+    throw new IdentityError("transport", "stytch session JWT is malformed (failed shape check)");
   }
-  const url = `${base}${TAKO_API_TOKEN_PATH}`;
+  const url = `${base}${TAKO_MCP_KEY_MINT_PATH}`;
 
   let response: Response;
   try {
     response = await fetch(url, {
-      method: "GET",
+      method: "POST",
       headers: {
-        // `cookie` is a forbidden request header in browser fetches, but
-        // Workers' fetch implementation allows setting it because the
-        // Worker is acting as a server proxy. Django reads it via
-        // `request.COOKIES.get("stytch_session_jwt")`.
+        // `cookie` is a forbidden browser header, but Workers' fetch allows it
+        // because the Worker is a server proxy. Django reads it via
+        // request.COOKIES.get("stytch_session_jwt").
         cookie: `stytch_session_jwt=${stytchSessionJwt}`,
+        "content-type": "application/json",
         accept: "application/json",
       },
+      body: JSON.stringify({ client_name: clientName }),
       signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     });
   } catch (err) {
-    if (
-      err instanceof DOMException &&
-      (err.name === "AbortError" || err.name === "TimeoutError")
-    ) {
-      throw new IdentityError(
-        "transport",
-        `Tako ${TAKO_API_TOKEN_PATH} timed out after ${DEFAULT_TIMEOUT_MS}ms`,
-      );
+    if (err instanceof DOMException && (err.name === "AbortError" || err.name === "TimeoutError")) {
+      throw new IdentityError("transport", `Tako ${TAKO_MCP_KEY_MINT_PATH} timed out after ${DEFAULT_TIMEOUT_MS}ms`);
     }
     throw new IdentityError(
       "transport",
-      `Tako ${TAKO_API_TOKEN_PATH} fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      `Tako ${TAKO_MCP_KEY_MINT_PATH} fetch failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
-  // 401/403 = Stytch session rejected by Django. Should be rare since we
-  // just minted the JWT, but possible if Stytch and Django have skewed
-  // clocks or the project ID/secret pair is mismatched between the
-  // Worker's Stytch credentials and Django's.
   if (response.status === 401 || response.status === 403) {
-    throw new IdentityError(
-      "unauthorized",
-      `Tako rejected the Stytch session JWT (status ${response.status})`,
-      response.status,
-    );
+    throw new IdentityError("unauthorized", `Tako rejected the Stytch session JWT (status ${response.status})`, response.status);
   }
 
-  // 404 = user has no Token row yet. The user-facing fix is to visit
-  // trytako.com → API tokens to mint one. We never call the generate
-  // endpoint from here because it rotates, which would invalidate any
-  // existing Claude Code wiring.
-  if (response.status === 404) {
-    throw new IdentityError(
-      "no_token",
-      "user has no Tako API token; must mint one at trytako.com first",
-      404,
-    );
+  // 400 = the user is at the API-key cap. The fix is to revoke a key on the
+  // developer page, not to retry.
+  if (response.status === 400) {
+    throw new IdentityError("at_cap", "user is at the Tako API-key cap; must revoke a key first", 400);
   }
 
   if (!response.ok) {
-    throw new IdentityError(
-      "transport",
-      `Tako ${TAKO_API_TOKEN_PATH} returned ${response.status}`,
-      response.status,
-    );
+    throw new IdentityError("transport", `Tako ${TAKO_MCP_KEY_MINT_PATH} returned ${response.status}`, response.status);
   }
 
   let body: unknown;
   try {
     body = await response.json();
   } catch {
-    throw new IdentityError(
-      "parse",
-      `Tako ${TAKO_API_TOKEN_PATH} returned 2xx with non-JSON body`,
-      response.status,
-    );
+    throw new IdentityError("parse", `Tako ${TAKO_MCP_KEY_MINT_PATH} returned 2xx with non-JSON body`, response.status);
   }
-
   if (typeof body !== "object" || body === null) {
-    throw new IdentityError(
-      "parse",
-      `Tako ${TAKO_API_TOKEN_PATH} response was not an object`,
-      response.status,
-    );
+    throw new IdentityError("parse", `Tako ${TAKO_MCP_KEY_MINT_PATH} response was not an object`, response.status);
   }
-  const token = (body as Record<string, unknown>)["token"];
-  if (typeof token !== "string" || token.length === 0) {
-    // 200 with empty/missing token field — treat as "user has no token"
-    // rather than a parse error. Some Django implementations return 200
-    // with `{"token": null}` for this case.
-    throw new IdentityError(
-      "no_token",
-      "user has no Tako API token (server returned empty/missing token field)",
-      response.status,
-    );
+  const key = (body as Record<string, unknown>)["key"];
+  if (typeof key !== "string" || key.length === 0) {
+    throw new IdentityError("parse", `Tako ${TAKO_MCP_KEY_MINT_PATH} returned an empty/missing key field`, response.status);
   }
-  return token;
+  return key;
 }

--- a/workers/src/oauth/identity.ts
+++ b/workers/src/oauth/identity.ts
@@ -52,6 +52,10 @@ const STYTCH_JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
  * with the Stytch session JWT in a `Cookie` header. `clientName` (from the DCR
  * registration) names the key on the developer page. Returns the raw key.
  * Throws `IdentityError` with a kind discriminator on any failure.
+ *
+ * `clientName` may be `null` or empty string — the backend normalizes a
+ * blank/missing name to "MCP: OAuth client", so passing `null`/`""` is an
+ * intentional, supported pass-through when the DCR client did not supply a name.
  */
 export async function mintTakoApiKey(
   env: Env,


### PR DESCRIPTION
The **Worker half** of the TAKO-3254 fix: every new OAuth connection (Claude.ai, ChatGPT, Smithery) currently fails because the consent flow reads a Tako token from `GET /api/v1/api_token/`, which TAKO-3212 deleted (API keys are now hashed + show-once and can't be read back).

The Worker already captures a credential once at consent and encrypts it into the access-token claim — only the *capture* step is wrong. This PR changes it from a **read** to a **mint**.

Backend half (the endpoint this calls): [tako#26646](https://github.com/TakoData/tako/pull/26646).

## What changes
- **`mintTakoApiKey`** replaces `fetchTakoApiToken` in `workers/src/oauth/identity.ts` — POSTs to `POST /api/v1/internal/mcp/api_key/` with the Stytch cookie and `{client_name}`, reads the show-once `key`. Error kinds become `unauthorized | at_cap | transport | parse` (the `no_token` kind is gone). The JWT-shape cookie-injection guard and the request timeout are preserved.
- **Consent handler** (`workers/src/oauth/handlers.ts`) now calls `mintTakoApiKey(env, stytchSessionJwt, client.client_name)` and renders an `at_cap` page (400, "too many API keys — revoke one") in place of the old `no_token` page. The encrypt-into-claim path and the refresh flow are unchanged — **refresh never re-mints**.
- **README** rationale updated: the consent flow mints a per-host key (`MCP: <client>`, visible/revocable on the dev page); additive, with the oldest MCP key trimmed past ten.

## Deploy order
**Merge this only after [tako#26646](https://github.com/TakoData/tako/pull/26646) is deployed** — this Worker calls that endpoint, so it must be live first or consent would 404.

## Testing
- New `identity.test.ts` (6): success reads `key` + posts `client_name`; 401 to `unauthorized`; 400 to `at_cap`; 5xx to `transport`; empty key to `parse`; malformed JWT rejected before fetch.
- `handlers.test.ts` mocks updated to the new endpoint/201/`{key}` shape; the former `no_token` test now exercises the `at_cap` 400 path.
- Full suite: 246 passed; `typecheck` clean; `registry:check` ok (16 tools).
- Final whole-branch review: ready to merge (no Critical/Important).

## Lines changed
- Logic: ~95 (identity.ts rewrite, handlers wiring)
- Tests: ~80 (new identity.test.ts, handlers.test.ts updates)
- Docs: ~7 (README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
