### PR TITLE
feat(tools): add tako_visualize (thin-viz create_card) — restore SDK↔MCP parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Tools are discovered automatically via the MCP `tools/list` handshake; your clie
 - **`tako_search`** — Fast search over Tako's curated knowledge graph (and the live web when asked) for charts and live data on any topic. The top result auto-renders inline as an interactive chart on hosts that support MCP Apps (Claude.ai, ChatGPT). Choose `sources` (`["tako"]` default, `["web"]`, or both) and `effort` (`fast` default | `instant`). For deep, multi-step research — or when search returns nothing — use `tako_agent`.
 - **`tako_answer`** — Get a single grounded, citation-backed prose answer. Ground in `["tako"]`, `["web"]`, or both (default).
 - **`tako_contents`** — Fetch the content behind a result URL: a Tako card URL returns a CSV; any other URL returns the page's extracted text.
+- **`tako_visualize`** — Create an embeddable chart/card directly from your own structured data (Tako's [Thin-Viz](https://tako.com/docs/) API). Supply typed `components` (timeseries, bar, table, financial boxes, …); the card auto-renders inline and returns `webpage_url` / `embed_url`.
 - **`tako_agent`** — Run Tako's deep research agent for complex, multi-step data questions. Returns a synthesized answer plus supporting chart cards. (On ChatGPT this is exposed as the `tako_agent_start` / `tako_agent_wait` pair to fit the host's tool-call timeout model.)
 - **`get_credit_balance`** — Check the connected account's API credit balance.
 
@@ -206,7 +207,7 @@ Tools are discovered automatically via the MCP `tools/list` handshake; your clie
 
 ## Breaking changes (v0.3.0)
 
-- The current tool surface is: **`tako_search`**, **`tako_answer`**, **`tako_contents`**, **`tako_agent`** (plus the ChatGPT split pair **`tako_agent_start`** / **`tako_agent_wait`**), and **`get_credit_balance`**.
+- The current tool surface is: **`tako_search`**, **`tako_answer`**, **`tako_contents`**, **`tako_visualize`**, **`tako_agent`** (plus the ChatGPT split pair **`tako_agent_start`** / **`tako_agent_wait`**), and **`get_credit_balance`**.
 - The chart-image (`get_chart_image`), interactive-chart (`open_chart_ui`), chart-creation (`create_chart`), and report tools (`create_report`, `get_report`, `list_reports`, `export_report`) were removed.
 - The self-hosted Python server (`pip install tako-mcp` / Docker) was removed in favor of the hosted Cloudflare Worker.
 

