### PR TITLE
fix(graph): validate responses via loose facade, not strict generated schema (fixes 'unexpected shape' on kind:source)

### DIFF
--- a/workers/src/tools/tako_graph_node.ts
+++ b/workers/src/tools/tako_graph_node.ts
@@ -3,12 +3,12 @@
  *
  * Wraps `GET /api/beta/graph/node/{id}`. Use it when you hold a bare node id
  * (e.g. from a tako_search card's slim `nodes`) and need aliases/subtype/label
- * to compose a grounded query. Wire-guarded against the generated GraphNode.
+ * to compose a grounded query. Validated against the loose graphNodeSchema
+ * facade (not the strict generated GraphNode, whose enums drift).
  */
 import { z } from "zod";
 
 import { djangoGet } from "../django.js";
-import { GraphNode } from "../generated/schemas.js";
 import { graphErrorMessage, graphNodeSchema } from "./_graph.js";
 import type { ToolModule } from "./types.js";
 
@@ -46,15 +46,17 @@ const tako_graph_node = {
       throw new Error(graphErrorMessage(err, "node", input.id));
     }
 
-    const wire = GraphNode.safeParse(data);
-    if (!wire.success) {
+    // Validate against the LOOSE advertised facade, NOT the generated GraphNode
+    // (whose subtype/label enums drift — a new EntityClassName/NerLabel would
+    // make a strict guard throw "unexpected shape" on a valid node). The facade
+    // keeps those as loose strings; structural breaks still throw.
+    const parsed = outputSchema.safeParse(data);
+    if (!parsed.success) {
       throw new Error(
         "Tako graph/node endpoint returned an unexpected shape. Retry once; if it persists, flag it to the Tako team.",
       );
     }
-    // Re-validate through the advertised facade (parse-don't-cast) so a future
-    // facade/wire drift is caught at runtime, matching the sibling tools.
-    return outputSchema.parse(wire.data);
+    return parsed.data;
   },
 } satisfies ToolModule<typeof inputSchema, Output>;
 

--- a/workers/src/tools/tako_graph_related.test.ts
+++ b/workers/src/tools/tako_graph_related.test.ts
@@ -96,6 +96,42 @@ describe("tako_graph_related", () => {
     ).rejects.toThrow(/unexpected shape/);
   });
 
