### PR TITLE
fix(mcp): clean post-deploy + Smithery scan — smoke rename, empty prompts, Smithery backlink

### DIFF
--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -8,7 +8,7 @@
  *   2. MCP `initialize`        → handshake completes
  *   3. MCP `tools/list`        → at least one tool, includes the canary set
  *   4. Per-tool MCP `tools/call` canaries (read-only unless noted):
- *        a. `knowledge_search "US GDP"`        — non-empty results, requires
+ *        a. `tako_search "US GDP"`        — non-empty results, requires
  *                                                at least one usable
  *                                                `card_id` (fails the smoke
  *                                                if every result lacks one
@@ -160,7 +160,7 @@ try {
   // assert on the *full* tool list because the surface evolves (e.g.
   // explore_knowledge_graph removal in PR #47).
   const requiredTools = [
-    "knowledge_search",
+    "tako_search",
     "get_credit_balance",
     "list_reports",
     "get_chart_image",
@@ -214,8 +214,8 @@ try {
     }
   }
 
-  // ----- a) knowledge_search canary --------------------------------------
-  const ksResult = await callOk(client, "knowledge_search", {
+  // ----- a) tako_search canary --------------------------------------
+  const ksResult = await callOk(client, "tako_search", {
     query: CANARY_QUERY,
   });
   const ksStructured = ksResult.structuredContent as
@@ -224,18 +224,18 @@ try {
         count?: number;
       }
     | undefined;
-  assert(ksStructured, "knowledge_search missing structuredContent");
+  assert(ksStructured, "tako_search missing structuredContent");
   const ksResults = ksStructured.results;
   assert(
     Array.isArray(ksResults) && ksResults.length > 0,
-    `knowledge_search returned empty results (count=${ksStructured.count ?? "?"})`,
+    `tako_search returned empty results (count=${ksStructured.count ?? "?"})`,
   );
   ok(
-    `knowledge_search "${CANARY_QUERY}" → ${ksStructured.count ?? ksResults.length} results`,
+    `tako_search "${CANARY_QUERY}" → ${ksStructured.count ?? ksResults.length} results`,
   );
 
   // Pull the first non-null card_id to chain into get_chart_image /
-  // open_chart_ui. We *require* at least one chartable card — knowledge_search
+  // open_chart_ui. We *require* at least one chartable card — tako_search
   // returning results-without-card_ids for "US GDP" is itself a pipeline
   // regression worth flagging (e.g., raw deep-research outputs leaking
   // through without indexer attribution), so we fail rather than skip the
@@ -245,7 +245,7 @@ try {
     .find((id): id is string => typeof id === "string" && id.length > 0);
   assert(
     chainPubId,
-    `knowledge_search "${CANARY_QUERY}" returned ${ksResults.length} results but none had a usable card_id — chart-tool chaining is broken`,
+    `tako_search "${CANARY_QUERY}" returned ${ksResults.length} results but none had a usable card_id — chart-tool chaining is broken`,
   );
 
   // ----- b) get_credit_balance ------------------------------------------

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -567,4 +567,24 @@ describe("worker routing", () => {
     };
     expect(parsed.pub_id).toBe("abc123");
   });
+
+  it("POST /mcp prompts/list returns an empty list (not -32601) for capability-probing clients", async () => {
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 4, method: "prompts/list", params: {} }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result?: { prompts: unknown[] }; error?: { code: number } };
+    // Must NOT be JSON-RPC -32601 "Method not found" — that is the warning
+    // Smithery's capability scan surfaces. We expose no prompts, so an empty
+    // list is the friendly, spec-clean response.
+    expect(body.error).toBeUndefined();
+    expect(body.result?.prompts).toEqual([]);
+  });
 });

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -4,6 +4,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 // `./validation/cfworker`, unlike the other server subpaths which do ship
 // `.js` entries. Adding the extension here breaks module resolution.
 import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
+import { ListPromptsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import {
   BearerAuthError,
@@ -149,6 +150,15 @@ export function createMcpServer(
       jsonSchemaValidator: JSON_SCHEMA_VALIDATOR,
     },
   );
+
+  // Advertise an empty prompt list. We expose no prompts, but capability-probing
+  // clients (Smithery's scan, some hosts) call `prompts/list` regardless; without
+  // the prompts capability the SDK answers JSON-RPC -32601, which surfaces as a
+  // "Failed to list prompts" warning. Returning {prompts: []} is the friendly,
+  // spec-clean answer. (tools/resources capabilities are auto-registered by the
+  // SDK as those modules are registered below.)
+  server.server.registerCapabilities({ prompts: {} });
+  server.server.setRequestHandler(ListPromptsRequestSchema, () => ({ prompts: [] }));
 
   // Dedupe state for `appUiResource` registration — multiple tools can
   // declare the same widget URI (e.g. `open_chart_ui` and


### PR DESCRIPTION
Two small fixes so the deployed Worker scans clean (post-deploy smoke + Smithery capability scan).

## 1. Smoke: `knowledge_search` → `tako_search`
The post-deploy smoke (`workers-smoke`) fails on every deploy because `scripts/smoke.ts` still references the legacy tool name `knowledge_search`, renamed to `tako_search` in #79. The staging smoke after #82 failed with:

```
✘ tools/list does not include knowledge_search (got: …, tako_search, …)
```

Renamed all 9 references (required-tools assertion + the canary `tools/call`). `tako_search` keeps the same `{query}` input / `{results, count, card_id}` output, so the canary logic is unchanged.

## 2. MCP: empty `prompts/list` instead of `-32601`
Smithery's capability scan (and some hosts) call `prompts/list` even though we expose no prompts. Without a prompts capability the SDK answers JSON-RPC `-32601`, which surfaces as:

```
Warning: Failed to list prompts: MCP error -32601: Method not found
```

Now `createMcpServer` registers the `prompts` capability + a `ListPrompts` handler returning `{prompts: []}` — the friendly, spec-clean response. Added a routing test asserting `prompts/list` → empty list (no error).

## Testing
- `npm run typecheck` clean; full suite **241 passed** (incl. the new prompts/list routing test).

## Lines changed
- Logic: ~3 (empty prompts capability in `mcp.ts`)
- Tests/CI: ~39 (smoke rename + new routing test)
- Docs: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)