### PR TITLE
fix(config): point DJANGO_BASE_URL at tako.com to unblock graph tools (403/WAF)

### DIFF
--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -36,7 +36,7 @@
     "staging": {
       "name": "tako-mcp-staging",
       "vars": {
-        "DJANGO_BASE_URL": "https://staging.trytako.com",
+        "DJANGO_BASE_URL": "https://staging.tako.com",
         "PUBLIC_BASE_URL": "https://staging.tako.com",
         // OpenAI connector-directory token issued for
         // `mcp.staging.tako.com`. Served as plain text from
@@ -60,7 +60,7 @@
     "production": {
       "name": "tako-mcp-production",
       "vars": {
-        "DJANGO_BASE_URL": "https://trytako.com",
+        "DJANGO_BASE_URL": "https://tako.com",
         "PUBLIC_BASE_URL": "https://tako.com",
         // OpenAI connector-directory domain-verification token issued
         // for `mcp.tako.com`. Served as plain text from


### PR DESCRIPTION
## Summary

One-line config fix (follow-up to #132): point the Worker's `DJANGO_BASE_URL` at **`tako.com`** instead of `trytako.com`.

## Why

The graph tools shipped in #132 return **403** in the deployed MCP, while `tako_search`/`tako_answer` work. Root cause: **`trytako.com` sits behind a Cloudflare bot/WAF rule that blocks `/api/beta/graph/*` for any non-browser/datacenter caller** — including the Worker's own edge egress. `/api/v1` and `/api/v3` on `trytako.com` aren't behind that rule, which is exactly why search worked but the graph tools didn't.

`tako.com` (the OpenAPI spec's canonical host — `servers.url: https://tako.com/api`) has no such block.

## Verified live (prod + staging)

| Host | credit_balance | v3 search | **graph search** |
|---|---|---|---|
| `trytako.com` | 200 | 200 | **403 (WAF)** |
| `tako.com` | 200 | 200 | **200 ✅** |
| `staging.tako.com` | 401\* | 401\* | **401\* (reaches app — not blocked)** |

\* 401 = the request reaches the Django app but my prod key is wrong-namespace for staging (per-env key namespaces). The point is it's **401, not 403** — i.e. not WAF-blocked.

`PUBLIC_BASE_URL` was already `tako.com`/`staging.tako.com`; `DJANGO_BASE_URL` was the lone holdout.

```
production: https://trytako.com         -> https://tako.com
staging:    https://staging.trytako.com -> https://staging.tako.com
```

## Test plan
- [x] `npm run test` (256), `typecheck`, `registry:check`, `schemas:check` — all green (config-only change; no code touched)
- [ ] After staging deploy: confirm the three graph tools return data (not 403) with a **staging** token, and `tako_search` no longer throws "unexpected shape"

## Scope
Config only — `workers/wrangler.jsonc`, both `staging` and `production` envs. No tool code. Leaves user-facing token-management copy (OAuth messages referencing `trytako.com`) untouched — that's a separate concern.
