### PR TITLE
docs(readme): add Smithery server backlink for ownership verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,5 +478,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 ## Links
 
 - [Tako](https://tako.com) - Data visualization platform
+- [Tako on Smithery](https://smithery.ai/servers/tako/tako) - MCP server listing
+- [Tako on the MCP Registry](https://registry.modelcontextprotocol.io) - `io.github.TakoData/tako-mcp`
 - [MCP Specification](https://spec.modelcontextprotocol.io/) - Model Context Protocol
 - [MCP-UI](https://mcpui.dev/) - MCP UI rendering standard


### PR DESCRIPTION
Adds a link to the Tako Smithery server page so Smithery's **ownership verification** finds a backlink in the README (it scans the default branch). This was authored alongside #83 but pushed just after that PR merged, so it missed the merge — hence this follow-up.

Adds to the README Links section:
- `https://smithery.ai/servers/tako/tako` — the Smithery listing
- `https://registry.modelcontextprotocol.io` — the official MCP Registry entry (`io.github.TakoData/tako-mcp`)

Once merged to `main`, re-run Smithery's "check again" and the backlink requirement is satisfied. (The separate `smithery-verification` TXT record on `developer.tako.com` is a Cloudflare DNS change, handled out-of-band.)

## Lines changed
- Logic: 0
- Tests: 0
- Docs: 2 (README Links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)