### PR TITLE
feat(tako_search): add sources param + web_results output

### DIFF
--- a/registry/server.json
+++ b/registry/server.json
@@ -394,6 +394,13 @@
           "description": "Maximum number of matching cards to return (1-20).",
           "default": 10
         },
+        "sources": {
+          "type": "array",
+          "description": "Which source(s) to search: `[\"tako\"]` (default) returns curated knowledge cards that render as charts; `[\"tako\",\"web\"]` also returns live web results; `[\"web\"]` returns web results only. Web results come back in `web_results` (they are not chartable cards). Deep research (the fast→deep escalation and `search_effort: \"deep\"`) applies to the `tako` source only.",
+          "default": [
+            "tako"
+          ]
+        },
         "search_effort": {
           "type": "string",
           "description": "Search depth: `fast` (lexical, sync, cheap) or `deep` (Orca research pipeline, async, slower, runs up to ~5 min server-side). Omit to run `fast` first and auto-escalate to `deep` only if `fast` returns no cards.",

--- a/workers/src/tools/_async_search_shape.ts
+++ b/workers/src/tools/_async_search_shape.ts
@@ -31,6 +31,16 @@ export type KnowledgeCard = {
   source?: string | null;
 };
 
+// A web result returned alongside knowledge cards when the search includes the
+// `web` source. Mirrors the backend `outputs.web_results[]` shape (the
+// knowledge_search GA view returns `{title, url, snippet, source_name}`).
+export type WebResult = {
+  title?: string | null;
+  url?: string | null;
+  snippet?: string | null;
+  source_name?: string | null;
+};
+
 // Append-only progress event log entry emitted by `run_knowledge_agent_search`
 // (Tako's Celery task). Surfaced in error / timeout messages so the
 // caller knows how far the pipeline got.
@@ -48,6 +58,7 @@ export type AsyncTaskStatus = {
   result?: {
     outputs?: {
       knowledge_cards?: KnowledgeCard[];
+      web_results?: WebResult[];
     };
   };
   error?: string;
@@ -63,6 +74,7 @@ export type AsyncTaskInitiation = {
 export type SyncSearchResponse = {
   outputs?: {
     knowledge_cards?: KnowledgeCard[];
+    web_results?: WebResult[];
   };
 };
 
@@ -152,6 +164,18 @@ export const visualizationSchema = z.object({
 
 export type Visualization = z.infer<typeof visualizationSchema>;
 
+// Web result shape returned to the agent when the search includes the `web`
+// source. Lenient (every field nullable/optional) so a malformed backend web
+// result can't fail the whole tool-output validation.
+export const webResultSchema = z
+  .object({
+    title: z.string().nullable().optional(),
+    url: z.string().nullable().optional(),
+    snippet: z.string().nullable().optional(),
+    source_name: z.string().nullable().optional(),
+  })
+  .loose();
+
 // Auto-chain widget fields lifted to the output root when the top card
 // has a card_id. Mirrors `open_chart_ui`'s output so the chart widget
 // reads the same keys on every tool that may render a chart.
@@ -177,6 +201,10 @@ export const autoChainShape = {
 export const resultsOutputShape = {
   results: z.array(visualizationSchema),
   count: z.number().int().nonnegative(),
+  // Web results when the search included the `web` source; defaults to [] so
+  // tools that only ever return cards (e.g. wait_for_knowledge_search) stay
+  // valid against this shape without setting the field.
+  web_results: z.array(webResultSchema).default([]),
   ...autoChainShape,
 } as const;
 
@@ -208,9 +236,11 @@ export function cardToVisualization(card: KnowledgeCard): Visualization {
 export function buildResultsWithAutoChain(
   cards: KnowledgeCard[],
   env: Env,
+  webResults: WebResult[] = [],
 ): {
   results: Visualization[];
   count: number;
+  web_results: WebResult[];
   pub_id?: string;
   embed_url?: string;
   image_url?: string;
@@ -229,6 +259,7 @@ export function buildResultsWithAutoChain(
     return {
       results,
       count: results.length,
+      web_results: webResults,
       pub_id: topCardId,
       embed_url,
       image_url,
@@ -237,5 +268,5 @@ export function buildResultsWithAutoChain(
       height: DEFAULT_HEIGHT,
     };
   }
-  return { results, count: results.length };
+  return { results, count: results.length, web_results: webResults };
 }

--- a/workers/src/tools/tako_search.test.ts
+++ b/workers/src/tools/tako_search.test.ts
@@ -50,7 +50,7 @@ const CTX: ToolContext = {
 };
 
 // Defaults the handler expects post-zod parse. count is 10 after this change.
-const DEFAULTS = { count: 10, country_code: "US", locale: "en-US" };
+const DEFAULTS = { count: 10, sources: ["tako"] as ("tako" | "web")[], country_code: "US", locale: "en-US" };
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -844,5 +844,85 @@ describe("tako_search auto-chain top-result chart fields", () => {
     expect(out.pub_id).toBeUndefined();
     expect(out.embed_url).toBeUndefined();
     expect(out.results).toEqual([]);
+  });
+});
+
+describe("tako_search sources + web_results", () => {
+  it("passes the requested sources through as source_indexes", async () => {
+    // Return a card so the fast hit stands (no deep escalation), keeping this
+    // a single-call assertion on the request body.
+    const fetchMock = mockFetchSequence([
+      jsonResponse(200, {
+        outputs: {
+          knowledge_cards: [
+            { card_id: "abc", title: "US GDP", description: null, url: null, source: "tako" },
+          ],
+          web_results: [],
+        },
+      }),
+    ]);
+
+    await tako_search.handler(
+      { query: "us gdp", ...DEFAULTS, sources: ["tako", "web"] },
+      CTX,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = await bodyOf(requestFrom(fetchMock.mock.calls[0]));
+    expect(body.source_indexes).toEqual(["tako", "web"]);
+  });
+
+  it("surfaces web_results from the response in the output", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse(200, {
+        outputs: {
+          knowledge_cards: [
+            { card_id: "abc", title: "US GDP", description: null, url: null, source: "tako" },
+          ],
+          web_results: [
+            { title: "BEA GDP release", url: "https://bea.gov/gdp", snippet: "…", source_name: "BEA" },
+          ],
+        },
+      }),
+    ]);
+
+    const out = await tako_search.handler(
+      { query: "us gdp", ...DEFAULTS, sources: ["tako", "web"] },
+      CTX,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(out.web_results).toHaveLength(1);
+    expect(out.web_results[0]?.url).toBe("https://bea.gov/gdp");
+    expect(out.results[0]?.card_id).toBe("abc");
+  });
+
+  it("does not escalate or throw for a web-only search that returns web results but zero cards", async () => {
+    const fetchMock = mockFetchSequence([
+      jsonResponse(200, {
+        outputs: {
+          knowledge_cards: [],
+          web_results: [
+            { title: "A result", url: "https://example.com/a", snippet: null, source_name: "example" },
+          ],
+        },
+      }),
+    ]);
+
+    const out = await tako_search.handler(
+      { query: "obscure web topic", ...DEFAULTS, sources: ["web"] },
+      // ChatGPT path would normally throw on zero cards; web-only must not.
+      { ...CTX, client: "chatgpt" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no deep escalation
+    expect(out.count).toBe(0);
+    expect(out.web_results).toHaveLength(1);
+  });
+
+  it("defaults sources to [tako] (curated cards only)", () => {
+    const parsed = tako_search.inputSchema.safeParse({ query: "x" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.sources).toEqual(["tako"]);
   });
 });

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -50,6 +50,7 @@ import {
   FAILURE_STATES,
   type KnowledgeCard,
   type SearchPostResponse,
+  type WebResult,
   buildResultsWithAutoChain,
   isAsyncTaskInitiation,
   isTransientStatusError,
@@ -157,6 +158,13 @@ const inputSchema = z.object({
     .max(20)
     .default(10)
     .describe("Maximum number of matching cards to return (1-20)."),
+  sources: z
+    .array(z.enum(["tako", "web"]))
+    .min(1)
+    .default(["tako"])
+    .describe(
+      'Which source(s) to search: `["tako"]` (default) returns curated knowledge cards that render as charts; `["tako","web"]` also returns live web results; `["web"]` returns web results only. Web results come back in `web_results` (they are not chartable cards). Deep research (the fast→deep escalation and `search_effort: "deep"`) applies to the `tako` source only.',
+    ),
   search_effort: z
     .enum(["fast", "deep"])
     .optional()
@@ -195,7 +203,7 @@ const tako_search = {
     ): Promise<SearchPostResponse> => {
       const body = {
         inputs: { text: input.query, count: input.count },
-        source_indexes: ["tako"],
+        source_indexes: input.sources,
         search_effort: effort,
         country_code: input.country_code,
         locale: input.locale,
@@ -273,28 +281,39 @@ const tako_search = {
     // First call: fast (default) or deep (explicit, only reachable
     // on clients with progress support after the guard above).
     const initialEffort: "fast" | "deep" = input.search_effort ?? "fast";
-    let cards = await (async () => {
-      const initial = await runSearch(initialEffort);
-      if (isAsyncTaskInitiation(initial)) {
-        return pollDeep(ctx, initial.task_id);
+    const extract = async (
+      resp: SearchPostResponse,
+    ): Promise<{ cards: KnowledgeCard[]; webResults: WebResult[] }> => {
+      if (isAsyncTaskInitiation(resp)) {
+        return pollDeep(ctx, resp.task_id);
       }
-      return initial.outputs?.knowledge_cards ?? [];
-    })();
+      return {
+        cards: resp.outputs?.knowledge_cards ?? [],
+        webResults: resp.outputs?.web_results ?? [],
+      };
+    };
+
+    let { cards, webResults } = await extract(await runSearch(initialEffort));
+
+    // Deep research (the auto-escalation + the ChatGPT empty-redirect below)
+    // targets the `tako` source — it finds knowledge cards. A search that
+    // didn't ask for `tako`, or that already returned web results, has nothing
+    // to escalate, so both gates also require `tako` in `sources` and zero web
+    // results. With the default `sources: ["tako"]`, web results are always
+    // empty, so this preserves the original tako-only escalation behavior.
+    const wantsTako = input.sources.includes("tako");
 
     // Auto-escalation: omitted effort + empty fast → deep, EXCEPT
     // on ChatGPT (where the kickoff/wait flow is the agent's path
     // for deep — see the explicit-deep guard above).
     if (
       input.search_effort === undefined &&
+      wantsTako &&
       cards.length === 0 &&
+      webResults.length === 0 &&
       ctx.client !== "chatgpt"
     ) {
-      const escalated = await runSearch("deep");
-      if (isAsyncTaskInitiation(escalated)) {
-        cards = await pollDeep(ctx, escalated.task_id);
-      } else {
-        cards = escalated.outputs?.knowledge_cards ?? [];
-      }
+      ({ cards, webResults } = await extract(await runSearch("deep")));
     }
 
     // ChatGPT-specific empty-result redirect. Server-side
@@ -328,7 +347,9 @@ const tako_search = {
     // for ChatGPT).
     if (
       input.search_effort === undefined &&
+      wantsTako &&
       cards.length === 0 &&
+      webResults.length === 0 &&
       ctx.client === "chatgpt"
     ) {
       throw new Error(
@@ -336,7 +357,7 @@ const tako_search = {
       );
     }
 
-    return buildResultsWithAutoChain(cards, ctx.env);
+    return buildResultsWithAutoChain(cards, ctx.env, webResults);
   },
   async extraMeta(output, ctx) {
     // Skip the fetch on ChatGPT: its widget bundle takes the iframe
@@ -383,7 +404,7 @@ const tako_search = {
 async function pollDeep(
   ctx: ToolContext,
   taskId: string,
-): Promise<KnowledgeCard[]> {
+): Promise<{ cards: KnowledgeCard[]; webResults: WebResult[] }> {
   const startedAt = Date.now();
   let nextSinceIndex = 0;
   let latestEvents: AsyncTaskEvent[] = [];
@@ -457,7 +478,10 @@ async function pollDeep(
     }
 
     if (normalizedStatus === COMPLETED_STATE) {
-      return status.result?.outputs?.knowledge_cards ?? [];
+      return {
+        cards: status.result?.outputs?.knowledge_cards ?? [],
+        webResults: status.result?.outputs?.web_results ?? [],
+      };
     }
 
     if (FAILURE_STATES.has(normalizedStatus)) {


### PR DESCRIPTION
Closes the gap where `tako_search` could only return curated Tako cards — it was hardcoded to `source_indexes: ["tako"]` and dropped web results, so MCP users could blend tako+web only via `tako_answer`, not search.

The legacy `/api/v1/knowledge_search` endpoint already returns `outputs.web_results`, so this is purely a Worker change — **no need to move `tako_search` to `/api/v3/search`** (which is fast-only today and would lose deep search; TAKO-3183).

## Changes
- **`sources` input param** (`["tako"]` / `["web"]` / `["tako","web"]`, default `["tako"]`), passed through as `source_indexes`. Default preserves the chart-first behavior.
- **`web_results` in the output** — added to the shared results output shape with `.default([])` so the deep split tools (`wait_for_knowledge_search`) stay valid without changes; threaded through both the fast and deep/async paths.
- **Escalation gating** — the deep auto-escalation and the ChatGPT empty-redirect now require `tako` in `sources` **and** zero cards **and** zero web results, so a web-only search (or one that already returned web results) no longer pointlessly escalates the tako deep pipeline or discards web hits. With the default `["tako"]`, behavior is unchanged.

## Testing
- 4 new tests (sources→source_indexes pass-through, web_results surfaced, web-only doesn’t escalate/throw on 0 cards, default sources `["tako"]`).
- Full suite **251 passed**; `typecheck` + `registry:check` clean; `registry/server.json` regenerated.

Docs follow-up: TakoData/docs#269 updated to document the `sources` param + `web_results` on the search tool.

## Lines changed
- Logic: ~45 (`tako_search.ts`, `_async_search_shape.ts`)
- Tests: ~75
- Generated: `registry/server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)