--- a/agent.json
+++ b/agent.json
@@ -2,7 +2,7 @@
   "name": "Tako",
   "description": "Data intelligence agent that searches a knowledge base of 100K+ charts, answers data questions with citations, fetches underlying source content, and runs deep multi-step research.",
   "url": "https://mcp.tako.com",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "capabilities": {
     "streaming": true,
     "pushNotifications": false
@@ -51,6 +51,17 @@
       "examples": [
         "Get the CSV behind this Tako chart",
         "Extract the text from this article"
+      ]
+    },
+    {
+      "id": "visualize-data",
+      "name": "Visualize Your Data",
+      "description": "Create an embeddable Tako chart/card directly from your own structured data — timeseries, bar, table, financial boxes, and more. The card auto-renders as an interactive chart.",
+      "tags": ["visualize", "charts", "create", "embed"],
+      "examples": [
+        "Chart this monthly revenue: Jan 50k, Feb 62k, Mar 71k",
+        "Make a bar chart of sales by region from my data",
+        "Turn this income statement into a financial card"
       ]
     },
     {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -50,7 +50,7 @@ Parameters:
 Create an embeddable Tako card directly from your OWN structured data (not from search), backed by Tako's Thin-Viz API. Provide one or more typed components; the card auto-renders inline as a chart and returns share/embed URLs.
 
 Parameters:
-- `components` (array, required): One or more `{ component_type, config }` objects. `component_type` is one of: header, generic_timeseries, categorical_bar, choropleth, data_table_chart, histogram, pie, table, financial_boxes, timeline, treemap, heatmap, marimekko, boxplot, waterfall, sankey, scatter, bubble, top_level_metric, person_card. `config` holds that type's data (validated server-side). `person_card` must be the only component.
+- `components` (array, required): One or more `{ component_type, config, component_variant? }` objects. `component_type` is one of: header, generic_timeseries, categorical_bar, choropleth, data_table_chart, histogram, pie, table, financial_boxes, timeline, treemap, heatmap, marimekko, boxplot, waterfall, sankey, scatter, bubble, top_level_metric, person_card. `config` holds that type's data (validated server-side). The optional `component_variant` string selects a type variant (e.g. 'simple', 'financial'). `person_card` must be the only component.
 - `title` (string, optional): Card title
 - `description` (string, optional): Card description
 - `source` (string, optional): Data source attribution shown in the footer

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -46,6 +46,17 @@ Fetch the underlying content behind a result URL. A Tako card URL returns a CSV 
 Parameters:
 - `url` (string, required): The result URL to fetch content for
 
+### tako_visualize
+Create an embeddable Tako card directly from your OWN structured data (not from search), backed by Tako's Thin-Viz API. Provide one or more typed components; the card auto-renders inline as a chart and returns share/embed URLs.
+
+Parameters:
+- `components` (array, required): One or more `{ component_type, config }` objects. `component_type` is one of: header, generic_timeseries, categorical_bar, choropleth, data_table_chart, histogram, pie, table, financial_boxes, timeline, treemap, heatmap, marimekko, boxplot, waterfall, sankey, scatter, bubble, top_level_metric, person_card. `config` holds that type's data (validated server-side). `person_card` must be the only component.
+- `title` (string, optional): Card title
+- `description` (string, optional): Card description
+- `source` (string, optional): Data source attribution shown in the footer
+- `height` (integer, 100-2000, optional): Chart height in pixels
+- `normalize_currencies` (string, optional): Target ISO 4217 code to convert currency-denominated datasets
+
 ### tako_agent
 Run Tako's deep research agent for complex, multi-step data questions — transformations, aggregations, comparisons across many entities, and multi-hop reasoning. Returns a synthesized answer plus supporting chart cards. On ChatGPT, exposed as the `tako_agent_start` / `tako_agent_wait` pair to fit the host's tool-call timeout model.
 

--- a/llms.txt
+++ b/llms.txt
@@ -18,5 +18,6 @@ Connect your MCP client to `https://mcp.tako.com/mcp` with `Authorization: Beare
 - Fast search over 100K+ curated charts and live data — economics, finance, demographics, sports, markets, weather — plus the live web on request (`tako_search`); the top result auto-renders as an interactive chart. Deep multi-step research is the agent (`tako_agent`).
 - Get grounded, citation-backed prose answers from Tako's knowledge graph and/or the live web (`tako_answer`)
 - Fetch the underlying data (CSV) or page text behind any result URL (`tako_contents`)
+- Create an embeddable chart/card directly from your own structured data — timeseries, bar, table, financial boxes, and more (`tako_visualize`); the card auto-renders as an interactive chart.
 - Run a deep multi-step research agent for complex analytical questions (`tako_agent`)
 - Check API credit balance (`get_credit_balance`)

--- a/registry/metadata.json
+++ b/registry/metadata.json
@@ -2,7 +2,7 @@
   "$schema": "https://registry.modelcontextprotocol.io/schemas/server.json",
   "namespace": "com.tako",
   "name": "tako-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "title": "Tako MCP Server",
   "description": "Search, answer, and fetch data from Tako's knowledge base of 100K+ charts covering economics, finance, demographics, sports, markets, and weather; and run deep multi-step research agents.",
   "repository": {

--- a/registry/server.json
+++ b/registry/server.json
@@ -202,6 +202,43 @@
         "destructiveHint": false,
         "openWorldHint": false
       }
+    },
+    {
+      "name": "tako_visualize",
+      "description": "Create an embeddable Tako chart/card directly from data you ALREADY HAVE (not from search). Provide one or more typed `components`, each with a `component_type` and a `config` object holding that type's data (e.g. `generic_timeseries`, `categorical_bar`, `table`, `financial_boxes`, `header`). The card auto-renders inline as a chart and returns `webpage_url` / `embed_url` for sharing or embedding. Use `tako_search` to FIND existing Tako data; use `tako_visualize` when you already have the numbers. For per-`component_type` `config` shapes and worked examples, see Tako's 'Agent Skills → Visualize Your Data' docs and the Thin-Viz chart-creation reference. NOTE: `person_card` must be the ONLY component when used. **Always include `[Open in Tako](embed_url)` once at the end of your reply.**",
+      "parameters": {
+        "components": {
+          "type": "array",
+          "description": "One or more components making up the card, rendered top to bottom.",
+          "required": true
+        },
+        "title": {
+          "type": "string",
+          "description": "Card title (falls back to a header component's title)."
+        },
+        "description": {
+          "type": "string",
+          "description": "Card description."
+        },
+        "source": {
+          "type": "string",
+          "description": "Data source attribution, shown in the footer."
+        },
+        "height": {
+          "type": "integer",
+          "description": "Chart height in pixels (100–2000). Overrides the default aspect-ratio height."
+        },
+        "normalize_currencies": {
+          "type": "string",
+          "description": "Target ISO 4217 currency code (e.g. 'USD'). Converts recognized currency-denominated datasets to this currency using historical rates."
+        }
+      },
+      "annotations": {
+        "title": "Tako: Visualize",
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "openWorldHint": true
+      }
     }
   ],
   "links": {

--- a/registry/server.json
+++ b/registry/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://registry.modelcontextprotocol.io/schemas/server.json",
   "namespace": "com.tako",
   "name": "tako-mcp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "title": "Tako MCP Server",
   "description": "Search, answer, and fetch data from Tako's knowledge base of 100K+ charts covering economics, finance, demographics, sports, markets, and weather; and run deep multi-step research agents.",
   "repository": {

--- a/registry/smithery.yaml
+++ b/registry/smithery.yaml
@@ -8,7 +8,7 @@ description: |
   covering economics, finance, demographics, sports, markets, and weather; and
   run deep multi-step research agents.
 
-version: "0.3.0"
+version: "0.4.0"
 license: MIT
 
 author:
@@ -66,6 +66,8 @@ tools:
     description: Get a synthesized, citation-backed answer from Tako and/or the web
   - name: tako_contents
     description: Fetch the content behind a result URL (a card's CSV or a page's text)
+  - name: tako_visualize
+    description: Create an embeddable chart/card from your own structured data
   - name: tako_agent
     description: Run Tako's deep research agent for complex, multi-step data questions
   - name: get_credit_balance

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.TakoData/tako-mcp",
   "title": "Tako",
   "description": "Search, answer, and fetch Tako's knowledge base of 100K+ data charts, plus deep research agents.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/TakoData/tako-mcp",
     "source": "github"

--- a/workers/package.json
+++ b/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tako-mcp-workers",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Tako MCP server on Cloudflare Workers (mcp.tako.com).",
   "type": "module",

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -6,16 +6,17 @@
  *
  *   1. `GET /health`           → expect HTTP 200 with body "ok"
  *   2. MCP `initialize`        → handshake completes
- *   3. MCP `tools/list`        → 7-tool surface present; hard-asserts
- *                                 the 4 non-gated canary tools; loosely
+ *   3. MCP `tools/list`        → 8-tool surface present; hard-asserts
+ *                                 the 5 non-gated canary tools; loosely
  *                                 asserts at least one agent tool is present
  *   4. MCP Apps widget assertion on `tako_search` (soft-warn on miss)
- *   5. Per-tool MCP `tools/call` canaries (read-only):
- *        a. `tako_search "US GDP"`        — non-empty results
- *        b. `tako_answer "US GDP"`        — answer text returned
- *        c. `tako_contents {url from search}` — download_url returned
+ *   5. Per-tool MCP `tools/call` canaries:
+ *        a. `tako_search "US GDP"`        — non-empty results (read-only)
+ *        b. `tako_answer "US GDP"`        — answer text returned (read-only)
+ *        c. `tako_contents {url from search}` — download_url returned (read-only)
  *        d. `get_credit_balance`          — `details.credit_balance`
- *                                           must be a number or numeric string
+ *                                           must be a number or numeric string (read-only)
+ *        e. `tako_visualize`              — creates a card (charges 1 credit)
  *
  * Excluded by design:
  *   - `tako_agent` / `tako_agent_start` / `tako_agent_wait` — long-running;
@@ -142,7 +143,7 @@ try {
   // with a useful diff if a registry change drops one of them. We don't
   // assert on the *full* tool list because the surface evolves (e.g.
   // explore_knowledge_graph removal in PR #47).
-  const requiredTools = ["tako_search", "tako_answer", "tako_contents", "get_credit_balance"];
+  const requiredTools = ["tako_search", "tako_answer", "tako_contents", "tako_visualize", "get_credit_balance"];
   for (const required of requiredTools) {
     if (!toolNames.includes(required)) {
       fail(
@@ -279,6 +280,35 @@ try {
     `get_credit_balance.details.credit_balance is not a number or numeric string: ${JSON.stringify(balance)}`,
   );
   ok(`get_credit_balance → details.credit_balance=${balanceNumeric}`);
+
+  // ----- e) tako_visualize canary (creates a tiny card; CHARGES 1 CREDIT) ----
+  const tvResult = await callOk(client, "tako_visualize", {
+    title: "MCP smoke test",
+    components: [
+      { component_type: "header", config: { title: "MCP smoke test" } },
+      {
+        component_type: "categorical_bar",
+        config: {
+          datasets: [
+            { label: "Smoke", units: "USD", data: [{ x: "A", y: 1 }, { x: "B", y: 2 }] },
+          ],
+        },
+      },
+    ],
+  });
+  const tvStructured = tvResult.structuredContent as
+    | { card_id?: string; embed_url?: string }
+    | undefined;
+  assert(tvStructured, "tako_visualize missing structuredContent");
+  assert(
+    typeof tvStructured.card_id === "string" && tvStructured.card_id.length > 0,
+    "tako_visualize returned no card_id",
+  );
+  assert(
+    typeof tvStructured.embed_url === "string" && /^https?:\/\//.test(tvStructured.embed_url),
+    `tako_visualize.embed_url is not http(s): ${JSON.stringify(tvStructured?.embed_url)}`,
+  );
+  ok(`tako_visualize → card_id ${tvStructured.card_id}`);
 } finally {
   await client.close().catch(() => {
     // ignore close errors — we already have the answer we care about

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -119,7 +119,7 @@ describe("worker routing", () => {
     expect(body.jsonrpc).toBe("2.0");
     expect(body.id).toBe(1);
     expect(body.result.serverInfo.name).toBe("tako-mcp");
-    expect(body.result.serverInfo.version).toBe("0.3.0");
+    expect(body.result.serverInfo.version).toBe("0.4.0");
     // Guard against silent SDK negotiation regressions — a missing or
     // malformed protocolVersion should fail loudly. The regex tolerates
     // future SDK bumps without pinning to a specific release.
@@ -200,6 +200,7 @@ describe("worker routing", () => {
       "tako_answer",
       "tako_contents",
       "tako_search",
+      "tako_visualize",
     ]);
 
     // MCP Apps: `tako_search` is the sole chart-widget tool after 0.3.0.
@@ -218,7 +219,7 @@ describe("worker routing", () => {
     // it the widget loads but `window.openai.toolOutput` never
     // populates). Other tools ship no widget and should declare
     // none of these fields.
-    const widgetTools = new Set(["tako_search"]);
+    const widgetTools = new Set(["tako_search", "tako_visualize"]);
     for (const name of widgetTools) {
       const tool = body.result.tools.find((t) => t.name === name);
       expect(tool?._meta).toMatchObject({
@@ -276,10 +277,10 @@ describe("worker routing", () => {
     expect(names.has("tako_agent")).toBe(false);
     // The default tools (minus tako_agent) are still present alongside.
     expect(names.has("tako_search")).toBe(true);
-    // 7 total tools − 1 (tako_agent excluded) + 2 chatgpt-only − 2 (those same
-    // chatgpt-only are in the 7) = 7 − 1 = 6
-    // More directly: 5 default-client tools − tako_agent + tako_agent_start + tako_agent_wait = 6
-    expect(body.result.tools).toHaveLength(6);
+    // 8 total tools − 1 (tako_agent excluded) + 2 chatgpt-only − 2 (those same
+    // chatgpt-only are in the 8) = 8 − 1 = 7
+    // More directly: 6 default-client tools − tako_agent + tako_agent_start + tako_agent_wait = 7
+    expect(body.result.tools).toHaveLength(7);
 
     // `tako_search` is the sole chart-widget tool on ChatGPT after 0.3.0.
     // The empty-fast widget-gap problem (ChatGPT pins widget container

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -32,7 +32,7 @@ import type { AnyToolModule, McpClientKind, ToolContext } from "./tools/types.js
  * returns, so a mismatch surfaces as "wrong server" in tooling.
  */
 export const SERVER_NAME = "tako-mcp";
-export const SERVER_VERSION = "0.3.0";
+export const SERVER_VERSION = "0.4.0";
 
 /**
  * MCP Apps UI resource MIME type. Hosts (claude.ai, ChatGPT Apps SDK, VS

--- a/workers/src/tools/_registry.ts
+++ b/workers/src/tools/_registry.ts
@@ -19,6 +19,7 @@ import tako_agent_wait from "./tako_agent_wait.js";
 import tako_answer from "./tako_answer.js";
 import tako_contents from "./tako_contents.js";
 import tako_search from "./tako_search.js";
+import tako_visualize from "./tako_visualize.js";
 
 // Cast at the barrel boundary because function parameters are invariant:
 // each tool's handler has a narrow input type from its Zod schema, which
@@ -32,4 +33,5 @@ export const TOOL_REGISTRY: ReadonlyArray<AnyToolModule> = [
   tako_answer as unknown as AnyToolModule,
   tako_contents as unknown as AnyToolModule,
   tako_search as unknown as AnyToolModule,
+  tako_visualize as unknown as AnyToolModule,
 ];

--- a/workers/src/tools/tako_visualize.test.ts
+++ b/workers/src/tools/tako_visualize.test.ts
@@ -132,6 +132,18 @@ describe("tako_visualize handler", () => {
 
     await expect(takoVisualize.handler(VALID_INPUT, CTX)).rejects.toThrow(/card_id/);
   });
+
+  it("reflects requested height in output (widget render size)", async () => {
+    // height: 600 → out.height === 600
+    mockFetchSequence([jsonResponse(200, CARD_RESPONSE)]);
+    const outWithHeight = await takoVisualize.handler({ ...VALID_INPUT, height: 600 }, CTX);
+    expect(outWithHeight.height).toBe(600);
+
+    // height omitted → out.height === DEFAULT_HEIGHT (720)
+    mockFetchSequence([jsonResponse(200, CARD_RESPONSE)]);
+    const outNoHeight = await takoVisualize.handler(VALID_INPUT, CTX);
+    expect(outNoHeight.height).toBe(720);
+  });
 });
 
 describe("tako_visualize input schema", () => {

--- a/workers/src/tools/tako_visualize.test.ts
+++ b/workers/src/tools/tako_visualize.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for the `tako_visualize` tool.
+ *
+ * The handler is a single POST + re-parse: it maps the tool input onto the
+ * backend's `/api/v1/thin_viz/create/` body, then lifts the returned
+ * `card_id` into the shared chart-widget fields (pub_id/embed_url/image_url)
+ * so the created card renders inline like a search result.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Env } from "../env.js";
+import type { ToolContext } from "./types.js";
+import takoVisualize from "./tako_visualize.js";
+import {
+  bodyOf,
+  jsonResponse,
+  mockFetchSequence,
+  noopSendProgress,
+  requestFrom,
+} from "./__test_helpers.js";
+
+const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
+const CTX: ToolContext = {
+  token: "sk-test",
+  env: ENV,
+  sendProgress: noopSendProgress,
+  client: "claude",
+};
+
+const CARD_RESPONSE = {
+  card_id: "card_abc123",
+  title: "Monthly Revenue",
+  description: "Revenue by month",
+  webpage_url: "https://staging.trytako.com/charts/card_abc123",
+  embed_url: "https://staging.trytako.com/embed/card_abc123/",
+  image_url: "https://staging.trytako.com/api/v1/image/card_abc123/",
+  embed_mode: "post",
+};
+
+const VALID_INPUT = {
+  title: "Monthly Revenue",
+  components: [
+    { component_type: "header" as const, config: { title: "Monthly Revenue" } },
+    {
+      component_type: "categorical_bar" as const,
+      config: {
+        datasets: [
+          { label: "Sales", units: "USD", data: [{ x: "NA", y: 500 }, { x: "EU", y: 300 }] },
+        ],
+      },
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("tako_visualize handler", () => {
+  it("tool name is tako_visualize", () => {
+    expect(takoVisualize.name).toBe("tako_visualize");
+  });
+
+  it("is a write tool that creates a public card (annotations)", () => {
+    expect(takoVisualize.annotations.readOnlyHint).toBe(false);
+    expect(takoVisualize.annotations.openWorldHint).toBe(true);
+  });
+
+  it("POSTs components + title to /api/v1/thin_viz/create/ and lifts card_id into widget fields", async () => {
+    const fetchMock = mockFetchSequence([jsonResponse(200, CARD_RESPONSE)]);
+
+    const out = await takoVisualize.handler(VALID_INPUT, CTX);
+
+    const req = requestFrom(fetchMock.mock.calls[0]);
+    expect(req.url).toBe("https://staging.trytako.com/api/v1/thin_viz/create/");
+    const body = await bodyOf(req);
+    expect(body.title).toBe("Monthly Revenue");
+    expect(Array.isArray(body.components)).toBe(true);
+    expect((body.components as unknown[]).length).toBe(2);
+
+    // card fields surfaced
+    expect(out.card_id).toBe("card_abc123");
+    expect(out.webpage_url).toBe("https://staging.trytako.com/charts/card_abc123");
+    // widget fields lifted for inline render
+    expect(out.pub_id).toBe("card_abc123");
+    expect(out.embed_url).toMatch(/^https?:\/\//);
+    expect(out.image_url).toMatch(/^https?:\/\//);
+    expect(out.dark_mode).toBe(true);
+  });
+
+  it("omits undefined optional top-level fields from the POST body", async () => {
+    const fetchMock = mockFetchSequence([jsonResponse(200, CARD_RESPONSE)]);
+
+    await takoVisualize.handler(
+      { components: [{ component_type: "header" as const, config: { title: "X" } }] },
+      CTX,
+    );
+
+    const body = await bodyOf(requestFrom(fetchMock.mock.calls[0]));
+    expect("title" in body).toBe(false);
+    expect("description" in body).toBe(false);
+    expect("source" in body).toBe(false);
+    expect("height" in body).toBe(false);
+    expect("normalize_currencies" in body).toBe(false);
+    // excluded-by-design fields never appear
+    expect("postmessage_embed" in body).toBe(false);
+    expect("image_ttl_minutes" in body).toBe(false);
+  });
+
+  it("forwards source, height, and normalize_currencies when provided", async () => {
+    const fetchMock = mockFetchSequence([jsonResponse(200, CARD_RESPONSE)]);
+
+    await takoVisualize.handler(
+      {
+        components: [{ component_type: "header" as const, config: { title: "X" } }],
+        source: "Internal Analytics",
+        height: 600,
+        normalize_currencies: "USD",
+      },
+      CTX,
+    );
+
+    const body = await bodyOf(requestFrom(fetchMock.mock.calls[0]));
+    expect(body.source).toBe("Internal Analytics");
+    expect(body.height).toBe(600);
+    expect(body.normalize_currencies).toBe("USD");
+  });
+
+  it("throws an actionable error when the backend returns no card_id", async () => {
+    mockFetchSequence([jsonResponse(200, { title: "X" })]);
+
+    await expect(takoVisualize.handler(VALID_INPUT, CTX)).rejects.toThrow(/card_id/);
+  });
+});
+
+describe("tako_visualize input schema", () => {
+  it("requires at least one component", () => {
+    expect(() => takoVisualize.inputSchema.parse({ components: [] })).toThrow();
+  });
+
+  it("rejects an unknown component_type", () => {
+    expect(() =>
+      takoVisualize.inputSchema.parse({
+        components: [{ component_type: "pie_chart", config: {} }],
+      }),
+    ).toThrow();
+  });
+
+  it("accepts a valid component with a freeform config object", () => {
+    const parsed = takoVisualize.inputSchema.parse({
+      components: [{ component_type: "scatter", config: { anything: [1, 2, 3], nested: { a: 1 } } }],
+    });
+    expect(parsed.components[0]?.component_type).toBe("scatter");
+  });
+});

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -164,7 +164,7 @@ const tako_visualize = {
       image_url,
       dark_mode: DEFAULT_DARK_MODE,
       width: DEFAULT_WIDTH,
-      height: DEFAULT_HEIGHT,
+      height: input.height ?? DEFAULT_HEIGHT,
     });
     if (!parsed.success) {
       throw new Error(

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -1,0 +1,207 @@
+/**
+ * `tako_visualize` — create an embeddable Tako card directly from the
+ * caller's OWN structured data, backed by `POST /api/v1/thin_viz/create/`
+ * (the SDK's `client.create_card`). Unlike `tako_search`, this does NOT
+ * search Tako's knowledge graph — it renders data the agent already has.
+ *
+ * The created card auto-renders inline as a chart: the backend returns a
+ * `card_id` (+ embed/image URLs), which the tool lifts into the same widget
+ * fields `tako_search` uses, sharing `_chart_widget.ts`.
+ */
+import { z } from "zod";
+
+import { djangoPost } from "../django.js";
+import {
+  APP_UI_RESOURCE_URI,
+  APP_UI_TEMPLATE_URI_PATTERN,
+  buildChartAppUiResource,
+  buildChartUrls,
+  DEFAULT_DARK_MODE,
+  DEFAULT_HEIGHT,
+  DEFAULT_WIDTH,
+  fetchImageDataUrlAndDims,
+  fetchPngContentBlock,
+} from "./_chart_widget.js";
+import { autoChainShape } from "./_search_results.js";
+import type { AppUiResource, ToolContentBlock, ToolModule } from "./types.js";
+
+// Mirrors VALID_COMPONENT_TYPES in the backend
+// (app/backend/knowledge/api/ga/v1/thinviz/views.py): COMPONENT_BUILDERS
+// keys plus "header" and "person_card". Keep in sync if the backend adds
+// a builder.
+const COMPONENT_TYPES = [
+  "header",
+  "generic_timeseries",
+  "categorical_bar",
+  "choropleth",
+  "data_table_chart",
+  "histogram",
+  "pie",
+  "table",
+  "financial_boxes",
+  "timeline",
+  "treemap",
+  "heatmap",
+  "marimekko",
+  "boxplot",
+  "waterfall",
+  "sankey",
+  "scatter",
+  "bubble",
+  "top_level_metric",
+  "person_card",
+] as const;
+
+const DESCRIPTION =
+  "Create an embeddable Tako chart/card directly from data you ALREADY HAVE (not from search). Provide one or more typed `components`, each with a `component_type` and a `config` object holding that type's data (e.g. `generic_timeseries`, `categorical_bar`, `table`, `financial_boxes`, `header`). The card auto-renders inline as a chart and returns `webpage_url` / `embed_url` for sharing or embedding. Use `tako_search` to FIND existing Tako data; use `tako_visualize` when you already have the numbers. For per-`component_type` `config` shapes and worked examples, see Tako's 'Agent Skills → Visualize Your Data' docs and the Thin-Viz chart-creation reference. NOTE: `person_card` must be the ONLY component when used. **Always include `[Open in Tako](embed_url)` once at the end of your reply.**";
+
+const inputSchema = z.object({
+  components: z
+    .array(
+      z.object({
+        component_type: z
+          .enum(COMPONENT_TYPES)
+          .describe("Component type; each type expects a different `config` shape."),
+        component_variant: z
+          .string()
+          .optional()
+          .describe("Optional component variant (e.g. 'simple', 'financial')."),
+        config: z
+          .record(z.string(), z.unknown())
+          .describe(
+            "Data/configuration for this `component_type` (e.g. a categorical_bar's `datasets`). Freeform per type; validated server-side.",
+          ),
+      }),
+    )
+    .min(1)
+    .describe("One or more components making up the card, rendered top to bottom."),
+  title: z.string().optional().describe("Card title (falls back to a header component's title)."),
+  description: z.string().optional().describe("Card description."),
+  source: z.string().optional().describe("Data source attribution, shown in the footer."),
+  height: z
+    .number()
+    .int()
+    .min(100)
+    .max(2000)
+    .optional()
+    .describe("Chart height in pixels (100–2000). Overrides the default aspect-ratio height."),
+  normalize_currencies: z
+    .string()
+    .optional()
+    .describe(
+      "Target ISO 4217 currency code (e.g. 'USD'). Converts recognized currency-denominated datasets to this currency using historical rates.",
+    ),
+});
+
+const outputSchema = z.object({
+  card_id: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  webpage_url: z.string().optional(),
+  ...autoChainShape,
+});
+
+type Output = z.infer<typeof outputSchema>;
+
+// Backend KnowledgeCard subset returned by /api/v1/thin_viz/create/.
+type CreateCardResponse = {
+  card_id?: string;
+  title?: string;
+  description?: string;
+  webpage_url?: string;
+  embed_url?: string;
+  image_url?: string;
+};
+
+const tako_visualize = {
+  name: "tako_visualize",
+  description: DESCRIPTION,
+  inputSchema,
+  outputSchema,
+  annotations: {
+    title: "Tako: Visualize",
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  async handler(input, ctx): Promise<Output> {
+    // Thin pass-through: send components + only the provided top-level
+    // fields. The backend validates configs and charges credits.
+    const body: Record<string, unknown> = { components: input.components };
+    if (input.title !== undefined) body.title = input.title;
+    if (input.description !== undefined) body.description = input.description;
+    if (input.source !== undefined) body.source = input.source;
+    if (input.height !== undefined) body.height = input.height;
+    if (input.normalize_currencies !== undefined) {
+      body.normalize_currencies = input.normalize_currencies;
+    }
+
+    const data = await djangoPost<CreateCardResponse>(
+      ctx.env,
+      ctx.token,
+      "/api/v1/thin_viz/create/",
+      body,
+      { timeoutMs: 130_000 },
+    );
+
+    const cardId = data.card_id ?? "";
+    if (cardId === "") {
+      throw new Error(
+        "Tako visualize endpoint did not return a card_id. Retry once; if it persists, flag it to the Tako team.",
+      );
+    }
+
+    // Build canonical widget URLs from the card_id (same as tako_search),
+    // so inline render works regardless of the URL form the backend returns.
+    const { embed_url, image_url } = buildChartUrls(ctx.env, cardId, DEFAULT_DARK_MODE);
+    const parsed = outputSchema.safeParse({
+      card_id: cardId,
+      title: data.title,
+      description: data.description,
+      webpage_url: data.webpage_url,
+      pub_id: cardId,
+      embed_url,
+      image_url,
+      dark_mode: DEFAULT_DARK_MODE,
+      width: DEFAULT_WIDTH,
+      height: DEFAULT_HEIGHT,
+    });
+    if (!parsed.success) {
+      throw new Error(
+        "Tako visualize endpoint returned an unexpected shape. Retry once; if it persists, flag it to the Tako team.",
+      );
+    }
+    return parsed.data;
+  },
+  async extraMeta(output, ctx) {
+    // Skip the PNG prefetch on ChatGPT (its widget renders embed_url
+    // directly) — mirrors tako_search.
+    if (ctx.client === "chatgpt") return undefined;
+    if (output.image_url === undefined) return undefined;
+    const fetched = await fetchImageDataUrlAndDims(output.image_url);
+    if (fetched === undefined) return undefined;
+    return {
+      image_data_url: fetched.dataUrl,
+      image_natural_width: fetched.naturalWidth,
+      image_natural_height: fetched.naturalHeight,
+    };
+  },
+  async extraContentBlocks(output, _ctx): Promise<ToolContentBlock[]> {
+    void _ctx;
+    if (output.image_url === undefined) return [];
+    return fetchPngContentBlock(output.image_url);
+  },
+  appUiResource(env): AppUiResource {
+    return buildChartAppUiResource(env, (_input, output) => {
+      void _input;
+      const pubId =
+        typeof (output as { pub_id?: unknown } | undefined)?.pub_id === "string"
+          ? (output as { pub_id: string }).pub_id
+          : "";
+      if (pubId === "") return APP_UI_RESOURCE_URI;
+      return APP_UI_TEMPLATE_URI_PATTERN.replace("{pub_id}", encodeURIComponent(pubId));
+    });
+  },
+} satisfies ToolModule<typeof inputSchema, Output>;
+
+export default tako_visualize;


### PR DESCRIPTION
## What & why

Adds a new MCP tool, **`tako_visualize`**, that creates an embeddable Tako card directly from the caller's own structured data — backed by the existing `POST /api/v1/thin_viz/create/` endpoint (the SDK's `client.create_card`). This restores SDK↔MCP capability parity: the 0.3.0 cleanup shrank the tool surface to match the SDK (search / answer / contents / agent), and now that ThinViz ships in the SDK, the MCP gets the matching tool.

Spec: `tako` monorepo `docs/superpowers/specs/2026-06-22-tako-visualize-mcp-parity-design.md`.

## How it works

- **Thin pass-through:** `components: [{ component_type, config, component_variant? }]` + `title` / `description` / `source` / `height` / `normalize_currencies`. `config` is an open object — the backend is the single validator, so there's zero schema drift. `component_type` is an enum of the 20 backend `VALID_COMPONENT_TYPES`. (`postmessage_embed` / `image_ttl_minutes` are intentionally excluded — infra/ZDR concerns, not agent-facing.)
- **Inline render:** the created card carries `card_id` / `embed_url` / `image_url`, so the tool reuses `tako_search`'s exact render path — `buildChartUrls` + `autoChainShape`, sharing the `_chart_widget.ts` widget URI (the `mcp.ts` `registeredResourceUris` dedup already supports two tools sharing one widget). A created card auto-renders inline like a search result.
- **Write-tool semantics:** first non-read-only tool — `readOnlyHint:false`, `openWorldHint:true`. Auth + credit charging + validation are all server-side; the Worker only forwards the token and the URLs are server-composed from `card_id` (widget re-validates the scheme).
- **Version → `0.4.0`** (minor: adds a public tool, breaks nothing) across `agent.json`, `registry/metadata.json`, `registry/server.json`, `server.json`, `registry/smithery.yaml`, `workers/package.json`, and `SERVER_VERSION` in `mcp.ts`.

## Verification

- `npm run typecheck` clean · `npm test` **182/182 (14 files)** · `npm run registry:check` ok (**8 tools**).
- Smoke (`workers/scripts/smoke.ts`): `tako_visualize` added to the required `tools/list` set + a create-card canary. ⚠️ The canary creates a real card and **charges 1 credit per smoke run** (documented inline).

## Lines changed (logic / tests / docs)

- **Logic ~266 / −7** — `tako_visualize.ts` (207), generated `_registry.ts` + `registry/server.json`, and the server descriptors/version (`agent.json`, `registry/metadata.json`, `server.json`, `registry/smithery.yaml`, `package.json`, `mcp.ts`). *(machine-read descriptors/config counted here)*
- **Tests ~213 / −14** — `tako_visualize.test.ts` (new, 168), `smoke.ts` canary, `index.test.ts` tool-set/version assertions.
- **Docs ~14 / −1** — `README.md`, `llms.txt`, `llms-full.txt`.

## Notes / follow-ups

- On merge, the root `server.json` `0.4.0` bump auto-publishes to the MCP registry; **production promotion is a manual `workers-deploy` dispatch** after staging smoke is green.
- The **Smithery** listing may need a manual re-sync (not automated from this repo).
- Docs PR (TakoData/docs) is separate and **should merge after this one** so it references a live tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkdhVrGfx77bHXKBkkzdDX
