### PR TITLE
chore(tako_search): rename display title to "Tako: Search"

### DIFF
--- a/registry/server.json
+++ b/registry/server.json
@@ -197,7 +197,7 @@
         }
       },
       "annotations": {
-        "title": "Tako: Live Data & Charts",
+        "title": "Tako: Search",
         "readOnlyHint": true,
         "destructiveHint": false,
         "openWorldHint": false

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -79,7 +79,7 @@ const tako_search = {
   inputSchema,
   outputSchema,
   annotations: {
-    title: "Tako: Live Data & Charts",
+    title: "Tako: Search",
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: false,


### PR DESCRIPTION
## Summary

Rename the `tako_search` MCP tool's **display title** from **"Tako: Live Data & Charts"** to **"Tako: Search"** — plainer, and consistent with the sibling `Tako: <verb>` convention (`Tako: Answer`, `Tako: Fetch Contents`, `Tako: Deep Agent`, …).

This is the label Claude / ChatGPT show in the tool list (`annotations.title`). The tool `name` (`tako_search`), its input/output schema, and its behavior are **unchanged** — only `annotations.title` and the regenerated `registry/server.json` entry change.

The new title appears in clients after the worker deploys (staging auto-deploys on merge to `main`; prod is a manual `workers-deploy` dispatch).

## Lines changed

- **Logic:** +1 / −1 (`workers/src/tools/tako_search.ts` — `annotations.title`)
- **Generated:** +1 / −1 (`registry/server.json`)
- **Tests / docs:** none

## Testing

`npm run typecheck` ✅ · `npm test` (171) ✅ · `npm run registry:check` ok (7 tools) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1VG7jkDh8kPLYyZsby8f2
