### PR TITLE
fix(deps): patch hono/undici/vite CVEs (CVE-2026-54290, -9697, -6734, -53571)

### DIFF
--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tako-mcp-workers",
-  "version": "0.7.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tako-mcp-workers",
-      "version": "0.7.2",
+      "version": "0.8.3",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -2497,9 +2497,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3421,9 +3421,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
-      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "engines": {
         "node": ">=20.18.1"
@@ -3461,9 +3461,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -5150,15 +5150,6 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
-      }
-    },
-    "node_modules/wrangler/node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/wrangler/node_modules/workerd": {

--- a/workers/package.json
+++ b/workers/package.json
@@ -43,6 +43,8 @@
     "@cloudflare/vitest-pool-workers": {
       "wrangler": ">=4.59.1"
     },
-    "undici@>=7.0.0 <7.24.0": "7.24.0"
+    "undici": "^7.28.0",
+    "hono": "^4.12.30",
+    "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
## Summary

Clears four Dependabot alerts on `workers/` (all transitive), due in 4–5 days, via `overrides` in `workers/package.json`:

| Package | Was | Now | CVE |
|---|---|---|---|
| undici | 7.24.0 | **7.28.0** | CVE-2026-9697, CVE-2026-6734 |
| hono | 4.12.16 | **4.12.30** | CVE-2026-54290 |
| vite | 6.4.2 | **6.4.3** | CVE-2026-53571 |

### Notes
- The existing `undici@>=7.0.0 <7.24.0 → 7.24.0` override (from a prior CVE fix) pinned undici at a version the *new* CVEs cover (`>=7.23.0,<7.28.0`). Replaced it with a blanket `"undici": "^7.28.0"`.
- `vite` stays on the 6.x line — vitest 3.2.6 and `@cloudflare/vitest-pool-workers` expect vite 6, so jumping to vite 7 would be a breaking, unrelated change.
- Scope: only the four listed alerts. `npm audit` reports a separate `@cloudflare/vitest-pool-workers`/miniflare/esbuild chain that would require a breaking major bump — out of scope for this security PR.

## Lines changed
- logic: 0 · deps: 4 · tests: 0 · docs: 0

## Verification
- `npm install` resolves a single copy of each: hono 4.12.30, undici 7.28.0, vite 6.4.3
- `npm audit` no longer flags hono/undici/vite
- `npm run typecheck` clean · `npm test` → 221 passed (16 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)