### PR TITLE
fix(tools): correct openWorldHint to reflect real web reach

### DIFF
--- a/registry/server.json
+++ b/registry/server.json
@@ -62,7 +62,7 @@
         "title": "Tako: Deep Agent",
         "readOnlyHint": true,
         "destructiveHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -79,7 +79,7 @@
         "title": "Tako: Start Agent Run",
         "readOnlyHint": true,
         "destructiveHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -101,7 +101,7 @@
         "title": "Tako: Wait for Agent Run",
         "readOnlyHint": true,
         "destructiveHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -136,7 +136,7 @@
         "title": "Tako: Answer",
         "readOnlyHint": true,
         "destructiveHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -153,7 +153,7 @@
         "title": "Tako: Fetch Contents",
         "readOnlyHint": true,
         "destructiveHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -200,7 +200,7 @@
         "title": "Tako: Search",
         "readOnlyHint": true,
         "destructiveHint": false,
-        "openWorldHint": false
+        "openWorldHint": true
       }
     },
     {
@@ -237,7 +237,7 @@
         "title": "Tako: Visualize",
         "readOnlyHint": false,
         "destructiveHint": false,
-        "openWorldHint": true
+        "openWorldHint": false
       }
     }
   ],

--- a/workers/src/tools/tako_agent.ts
+++ b/workers/src/tools/tako_agent.ts
@@ -151,7 +151,7 @@ const takoAgent = {
     title: "Tako: Deep Agent",
     readOnlyHint: true,
     destructiveHint: false,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   async handler(input, ctx): Promise<AgentRun> {
     const runId = await dispatchAgentRun(ctx, input.query);

--- a/workers/src/tools/tako_agent_start.ts
+++ b/workers/src/tools/tako_agent_start.ts
@@ -44,7 +44,7 @@ const tako_agent_start = {
     title: "Tako: Start Agent Run",
     readOnlyHint: true,
     destructiveHint: false,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   async handler(input, ctx): Promise<Output> {
     const runId = await dispatchAgentRun(ctx, input.query);

--- a/workers/src/tools/tako_agent_wait.ts
+++ b/workers/src/tools/tako_agent_wait.ts
@@ -45,7 +45,7 @@ const tako_agent_wait = {
     title: "Tako: Wait for Agent Run",
     readOnlyHint: true,
     destructiveHint: false,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   async handler(input, ctx): Promise<AgentRun> {
     return pollAgentRun(ctx, input.run_id, {

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -52,7 +52,7 @@ const takoAnswer = {
     title: "Tako: Answer",
     readOnlyHint: true,
     destructiveHint: false,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   async handler(input, ctx): Promise<Output> {
     // GA /api/v1/answer takes the v3 SearchRequest shape: top-level `query`

--- a/workers/src/tools/tako_contents.ts
+++ b/workers/src/tools/tako_contents.ts
@@ -48,7 +48,7 @@ const takoContents = {
     title: "Tako: Fetch Contents",
     readOnlyHint: true,
     destructiveHint: false,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   async handler(input, ctx): Promise<Output> {
     const data = await djangoPost<ContentsPostResponse>(

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -82,7 +82,7 @@ const tako_search = {
     title: "Tako: Search",
     readOnlyHint: true,
     destructiveHint: false,
-    openWorldHint: false,
+    openWorldHint: true,
   },
   async handler(input, ctx): Promise<Output> {
     const body: Record<string, unknown> = {

--- a/workers/src/tools/tako_visualize.test.ts
+++ b/workers/src/tools/tako_visualize.test.ts
@@ -64,7 +64,7 @@ describe("tako_visualize handler", () => {
 
   it("is a write tool that creates a public card (annotations)", () => {
     expect(takoVisualize.annotations.readOnlyHint).toBe(false);
-    expect(takoVisualize.annotations.openWorldHint).toBe(true);
+    expect(takoVisualize.annotations.openWorldHint).toBe(false);
   });
 
   it("POSTs components + title to /api/v1/thin_viz/create/ and lifts card_id into widget fields", async () => {

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -122,7 +122,7 @@ const tako_visualize = {
     title: "Tako: Visualize",
     readOnlyHint: false,
     destructiveHint: false,
-    openWorldHint: true,
+    openWorldHint: false,
   },
   async handler(input, ctx): Promise<Output> {
     // Thin pass-through: send components + only the provided top-level


### PR DESCRIPTION
## What

Corrects the `openWorldHint` MCP annotation on the tool surface so it accurately reflects whether each tool can reach the **live, unbounded web** vs. a **closed domain** — relevant for the OpenAI connector-directory resubmission, where each annotation must be justified.

| Tool | Before | After | Why |
|------|--------|-------|-----|
| `tako_search` | false | **true** | `sources` accepts `["web"]` — queries the live web |
| `tako_answer` | false | **true** | `sources` defaults to `["tako","web"]` — blends live web by default |
| `tako_contents` | false | **true** | fetches the extracted text of *any* URL |
| `tako_agent` | false | **true** | deep research can blend the live web |
| `tako_agent_start` | false | **true** | dispatches the same deep agent run |
| `tako_agent_wait` | false | **true** | polls the same deep agent run |
| `tako_visualize` | true | **false** | renders only caller-supplied data — reaches no external world |

Per the MCP spec, `openWorldHint: true` means the tool may interact with an unpredictable/dynamic set of external entities (the canonical example being web search); `false` means a closed, well-defined domain.

## Scope

Annotations only — no behavior change. `readOnlyHint` / `destructiveHint` are intentionally untouched in this PR.

## Verification

- `registry/server.json` regenerated (`npm run registry:gen`); `registry:check` passes
- `npm run typecheck` clean
- `npm test` — 182 passed (updated the `tako_visualize` annotation test to expect `openWorldHint: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)