### PR TITLE
fix(mcp): unmask Django errors by moving detail to _meta, not structuredContent

### DIFF
--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -11,6 +11,24 @@ import {
 import { djangoErrorToToolResult } from "./mcp.js";
 
 describe("djangoErrorToToolResult", () => {
+  // Read tools (tako_search/tako_answer/tako_contents) declare an
+  // `outputSchema`. Spec-compliant MCP clients validate ANY
+  // `structuredContent` present on a result against that schema — even when
+  // `isError: true` — so attaching the error discriminant as
+  // `structuredContent` made every Django error get rejected with a generic
+  // `-32602` (masking the real failure). The machine-readable detail now
+  // rides on `_meta["tako/error"]`, which clients forward but do NOT validate.
+  it("omits structuredContent so clients validating against outputSchema don't reject the error", () => {
+    const err = new DjangoHttpError({
+      path: "/api/v3/search/",
+      method: "POST",
+      status: 503,
+      body: "service unavailable",
+    });
+    const result = djangoErrorToToolResult(err);
+    expect(result).not.toHaveProperty("structuredContent");
+  });
+
   it("maps DjangoUnauthorizedError to kind=unauthorized with status 401", () => {
     const err = new DjangoUnauthorizedError({
       path: "/api/v1/knowledge_search",
@@ -18,7 +36,7 @@ describe("djangoErrorToToolResult", () => {
     });
     const result = djangoErrorToToolResult(err);
     expect(result.isError).toBe(true);
-    expect(result.structuredContent).toEqual({
+    expect(result._meta["tako/error"]).toEqual({
       kind: "unauthorized",
       path: "/api/v1/knowledge_search",
       method: "GET",
@@ -34,14 +52,14 @@ describe("djangoErrorToToolResult", () => {
       timeoutMs: 90_000,
     });
     const result = djangoErrorToToolResult(err);
-    expect(result.structuredContent).toEqual({
+    expect(result._meta["tako/error"]).toEqual({
       kind: "timeout",
       path: "/api/v1/insights",
       method: "POST",
       timeoutMs: 90_000,
     });
     // No `status` — timeouts have no HTTP status by construction.
-    expect(result.structuredContent).not.toHaveProperty("status");
+    expect(result._meta["tako/error"]).not.toHaveProperty("status");
   });
 
   it("maps DjangoNotFoundError to kind=not_found with status 404", () => {
@@ -50,7 +68,7 @@ describe("djangoErrorToToolResult", () => {
       method: "GET",
     });
     const result = djangoErrorToToolResult(err);
-    expect(result.structuredContent).toEqual({
+    expect(result._meta["tako/error"]).toEqual({
       kind: "not_found",
       path: "/api/v1/charts/missing",
       method: "GET",
@@ -58,14 +76,14 @@ describe("djangoErrorToToolResult", () => {
     });
   });
 
-  it("maps DjangoBadRequestError and surfaces the response body in both structured and text content", () => {
+  it("maps DjangoBadRequestError and surfaces the response body in both _meta and text content", () => {
     const err = new DjangoBadRequestError({
       path: "/api/v3/search/",
       method: "POST",
       body: '{"query":["this field is required"]}',
     });
     const result = djangoErrorToToolResult(err);
-    expect(result.structuredContent).toEqual({
+    expect(result._meta["tako/error"]).toEqual({
       kind: "bad_request",
       path: "/api/v3/search/",
       method: "POST",
@@ -74,7 +92,7 @@ describe("djangoErrorToToolResult", () => {
     });
     // 400s are the only subtype whose body is spliced into `content[0].text`:
     // DRF validation errors carry the guidance the LLM needs to retry, and
-    // not every MCP client surfaces `structuredContent` to the model.
+    // not every MCP client surfaces structured detail to the model.
     expect(result.content[0]).toEqual({
       type: "text",
       text: `${err.message}: {"query":["this field is required"]}`,
@@ -89,7 +107,7 @@ describe("djangoErrorToToolResult", () => {
       cause: new Error("unexpected token"),
     });
     const result = djangoErrorToToolResult(err);
-    expect(result.structuredContent).toEqual({
+    expect(result._meta["tako/error"]).toEqual({
       kind: "response_parse",
       path: "/api/v1/knowledge_search",
       method: "GET",
@@ -97,7 +115,7 @@ describe("djangoErrorToToolResult", () => {
     });
   });
 
-  it("maps DjangoHttpError (catch-all) and surfaces the response body", () => {
+  it("maps DjangoHttpError (catch-all) and surfaces the response body in _meta", () => {
     const err = new DjangoHttpError({
       path: "/api/v1/whatever",
       method: "GET",
@@ -105,16 +123,16 @@ describe("djangoErrorToToolResult", () => {
       body: "service unavailable",
     });
     const result = djangoErrorToToolResult(err);
-    expect(result.structuredContent).toEqual({
+    expect(result._meta["tako/error"]).toEqual({
       kind: "http",
       path: "/api/v1/whatever",
       method: "GET",
       status: 503,
       body: "service unavailable",
     });
-    // 5xx body stays in `structuredContent` only — not spliced into the
-    // text content. Non-400 errors don't carry LLM-actionable retry
-    // guidance and a noisy upstream body would flood the text channel.
+    // 5xx body stays in `_meta` only — not spliced into the text content.
+    // Non-400 errors don't carry LLM-actionable retry guidance and a noisy
+    // upstream body would flood the text channel.
     expect(result.content[0]).toEqual({ type: "text", text: err.message });
     expect(result.content[0]?.text).not.toContain("service unavailable");
   });

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -712,29 +712,40 @@ function registerTool(
 }
 
 /**
- * Convert a `DjangoError` into a structured MCP `CallToolResult` with
- * `isError: true`. Each subtype maps to a distinct `kind` discriminator so
- * clients can branch on `structuredContent.kind` (e.g. "unauthorized" vs
- * "timeout") instead of parsing `err.message`. Per-subtype fields
- * (`timeoutMs`, `body`) are only attached where they exist on the error.
+ * Convert a `DjangoError` into an MCP `CallToolResult` with `isError: true`.
+ * Each subtype maps to a distinct `kind` discriminator so clients can branch
+ * on `_meta["tako/error"].kind` (e.g. "unauthorized" vs "timeout") instead of
+ * parsing `err.message`. Per-subtype fields (`timeoutMs`, `body`) are only
+ * attached where they exist on the error.
+ *
+ * The discriminant rides on `_meta`, NOT `structuredContent`: read tools
+ * (`tako_search`, `tako_answer`, `tako_contents`) declare an `outputSchema`,
+ * and spec-compliant MCP clients validate ANY `structuredContent` present on
+ * a result against that schema — even when `isError: true` (the SDK's
+ * "skip on error" comment notwithstanding; it only skips the *missing*-content
+ * check, not validation). Carrying the error shape as `structuredContent`
+ * therefore got every Django error rejected with a generic `-32602`, masking
+ * the real failure (e.g. the post-deploy smoke saw "data must have required
+ * property 'cards'" instead of the upstream error). `_meta` is forwarded to
+ * clients but never schema-validated, so it's the correct channel.
  *
  * Exported for unit testing — the wire contract is stable enough that
  * Phase 2 tests can rely on the `kind` strings here.
  */
 export function djangoErrorToToolResult(err: DjangoError): {
   content: Array<{ type: "text"; text: string }>;
-  structuredContent: Record<string, unknown>;
+  _meta: Record<string, unknown>;
   isError: true;
 } {
-  const structured: Record<string, unknown> = {
+  const detail: Record<string, unknown> = {
     kind: djangoErrorKind(err),
     path: err.path,
     method: err.method,
   };
-  if (err.status !== undefined) structured.status = err.status;
-  if (err instanceof DjangoTimeoutError) structured.timeoutMs = err.timeoutMs;
+  if (err.status !== undefined) detail.status = err.status;
+  if (err instanceof DjangoTimeoutError) detail.timeoutMs = err.timeoutMs;
   if (err instanceof DjangoBadRequestError || err instanceof DjangoHttpError) {
-    structured.body = err.body;
+    detail.body = err.body;
   }
   // For 400s, splice the response body into the text content. DRF
   // validation errors (missing fields, invalid enum values, bad
@@ -752,7 +763,7 @@ export function djangoErrorToToolResult(err: DjangoError): {
       : err.message;
   return {
     content: [{ type: "text", text }],
-    structuredContent: structured,
+    _meta: { "tako/error": detail },
     isError: true,
   };
 }


### PR DESCRIPTION
## Problem

The post-deploy smoke (`workers-smoke`) fails on the `tako_search` canary with:

```
MCP error -32602: Structured content does not match the tool's output schema:
  data must have required property 'cards' / 'web_results' / 'request_id',
  data must NOT have additional properties
```

This is a **mask**. The real cause is that staging's `tako_search → POST /api/v3/search/` is erroring. On a `DjangoError`, the worker returns `djangoErrorToToolResult` (`isError: true`) whose `structuredContent` is the error shape `{ kind, path, method, status }`.

Read tools (`tako_search`/`tako_answer`/`tako_contents`) declare an `outputSchema`. Spec-compliant MCP clients (including the SDK used by the smoke) validate **any** `structuredContent` present on a result against that schema — **even when `isError: true`**. The SDK's "skip on error" comment only guards the *missing*-content check, not validation (`client/index.js:503`). So every Django error on a read tool gets rejected client-side with a generic `-32602`, hiding the real error from the smoke (and from any production client that validates structured output).

## Fix

Move the machine-readable error detail from `structuredContent` to **`_meta["tako/error"]`** — a channel clients forward but never schema-validate. `isError: true` and the text content (including the 400-body splice) are unchanged. Clients that branched on `structuredContent.kind` now read `_meta["tako/error"].kind`.

## Note: this does not turn the smoke green

It removes the mask. The next smoke run will still fail on the canary, but now prints the **real** upstream error (`unauthorized` / `timeout` / `http 5xx`) so the staging/token issue is diagnosable. Turning the smoke green is a separate owner action (verify `TAKO_SMOKE_API_TOKEN` / staging search backend).

## Testing

- TDD: rewrote the 6 `djangoErrorToToolResult` tests to the `_meta` contract + added a regression test asserting no `structuredContent` is emitted.
- `npx vitest run` → 172 passing; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)