+  // Regression: the live API returns relation groups with kind:"source" (and can
+  // return new subtype/label values), which the generated RelationKind /
+  // EntityClassName / NerLabel enums don't list. Validating through the loose
+  // facade must accept these instead of throwing "unexpected shape". (Verified
+  // live on tako.com: Tesla's overview includes a kind:"source" group.)
+  it("accepts enum values the generated schema lacks (kind:source, exotic subtype/label)", async () => {
+    mockFetchSequence([
+      jsonResponse(200, {
+        node: hub,
+        relations: [
+          {
+            key: "rel:sourced_from",
+            kind: "source", // NOT in the generated RelationKind enum
+            label: "Sourced from",
+            items: [
+              {
+                id: "ent::x::1",
+                type: "entity",
+                name: "Some Source",
+                subtype: "Brand New Entity Class", // not in EntityClassName
+                label: "NEW_NER_LABEL", // not in NerLabel
+              },
+            ],
+            total: 1,
+            total_capped: false,
+          },
+        ],
+      }),
+    ]);
+
+    const out = await takoGraphRelated.handler({ node_id: "tesla-x1" }, CTX);
+    expect(out.relations?.[0]?.kind).toBe("source");
+    expect(out.relations?.[0]?.items[0]?.subtype).toBe("Brand New Entity Class");
+    expect(out.relations?.[0]?.items[0]?.label).toBe("NEW_NER_LABEL");
+  });
+
   it("maps a 404 into a node_id-focused message that distinguishes it from a bad relation", async () => {
     mockFetchSequence([jsonResponse(404, { detail: "not found" })]);
     await expect(

--- a/workers/src/tools/tako_graph_related.ts
+++ b/workers/src/tools/tako_graph_related.ts
@@ -5,12 +5,12 @@
  * coverage map; drill mode (relation=<key>) pages one group. `q` is a single
  * substring filter — to cover several name-variants of a metric, call this
  * tool once per variant (graph calls are free). Wire-guarded against the
- * generated GraphRelatedResponse.
+ * loose graphRelatedOutputShape facade (not the strict generated schema, whose
+ * RelationKind enum drifts — see the handler note).
  */
 import { z } from "zod";
 
 import { djangoGet } from "../django.js";
-import { GraphRelatedResponse } from "../generated/schemas.js";
 import { graphErrorMessage, graphRelatedOutputShape } from "./_graph.js";
 import type { ToolModule } from "./types.js";
 
@@ -80,15 +80,20 @@ const tako_graph_related = {
     } catch (err) {
       throw new Error(graphErrorMessage(err, "related", input.node_id));
     }
-    const wire = GraphRelatedResponse.safeParse(data);
-    if (!wire.success) {
+    // Validate against the LOOSE advertised facade, NOT the generated schema.
+    // The generated GraphRelatedResponse enforces a strict RelationKind enum
+    // (related|data|sibling|membership) — but the live API also returns
+    // kind:"source", which a strict guard rejects as "unexpected shape" even
+    // though the response is fine. Same drift class as content_format. The
+    // facade keeps kind/type/subtype/label as loose strings, so a new enum
+    // value passes while genuine structural breaks still throw.
+    const parsed = outputSchema.safeParse(data);
+    if (!parsed.success) {
       throw new Error(
         "Tako graph/related endpoint returned an unexpected shape. Retry once; if it persists, flag it to the Tako team.",
       );
     }
-    // Re-validate through the advertised facade (parse-don't-cast) so a future
-    // facade/wire drift is caught at runtime, matching the sibling tools.
-    return outputSchema.parse(wire.data);
+    return parsed.data;
   },
 } satisfies ToolModule<typeof inputSchema, Output>;
 

--- a/workers/src/tools/tako_graph_search.ts
+++ b/workers/src/tools/tako_graph_search.ts
@@ -2,14 +2,13 @@
  * `tako_graph_search` — resolve a name to Tako data-graph node(s).
  *
  * Wraps `GET /api/beta/graph/search`. Free + fast. The resolved node ids pin
- * into tako_search / tako_answer (sources.data.node_ids). Wire-guarded against
- * the generated GraphSearchResponse; returns the flat graphSearchOutputShape
- * facade.
+ * into tako_search / tako_answer (sources.data.node_ids). Validated against the
+ * loose graphSearchOutputShape facade (not the strict generated schema, whose
+ * enums drift — see the handler note).
  */
 import { z } from "zod";
 
 import { djangoGet } from "../django.js";
-import { GraphSearchResponse } from "../generated/schemas.js";
 import { graphErrorMessage, graphSearchOutputShape } from "./_graph.js";
 import type { ToolModule } from "./types.js";
 
@@ -70,15 +69,20 @@ const tako_graph_search = {
       throw new Error(graphErrorMessage(err, "search"));
     }
 
-    const wire = GraphSearchResponse.safeParse(data);
-    if (!wire.success) {
+    // Validate against the LOOSE advertised facade, NOT the generated schema.
+    // The generated GraphSearchResponse enforces strict enums (NerLabel,
+    // EntityClassName, ...) that drift: when the backend adds a value the
+    // committed enum lacks, a strict guard turns a benign addition into a total
+    // "unexpected shape" outage (already seen with content_format and with a
+    // graph/related kind of "source"). The facade keeps these fields as loose
+    // strings, so structural breaks still throw but new enum values pass.
+    const parsed = outputSchema.safeParse(data);
+    if (!parsed.success) {
       throw new Error(
         "Tako graph/search endpoint returned an unexpected shape. Retry once; if it persists, flag it to the Tako team.",
       );
     }
-    // Re-validate through the advertised facade (parse-don't-cast) so a future
-    // facade/wire drift is caught at runtime, matching the sibling tools.
-    return outputSchema.parse(wire.data);
+    return parsed.data;
   },
 } satisfies ToolModule<typeof inputSchema, Output>;
 


### PR DESCRIPTION
## Summary

Make the graph tools validate their responses through the **loose output facade** instead of the strict **generated** schema, so a new backend enum value can't take a tool down.

## The bug

Testing the deployed graph tools (from #132, now on `main`), `tako_graph_related` threw `"unexpected shape"` on a valid node. Root cause: the live API returns a relation group with **`kind: "source"`**, but the generated `RelationKind` enum only lists `related | data | sibling | membership`. The strict `GraphRelatedResponse.safeParse` wire-guard rejected the *entire* (valid) response over that one value.

This is the **same drift class** as the `content_format` outage and the node-`type` enum flagged in #132 review: the generated schema's enums (`RelationKind`, `NerLabel`, `EntityClassName`) go stale relative to the deployed API, and a strict guard turns a benign addition into a total failure.

## The fix

All three graph tools (`tako_graph_search` / `related` / `node`) now `safeParse` the raw response through their **loose facade** (`kind`/`type`/`subtype`/`label` are `z.string()`) rather than the strict generated schema. A new enum value passes; genuine structural breaks (missing `id`, `results`/`relations` not an array, an error object) still throw. Removes the now-unused generated-schema imports.

This kills the whole enum-drift class permanently — no schema regeneration needed to keep the tools alive when the backend adds a value.

## Verification

- Verified live against `tako.com`: the real Tesla `/related` response (16 relation groups, incl. a `kind:"source"` group) now parses cleanly through the facade.
- Regression test added: an overview with `kind:"source"` plus an out-of-enum `subtype`/`label` must be accepted, not rejected.
- Full suite **263 passing**, typecheck + registry:check green.

## Relationship to #133
Independent. #133 is the `DJANGO_BASE_URL → tako.com` config fix (the `403`/WAF problem); this PR is the response-validation fix (the `"unexpected shape"` problem). Both are needed for the graph tools to work end-to-end in the deployed MCP; they can merge in any order.
