### PR TITLE
chore: add glama.json to claim MCP listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "jed326",
+    "robertabbott"
+  ]
+}


### PR DESCRIPTION
## What

Adds `glama.json` at the repo root so the **Tako MCP** server listing on [Glama](https://glama.ai) can be claimed and managed.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["jed326", "robertabbott"]
}
```

## Why

Claiming the listing unlocks: editing the server's name/description, configuring its Docker image, viewing usage reports, and receiving review notifications. Org-hosted repos (like `TakoData/*`) **require** this file for the claim flow — GitHub auth alone isn't sufficient. See https://glama.ai/blog/2025-07-08-what-is-glamajson.

`maintainers` lists the GitHub usernames granted ownership/management access.

## Follow-up

After merge, run Glama's **Claim ownership** flow with the `jed326` account to sync. Re-run that flow after any future edits to this file.

## Lines changed
- Logic: 0
- Tests: 0
- Docs/config: +7 (new `glama.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)