### PR TITLE
feat(workers): serve OpenAI connector-directory domain-verification token

### DIFF
--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -78,6 +78,17 @@ export interface Env {
    * a trailing slash.
    */
   STYTCH_BASE_URL?: string;
+  /**
+   * OpenAI connector-directory domain-verification token. OpenAI
+   * GETs `/.well-known/openai-apps-challenge` on the registered MCP
+   * hostname during submission and expects this exact string back as
+   * the response body. Set per-env in `wrangler.jsonc` `vars` (not a
+   * secret — the value is meant to be served on a public URL).
+   * When unset, the well-known route returns 404 so non-production
+   * environments don't accidentally satisfy a verification challenge
+   * for a connector that was never registered against them.
+   */
+  OPENAI_APPS_CHALLENGE_TOKEN?: string;
 }
 
 /**

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -1,5 +1,7 @@
 import { SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
+import type { Env } from "./env.js";
+import worker from "./index.js";
 
 // Valid RFC 6750 b64token — any non-empty ASCII token works for these tests
 // because `extractBearer` only validates shape, not value. Django's the one
@@ -33,6 +35,20 @@ describe("worker routing", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
     expect(await res.text()).toBe("dev-stub-not-a-real-challenge-token");
+  });
+
+  it("GET /.well-known/openai-apps-challenge returns 404 when the token is unset", async () => {
+    // The "never satisfy an un-issued challenge" security property: with
+    // no `OPENAI_APPS_CHALLENGE_TOKEN` binding, the route must not answer
+    // and instead falls through to the catch-all 404. `SELF.fetch` always
+    // carries the configured stub, so we invoke the handler directly with
+    // an env lacking the token to exercise the unset path.
+    const env = { DJANGO_BASE_URL: "http://localhost:8000" } as Env;
+    const res = await worker.fetch(
+      new Request("https://example.com/.well-known/openai-apps-challenge"),
+      env,
+    );
+    expect(res.status).toBe(404);
   });
 
   // We deliberately do not alias the OIDC discovery path. ChatGPT's App

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -20,6 +20,21 @@ describe("worker routing", () => {
     expect(res.status).toBe(404);
   });
 
+  it("GET /.well-known/openai-apps-challenge returns the configured token as plain text", async () => {
+    // OpenAI's connector-directory domain-verification flow GETs this
+    // URL during submission and matches the response body verbatim
+    // against the token shown in their dashboard. The token comes
+    // from the `OPENAI_APPS_CHALLENGE_TOKEN` binding (per env, in
+    // `wrangler.jsonc`); for the test runner the top-level `vars`
+    // entry stubs it to a known string.
+    const res = await SELF.fetch(
+      "https://example.com/.well-known/openai-apps-challenge",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await res.text()).toBe("dev-stub-not-a-real-challenge-token");
+  });
+
   // We deliberately do not alias the OIDC discovery path. ChatGPT's App
   // Review wizard auto-locks the OIDC form fields once the URL resolves,
   // and the resulting half-OIDC / half-OAuth shape trips its classifier.

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -52,6 +52,30 @@ export default {
     // when Phase 2 introduces streaming tools or browser-based clients —
     // see the `transport.close()` TODO in `mcp.ts`.
 
+    // OpenAI connector-directory domain verification. During the
+    // submission flow OpenAI hits this URL and expects to read back
+    // the exact token shown in their dashboard. Token is per-env via
+    // `OPENAI_APPS_CHALLENGE_TOKEN`; when unset, return 404 so an
+    // unrelated environment never satisfies a verification it wasn't
+    // issued. Plain text response — no CORS wrapper needed (OpenAI
+    // hits this server-to-server, not from a browser).
+    if (
+      request.method === "GET" &&
+      url.pathname === "/.well-known/openai-apps-challenge"
+    ) {
+      const token = env.OPENAI_APPS_CHALLENGE_TOKEN;
+      if (token === undefined || token === "") {
+        return new Response("not found", {
+          status: 404,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
+      }
+      return new Response(token, {
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
     // OAuth 2.1 + DCR + PKCE (TAKO-2679). The two `.well-known/...`
     // discovery docs let MCP hosts (Claude.ai, ChatGPT) bootstrap the
     // OAuth flow from just the resource URL. `/register`, `/authorize`,

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -55,22 +55,17 @@ export default {
     // OpenAI connector-directory domain verification. During the
     // submission flow OpenAI hits this URL and expects to read back
     // the exact token shown in their dashboard. Token is per-env via
-    // `OPENAI_APPS_CHALLENGE_TOKEN`; when unset, return 404 so an
-    // unrelated environment never satisfies a verification it wasn't
-    // issued. Plain text response — no CORS wrapper needed (OpenAI
-    // hits this server-to-server, not from a browser).
+    // `OPENAI_APPS_CHALLENGE_TOKEN`. We only serve it when configured;
+    // an unset/empty binding falls through to the catch-all 404 below,
+    // so a non-production environment never satisfies a verification it
+    // wasn't issued. Plain text response — no CORS wrapper needed
+    // (OpenAI hits this server-to-server, not from a browser).
     if (
       request.method === "GET" &&
-      url.pathname === "/.well-known/openai-apps-challenge"
+      url.pathname === "/.well-known/openai-apps-challenge" &&
+      env.OPENAI_APPS_CHALLENGE_TOKEN
     ) {
-      const token = env.OPENAI_APPS_CHALLENGE_TOKEN;
-      if (token === undefined || token === "") {
-        return new Response("not found", {
-          status: 404,
-          headers: { "content-type": "text/plain; charset=utf-8" },
-        });
-      }
-      return new Response(token, {
+      return new Response(env.OPENAI_APPS_CHALLENGE_TOKEN, {
         status: 200,
         headers: { "content-type": "text/plain; charset=utf-8" },
       });

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -24,14 +24,24 @@
     // `wrangler dev` works out of the box. Staging / production overrides
     // are declared per-env below and are selected via
     // `wrangler deploy --env staging|production`.
-    "DJANGO_BASE_URL": "http://localhost:8000"
+    "DJANGO_BASE_URL": "http://localhost:8000",
+    // Stub value for `wrangler dev` and the vitest-pool-workers test
+    // suite. The integration test in `index.test.ts` asserts the
+    // `/.well-known/openai-apps-challenge` route echoes whatever this
+    // is set to. Staging / production override with OpenAI-issued
+    // tokens below.
+    "OPENAI_APPS_CHALLENGE_TOKEN": "dev-stub-not-a-real-challenge-token"
   },
   "env": {
     "staging": {
       "name": "tako-mcp-staging",
       "vars": {
         "DJANGO_BASE_URL": "https://staging.trytako.com",
-        "PUBLIC_BASE_URL": "https://staging.tako.com"
+        "PUBLIC_BASE_URL": "https://staging.tako.com",
+        // OpenAI connector-directory token issued for
+        // `mcp.staging.tako.com`. Served as plain text from
+        // `/.well-known/openai-apps-challenge`.
+        "OPENAI_APPS_CHALLENGE_TOKEN": "yvdAP5oZPvNXuisifiatKihXGqCnPqg64InQXJ0yB5U"
       },
       // `custom_domain: true` provisions a Cloudflare Custom Domain (TLS
       // auto-issued, CNAME auto-managed) on the deploying account's
@@ -51,7 +61,13 @@
       "name": "tako-mcp-production",
       "vars": {
         "DJANGO_BASE_URL": "https://trytako.com",
-        "PUBLIC_BASE_URL": "https://tako.com"
+        "PUBLIC_BASE_URL": "https://tako.com",
+        // OpenAI connector-directory domain-verification token issued
+        // for `mcp.tako.com`. Served as plain text from
+        // `/.well-known/openai-apps-challenge`. If OpenAI rotates the
+        // value, update here and redeploy. Not a secret — the URL is
+        // public by design.
+        "OPENAI_APPS_CHALLENGE_TOKEN": "uXTBcUGnISWBPU2YXEn7IPIDh2ANMxLa1rkFvv3Z0c0"
       },
       "routes": [
         { "pattern": "mcp.tako.com", "custom_domain": true }


### PR DESCRIPTION
## What

Adds a `GET /.well-known/openai-apps-challenge` route that serves the OpenAI connector-directory domain-verification token as plain text, read from a per-env `OPENAI_APPS_CHALLENGE_TOKEN` binding. Returns 404 when unset so an environment never satisfies a verification it wasn't issued.

This unblocks the OpenAI Apps submission for `mcp.tako.com`, which was failing domain verification because the endpoint 404'd.

## Why it was missing

The route was originally built on `jfassio/resource-bare-origin` (May 6) but that branch was never merged — so it never reached main or prod. This re-applies just the challenge changes on top of current main (the old branch bundled an unrelated OAuth change and predated the tool-surface cleanup), with the **current** dashboard token.

## Tokens
- **production** (`mcp.tako.com`): `uXTBcUGnISWBPU2YXEn7IPIDh2ANMxLa1rkFvv3Z0c0` — the value now shown in the OpenAI dashboard (OpenAI rotated it from the old branch's value)
- **staging** (`mcp.staging.tako.com`): prior issued token, kept for parity
- **dev**: stub the integration test pins

## Verification
- `npm run typecheck` ✅
- `npm run registry:check` ✅
- `src/index.test.ts` — 18/18 pass, incl. new route test ✅

## ⚠️ Deploy note
Merging alone does **not** make the endpoint respond. The route goes live only after `wrangler deploy --env production` runs against `mcp.tako.com`. Since CI prod deploys fail on the zone-route token error, prod ships out-of-band — someone with CF account access needs to deploy before OpenAI's "Verify Domain" will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)