### PR TITLE
feat(tools): make tako_visualize, tako_graph_node, get_credit_balance opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ Source of truth: `workers/src/tools/*.ts`. Tools are discovered at runtime via t
 2. `tako_answer` — Get **one** synthesized, citation-backed prose answer (arbiter over data + web) to a specific data question; ground in `["data"]`, `["web"]`, or both. Use when you want a direct written answer in a single call rather than a list of cards.
 3. `tako_contents` — Fetch underlying content (CSV or text) behind a result URL
 4. `tako_agent` — Answer Agent for multi-step data questions (on ChatGPT split into `tako_agent_start` / `tako_agent_wait`). **Opt-in** — off by default; enabled per-connection via `?tools=agent` (see `workers/src/tools/_optional.ts`).
-5. `get_credit_balance` — Current credit balance
+5. `tako_visualize` — Create an embeddable chart/card from your own structured data. **Opt-in** — `?tools=visualize`; stays default-on for ChatGPT (it powers the widget — see `CHATGPT_DEFAULT_ON_TOOL_NAMES` in `workers/src/mcp.ts`).
+6. `tako_graph_node` — Hydrate a graph node ID into full detail. **Opt-in** — `?tools=graph_node`.
+7. `get_credit_balance` — Current credit balance. **Opt-in** — `?tools=credits`.
 
 ### Endpoints
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This MCP server enables AI agents to:
 - **Fetch** underlying content (CSV or text) behind result URLs
 - **Explore** Tako's data graph to see exactly what data exists for an entity or metric
 - **Visualize** your own structured data as an embeddable chart
-- **Run** Tako's Answer Agent for deep, multi-step research (opt-in — [enable it](#enabling-the-tako-agent-opt-in))
+- **Run** Tako's Answer Agent for deep, multi-step research (opt-in — [enable it](#optional-tools-opt-in))
 
 ## Quick start
 
@@ -186,15 +186,15 @@ There are two ways to break the connection, and they have different blast radius
 
 Tools are discovered automatically via the MCP `tools/list` handshake; your client always sees the live surface. Auth is connection-level (Bearer token or OAuth) — there is no per-call `api_token` argument.
 
-- **`tako_search`** — **Pull the actual data to work with.** Fast search over Tako's curated knowledge graph and the live web; each card carries a free inline preview of its latest rows by default (`include_contents`, on by default; set `false` for pointers-only). The top result renders as an interactive chart — inline as an MCP Apps widget on ChatGPT, and with an **Open in Tako** link everywhere. **Parallelize it:** decompose a broad or multi-part question into several narrow, single entity+metric searches run concurrently (e.g. "US CPI inflation", "US core PCE inflation", …) rather than one broad query — narrow queries retrieve far better. Choose `sources` (`["data"]`, `["web"]`, or **both by default**) and `effort` (`fast` default | `instant`). For the full data (or a web page's text), call `tako_contents` on the result URL. For deep, multi-step research — or when search returns nothing — use `tako_agent` (an [opt-in tool](#enabling-the-tako-agent-opt-in)).
+- **`tako_search`** — **Pull the actual data to work with.** Fast search over Tako's curated knowledge graph and the live web; each card carries a free inline preview of its latest rows by default (`include_contents`, on by default; set `false` for pointers-only). The top result renders as an interactive chart — inline as an MCP Apps widget on ChatGPT, and with an **Open in Tako** link everywhere. **Parallelize it:** decompose a broad or multi-part question into several narrow, single entity+metric searches run concurrently (e.g. "US CPI inflation", "US core PCE inflation", …) rather than one broad query — narrow queries retrieve far better. Choose `sources` (`["data"]`, `["web"]`, or **both by default**) and `effort` (`fast` default | `instant`). For the full data (or a web page's text), call `tako_contents` on the result URL. For deep, multi-step research — or when search returns nothing — use `tako_agent` (an [opt-in tool](#optional-tools-opt-in)).
 - **`tako_answer`** — **Ask one specific, self-contained data question, get the answer.** A single grounded, citation-backed prose answer written for you (you don't touch the rows). Ground in `["data"]`, `["web"]`, or **both (default)**. For broad/multi-part needs, or when you want the underlying data to synthesize yourself, use `tako_search` (parallelized) instead; dig into a cited result's data with `tako_contents`.
 - **`tako_contents`** — Fetch the content behind a result URL: a Tako card URL returns a CSV; any other URL returns the page's extracted text.
 - **`tako_graph_search`** — Resolve a name (an entity or a metric) to Tako data-graph node IDs, so you can see **what data Tako has** for it and pin those IDs into `tako_search` / `tako_answer` for a strong retrieval boost. Graph calls are free.
 - **`tako_graph_related`** — Explore what a resolved node connects to — its available metrics, related entities, and named relationships. This is the map of what data Tako actually holds for an entity.
-- **`tako_graph_node`** — Hydrate a bare node ID into full detail (name, aliases, subtype, description) — useful for confirming what a node returned on a search card actually is.
-- **`tako_visualize`** — Create an embeddable chart/card directly from your own structured data (Tako's [Thin-Viz](https://tako.com/docs/) API). Supply typed `components` (timeseries, bar, table, financial boxes, …); the card auto-renders inline and returns `webpage_url` / `embed_url`.
-- **`tako_agent`** — _Opt-in tool ([enable it](#enabling-the-tako-agent-opt-in))._ Run Tako's **Answer Agent**: opinionated, multi-step research for complex questions that need reasoning across many retrievals. Returns a synthesized, citation-backed answer plus supporting chart cards. Distinct from one-shot `tako_answer` (a single grounded lookup) — the agent is slower (~30–90s) but far more thorough. (On ChatGPT this is exposed as the `tako_agent_start` / `tako_agent_wait` pair to fit the host's tool-call timeout model.)
-- **`get_credit_balance`** — Check the connected account's API credit balance.
+- **`tako_graph_node`** — _Opt-in tool ([enable with `?tools=graph_node`](#optional-tools-opt-in))._ Hydrate a bare node ID into full detail (name, aliases, subtype, description) — useful for confirming what a node returned on a search card actually is.
+- **`tako_visualize`** — _Opt-in tool ([enable with `?tools=visualize`](#optional-tools-opt-in); on by default for ChatGPT)._ Create an embeddable chart/card directly from your own structured data (Tako's [Thin-Viz](https://tako.com/docs/) API). Supply typed `components` (timeseries, bar, table, financial boxes, …); the card auto-renders inline and returns `webpage_url` / `embed_url`.
+- **`tako_agent`** — _Opt-in tool ([enable with `?tools=agent`](#optional-tools-opt-in))._ Run Tako's **Answer Agent**: opinionated, multi-step research for complex questions that need reasoning across many retrievals. Returns a synthesized, citation-backed answer plus supporting chart cards. Distinct from one-shot `tako_answer` (a single grounded lookup) — the agent is slower (~30–90s) but far more thorough. (On ChatGPT this is exposed as the `tako_agent_start` / `tako_agent_wait` pair to fit the host's tool-call timeout model.)
+- **`get_credit_balance`** — _Opt-in tool ([enable with `?tools=credits`](#optional-tools-opt-in))._ Check the connected account's API credit balance.
 
 ### Answer vs. Search — the core distinction
 
@@ -211,12 +211,21 @@ Rules of thumb:
 - **Broad or multi-part → `tako_search`, parallelized.** Don't send a multi-part question to *either* tool as one call. Decompose it into narrow single **entity + metric** searches and fire them concurrently — e.g. *"US CPI inflation"*, *"US core CPI inflation"*, *"US PCE inflation"*, *"US core PCE inflation"* — then synthesize the four results yourself. Narrow queries retrieve far more accurately.
 - In one line: **`tako_answer` hands you a conclusion; `tako_search` hands you the evidence.**
 
-### Enabling the Tako agent (opt-in)
+### Optional tools (opt-in)
 
-The Answer Agent is **off by default** — the everyday tools (`tako_search`, `tako_answer`, `tako_contents`, …) cover most questions, and the agent is a slower, heavier tool you turn on when you want it. Enable it by adding `?tools=agent` to the MCP URL:
+To keep the default tool surface small (less context loaded into every session, fewer tools for the model to weigh), some tools are **off by default** and enabled per-connection via the `?tools=` query parameter on the MCP URL. The everyday tools (`tako_search`, `tako_answer`, `tako_contents`, `tako_graph_search`, `tako_graph_related`) cover most questions; opt in to the rest as needed:
+
+| Alias | Enables | What it's for |
+|---|---|---|
+| `agent` | `tako_agent` (ChatGPT: `tako_agent_start` / `tako_agent_wait`) | Deep, multi-step Answer Agent research |
+| `visualize` | `tako_visualize` | Author charts from your own data (already on by default for ChatGPT, where it powers the widget) |
+| `graph_node` | `tako_graph_node` | Hydrate a bare graph node ID into full detail |
+| `credits` | `get_credit_balance` | Check API credit balance |
+
+Aliases compose as a comma-separated list:
 
 ```
-https://mcp.tako.com/mcp?tools=agent
+https://mcp.tako.com/mcp?tools=agent,visualize,credits
 ```
 
 For example, with the CLI:
@@ -226,7 +235,7 @@ claude mcp add tako-mcp --transport http "https://mcp.tako.com/mcp?tools=agent" 
   --header "Authorization: Bearer $TAKO_API_TOKEN"
 ```
 
-`agent` is an alias — with it enabled, the server exposes the single-call `tako_agent` on most clients and automatically switches to the `tako_agent_start` / `tako_agent_wait` pair on ChatGPT. Unknown values in `?tools=` are ignored, so a typo never breaks the connection. Omit the parameter entirely to run without the agent.
+Only alias names are recognized (not raw tool names), and unknown values in `?tools=` are ignored, so a typo never breaks the connection. Omit the parameter entirely for the default surface.
 
 ## Example Flows
 
@@ -243,7 +252,7 @@ claude mcp add tako-mcp --transport http "https://mcp.tako.com/mcp?tools=agent" 
 
 ## Breaking changes (v0.3.0)
 
-- The default tool surface is: **`tako_search`**, **`tako_answer`**, **`tako_contents`**, **`tako_graph_search`**, **`tako_graph_related`**, **`tako_graph_node`**, **`tako_visualize`**, and **`get_credit_balance`**, plus the opt-in **`tako_agent`** (the ChatGPT split pair **`tako_agent_start`** / **`tako_agent_wait`**), enabled with [`?tools=agent`](#enabling-the-tako-agent-opt-in).
+- The default tool surface is: **`tako_search`**, **`tako_answer`**, **`tako_contents`**, **`tako_graph_search`**, and **`tako_graph_related`**. Everything else is [opt-in via `?tools=`](#optional-tools-opt-in): **`tako_agent`** (`agent`; on ChatGPT the split pair **`tako_agent_start`** / **`tako_agent_wait`**), **`tako_visualize`** (`visualize`; default-on for ChatGPT), **`tako_graph_node`** (`graph_node`), and **`get_credit_balance`** (`credits`).
 - The chart-image (`get_chart_image`), interactive-chart (`open_chart_ui`), chart-creation (`create_chart`), and report tools (`create_report`, `get_report`, `list_reports`, `export_report`) were removed.
 - The self-hosted Python server (`pip install tako-mcp` / Docker) was removed in favor of the hosted Cloudflare Worker.
 

--- a/agent.json
+++ b/agent.json
@@ -97,7 +97,7 @@
     {
       "id": "visualize-data",
       "name": "Visualize Your Data",
-      "description": "Create an embeddable Tako chart/card directly from your own structured data — timeseries, bar, table, financial boxes, and more. The card auto-renders as an interactive chart.",
+      "description": "Create an embeddable Tako chart/card directly from your own structured data — timeseries, bar, table, financial boxes, and more. The card auto-renders as an interactive chart. Opt-in (enable with ?tools=visualize; on by default for ChatGPT).",
       "tags": [
         "visualize",
         "charts",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16,7 +16,7 @@ Hosted endpoint: `https://mcp.tako.com/mcp` (Streamable HTTP).
 - CLI/desktop hosts (Claude Code, Claude Desktop, Cursor, Windsurf): pass `Authorization: Bearer <TAKO_API_TOKEN>`. Get a token at tako.com -> account settings -> API tokens.
 - Web hosts (Claude.ai, ChatGPT): connect via the server's OAuth flow; no token config needed.
 
-Optional tools: the Answer Agent (`tako_agent`) is opt-in and off by default. Enable it by adding `?tools=agent` to the endpoint URL: `https://mcp.tako.com/mcp?tools=agent`. `agent` is an alias — the server picks the single-call `tako_agent` on most clients and the `tako_agent_start` / `tako_agent_wait` pair on ChatGPT. Unknown `?tools=` values are ignored, so a typo never breaks the connection.
+Optional tools: some tools are opt-in and off by default, to keep the default surface small. Enable them by adding `?tools=` to the endpoint URL with comma-separated aliases, e.g. `https://mcp.tako.com/mcp?tools=agent,visualize`. Aliases: `agent` (Answer Agent — the server picks the single-call `tako_agent` on most clients and the `tako_agent_start` / `tako_agent_wait` pair on ChatGPT), `visualize` (`tako_visualize`; already on by default for ChatGPT, where it powers the chart widget), `graph_node` (`tako_graph_node`), `credits` (`get_credit_balance`). Only aliases are recognized (not raw tool names); unknown `?tools=` values are ignored, so a typo never breaks the connection.
 
 Tools are discovered at runtime via `tools/list`. There is no per-call `api_token` argument — auth is connection-level.
 
@@ -69,7 +69,7 @@ Parameters:
 Typical flow: `tako_search` to find cards/results → `tako_contents` on a result URL to pull the actual rows or data for analysis.
 
 ### tako_visualize
-Create an embeddable Tako card directly from your OWN structured data (not from search), backed by Tako's Thin-Viz API. Provide one or more typed components; the card auto-renders inline as a chart and returns share/embed URLs.
+Opt-in tool — off by default; enable with `?tools=visualize` on the endpoint URL (see Connecting; already on by default for ChatGPT). Create an embeddable Tako card directly from your OWN structured data (not from search), backed by Tako's Thin-Viz API. Provide one or more typed components; the card auto-renders inline as a chart and returns share/embed URLs.
 
 Parameters:
 - `components` (array, required): One or more `{ component_type, config, component_variant? }` objects. `component_type` is one of: header, generic_timeseries, categorical_bar, choropleth, data_table_chart, histogram, pie, table, financial_boxes, timeline, treemap, heatmap, marimekko, boxplot, waterfall, sankey, scatter, bubble, top_level_metric, person_card. `config` holds that type's data (validated server-side). The optional `component_variant` string selects a type variant (e.g. 'simple', 'financial'). `person_card` must be the only component.
@@ -86,6 +86,6 @@ Parameters:
 - `query` (string, required): The deep/analytical question
 
 ### get_credit_balance
-Check the connected account's API credit balance.
+Opt-in tool — off by default; enable with `?tools=credits` on the endpoint URL (see Connecting). Check the connected account's API credit balance.
 
 Parameters: none.

--- a/llms.txt
+++ b/llms.txt
@@ -13,13 +13,13 @@
 
 Connect your MCP client to `https://mcp.tako.com/mcp` with `Authorization: Bearer <TAKO_API_TOKEN>` (CLI/desktop), or via the server's OAuth flow (Claude.ai, ChatGPT).
 
-The Answer Agent (`tako_agent`) is opt-in — off by default. Enable it by adding `?tools=agent` to the URL: `https://mcp.tako.com/mcp?tools=agent`.
+Some tools are opt-in — off by default to keep the tool surface small. Enable them via `?tools=` on the URL (comma-separated aliases): `agent` (Answer Agent), `visualize` (chart authoring; already on by default for ChatGPT), `graph_node` (node detail lookup), `credits` (credit balance). Example: `https://mcp.tako.com/mcp?tools=agent,visualize`.
 
 ## Capabilities
 
 - Pull the actual data to work with — real rows/time-series over 100K+ curated charts (economics, finance, demographics, sports, markets, weather) plus the live web on request (`tako_search`); cards carry a free inline row preview by default and the top result auto-renders as an interactive chart. Parallelize it: fire several narrow single entity+metric searches rather than one broad multi-part query. Deep multi-step research is the opt-in Answer Agent (`tako_agent`, enable with `?tools=agent`).
 - Ask a single specific data question and get a grounded, citation-backed prose answer already synthesized for you — trust it and relay it directly (`tako_answer`); for broad or multi-part needs, or when you want the underlying data to synthesize yourself, use `tako_search` (parallelized into narrow entity+metric queries) instead.
 - Fetch the actual rows or data (CSV/JSON) behind a Tako card, or the extracted text behind a web result — the step after search when you need real data to analyze (`tako_contents`)
-- Create an embeddable chart/card directly from your own structured data — timeseries, bar, table, financial boxes, and more (`tako_visualize`); the card auto-renders as an interactive chart.
+- Create an embeddable chart/card directly from your own structured data — timeseries, bar, table, financial boxes, and more (`tako_visualize`; opt-in, enable with `?tools=visualize`; on by default for ChatGPT); the card auto-renders as an interactive chart.
 - Run a multi-step Answer Agent for complex analytical questions (`tako_agent`; opt-in, enable with `?tools=agent`)
-- Check API credit balance (`get_credit_balance`)
+- Check API credit balance (`get_credit_balance`; opt-in, enable with `?tools=credits`)

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -6,8 +6,9 @@
  *
  *   1. `GET /health`           → expect HTTP 200 with body "ok"
  *   2. MCP `initialize`        → handshake completes
- *   3. MCP `tools/list`        → 8-tool surface present; hard-asserts
- *                                 the 5 non-gated canary tools; loosely
+ *   3. MCP `tools/list`        → connects with `?tools=agent,visualize,credits`
+ *                                 (those tools are opt-in — see `_optional.ts`);
+ *                                 hard-asserts the 5 canary tools; loosely
  *                                 asserts at least one agent tool is present
  *   4. MCP Apps widget assertion on `tako_search` (soft-warn on miss)
  *   5. Per-tool MCP `tools/call` canaries:
@@ -117,11 +118,17 @@ ok(`/health → 200 "ok"`);
 // ---------------------------------------------------------------------------
 // 2-5. MCP protocol via the SDK client
 // ---------------------------------------------------------------------------
-const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
-  requestInit: {
-    headers: { authorization: `Bearer ${apiToken}` },
+// Opt in to the optional tools the smoke exercises (see `_optional.ts`):
+// `agent` for the agent-presence assert, `visualize` and `credits` for the
+// tool calls below. This also smoke-tests the `?tools=` opt-in path itself.
+const transport = new StreamableHTTPClientTransport(
+  new URL(`${baseUrl}/mcp?tools=agent,visualize,credits`),
+  {
+    requestInit: {
+      headers: { authorization: `Bearer ${apiToken}` },
+    },
   },
-});
+);
 const client = new Client({ name: "tako-mcp-smoke", version: "1.0.0" });
 
 try {

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -216,22 +216,21 @@ describe("worker routing", () => {
       };
     };
     const names = body.result.tools.map((t) => t.name).sort();
-    // Default tool set with NO `tools` query param — the agent is opt-in and
-    // therefore absent. `tako_agent` (single-call) and the ChatGPT split pair
-    // `tako_agent_start` / `tako_agent_wait` are all in `OPTIONAL_TOOL_NAMES`
-    // (see `_optional.ts`) and only appear when the connector adds
-    // `?tools=agent`. Chart-authoring tools (`create_chart`, `get_chart_image`,
-    // `open_chart_ui`) were removed in 0.3.0; `tako_search` is the sole owner
-    // of the chart widget (auto-renders the top card inline).
+    // Default tool set with NO `tools` query param — every opt-in tool is
+    // absent. The agent trio (`?tools=agent`), `tako_visualize`
+    // (`?tools=visualize`), `tako_graph_node` (`?tools=graph_node`), and
+    // `get_credit_balance` (`?tools=credits`) are all in
+    // `OPTIONAL_TOOL_NAMES` (see `_optional.ts`) and only appear when the
+    // connector opts in. Chart-authoring tools (`create_chart`,
+    // `get_chart_image`, `open_chart_ui`) were removed in 0.3.0;
+    // `tako_search` is the sole owner of the chart widget on the default
+    // surface (auto-renders the top card inline).
     expect(names).toEqual([
-      "get_credit_balance",
       "tako_answer",
       "tako_contents",
-      "tako_graph_node",
       "tako_graph_related",
       "tako_graph_search",
       "tako_search",
-      "tako_visualize",
     ]);
 
     // MCP Apps: `tako_search` is the sole chart-widget tool after 0.3.0.
@@ -250,7 +249,9 @@ describe("worker routing", () => {
     // it the widget loads but `window.openai.toolOutput` never
     // populates). Other tools ship no widget and should declare
     // none of these fields.
-    const widgetTools = new Set(["tako_search", "tako_visualize"]);
+    // `tako_visualize` also carries the widget but is opt-in (absent here);
+    // its listing metadata is asserted in the `?tools=visualize` test below.
+    const widgetTools = new Set(["tako_search"]);
     for (const name of widgetTools) {
       const tool = body.result.tools.find((t) => t.name === name);
       expect(tool?._meta).toMatchObject({
@@ -308,8 +309,11 @@ describe("worker routing", () => {
     expect(names.has("tako_agent")).toBe(false);
     // The default tools are still present alongside.
     expect(names.has("tako_search")).toBe(true);
-    // 8 default tools + tako_agent_start + tako_agent_wait = 10.
-    expect(body.result.tools).toHaveLength(10);
+    // `tako_visualize` is opt-in for other clients but default-on for
+    // ChatGPT (`CHATGPT_DEFAULT_ON_TOOL_NAMES`) — it powers the widget.
+    expect(names.has("tako_visualize")).toBe(true);
+    // 5 defaults + tako_visualize (ChatGPT default-on) + the split pair = 8.
+    expect(body.result.tools).toHaveLength(8);
 
     // `tako_search` is the sole chart-widget tool on ChatGPT after 0.3.0.
     // The empty-fast widget-gap problem (ChatGPT pins widget container
@@ -349,12 +353,19 @@ describe("worker routing", () => {
     };
     const names = new Set(body.result.tools.map((t) => t.name));
     // The agent is opt-in: without `?tools=agent`, ChatGPT gets neither the
-    // split pair nor the single tool — just the 8 default tools.
+    // split pair nor the single tool.
     expect(names.has("tako_agent_start")).toBe(false);
     expect(names.has("tako_agent_wait")).toBe(false);
     expect(names.has("tako_agent")).toBe(false);
     expect(names.has("tako_search")).toBe(true);
-    expect(body.result.tools).toHaveLength(8);
+    // `tako_visualize` IS present without opting in — ChatGPT keeps it on
+    // the default surface (`CHATGPT_DEFAULT_ON_TOOL_NAMES`) for the widget.
+    expect(names.has("tako_visualize")).toBe(true);
+    // The other opt-in tools stay absent for ChatGPT too.
+    expect(names.has("tako_graph_node")).toBe(false);
+    expect(names.has("get_credit_balance")).toBe(false);
+    // 5 defaults + tako_visualize = 6.
+    expect(body.result.tools).toHaveLength(6);
   });
 
   it("POST /mcp?tools=agent adds the single tako_agent tool on non-ChatGPT clients", async () => {
@@ -386,14 +397,16 @@ describe("worker routing", () => {
     expect(names.has("tako_agent_start")).toBe(false);
     expect(names.has("tako_agent_wait")).toBe(false);
     expect(names.has("tako_search")).toBe(true);
-    // 8 default tools + tako_agent = 9.
-    expect(body.result.tools).toHaveLength(9);
+    // Other opt-in tools stay absent — `?tools=agent` enables only the agent.
+    expect(names.has("tako_visualize")).toBe(false);
+    // 5 default tools + tako_agent = 6.
+    expect(body.result.tools).toHaveLength(6);
   });
 
-  it("POST /mcp?tools=<unknown> ignores the bad value and serves the default 8 tools", async () => {
+  it("POST /mcp?tools=<unknown> ignores the bad value and serves the default 5 tools", async () => {
     // A typo (or any unrecognized alias) in `?tools=` must never break the
     // connection: unknown tokens are dropped, no optional tool is enabled, and
-    // the request layer still returns exactly the 8 defaults. This guards the
+    // the request layer still returns exactly the 5 defaults. This guards the
     // parser's "unknown token is never fatal" promise end-to-end.
     const res = await SELF.fetch("https://example.com/mcp?tools=nope", {
       method: "POST",
@@ -416,12 +429,94 @@ describe("worker routing", () => {
       result: { tools: Array<{ name: string }> };
     };
     const names = new Set(body.result.tools.map((t) => t.name));
-    // No agent tool sneaks in from an unrecognized alias.
+    // No opt-in tool sneaks in from an unrecognized alias.
     expect(names.has("tako_agent")).toBe(false);
     expect(names.has("tako_agent_start")).toBe(false);
     expect(names.has("tako_agent_wait")).toBe(false);
+    expect(names.has("tako_visualize")).toBe(false);
     expect(names.has("tako_search")).toBe(true);
-    expect(body.result.tools).toHaveLength(8);
+    expect(body.result.tools).toHaveLength(5);
+  });
+
+  it("POST /mcp?tools=visualize adds tako_visualize with its widget metadata (non-ChatGPT)", async () => {
+    // No User-Agent → client "unknown". A claude UA would blanket-suppress
+    // widget `_meta` (see `widgetSuppressed` in mcp.ts), which would make the
+    // widget assertion below vacuous.
+    const res = await SELF.fetch("https://example.com/mcp?tools=visualize", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        tools: Array<{ name: string; _meta?: Record<string, unknown> }>;
+      };
+    };
+    const names = new Set(body.result.tools.map((t) => t.name));
+    expect(names.has("tako_visualize")).toBe(true);
+    // Only the requested alias is enabled — the other opt-ins stay off.
+    expect(names.has("tako_graph_node")).toBe(false);
+    expect(names.has("get_credit_balance")).toBe(false);
+    expect(names.has("tako_agent")).toBe(false);
+    // 5 default tools + tako_visualize = 6.
+    expect(body.result.tools).toHaveLength(6);
+
+    // Opting in must not strip the widget: the listing still declares the
+    // chart resource under all three metadata keys (see the default-set test
+    // for why each key exists).
+    const visualizeTool = body.result.tools.find(
+      (t) => t.name === "tako_visualize",
+    );
+    expect(visualizeTool?._meta).toMatchObject({
+      ui: { resourceUri: "ui://tako/embed/chart" },
+      "ui/resourceUri": "ui://tako/embed/chart",
+      "openai/outputTemplate": "ui://tako/embed/chart",
+    });
+  });
+
+  it("POST /mcp?tools=graph_node,credits composes multiple single-tool aliases", async () => {
+    const res = await SELF.fetch(
+      "https://example.com/mcp?tools=graph_node,credits",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          authorization: AUTH_HEADER,
+          "user-agent": "claude-mcp-client/1.0",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+          params: {},
+        }),
+      },
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { tools: Array<{ name: string }> };
+    };
+    const names = new Set(body.result.tools.map((t) => t.name));
+    expect(names.has("tako_graph_node")).toBe(true);
+    expect(names.has("get_credit_balance")).toBe(true);
+    // Aliases not in the list stay off.
+    expect(names.has("tako_visualize")).toBe(false);
+    expect(names.has("tako_agent")).toBe(false);
+    // 5 default tools + tako_graph_node + get_credit_balance = 7.
+    expect(body.result.tools).toHaveLength(7);
   });
 
   it("POST /mcp tools/list serves one client-agnostic tako_search description", async () => {

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -227,6 +227,12 @@ export function createMcpServer(
   // success state. Most chart-conditional tools should rely on the
   // throw-on-empty pattern instead.
   const CHATGPT_NO_WIDGET_TOOL_NAMES = new Set<string>();
+  // Optional tools that stay on the DEFAULT surface for ChatGPT only.
+  // `tako_visualize` ships the chart widget ChatGPT renders; hiding it
+  // behind `?tools=` would silently break the ChatGPT app experience,
+  // so ChatGPT keeps it without opting in. Every other client must
+  // enable it via `?tools=visualize`.
+  const CHATGPT_DEFAULT_ON_TOOL_NAMES = new Set(["tako_visualize"]);
   const client = options.client ?? "unknown";
   // Opt-in tools enabled for this request via `?tools=` (see `_optional.ts`).
   // Empty by default → the default surface excludes every optional tool.
@@ -234,13 +240,16 @@ export function createMcpServer(
     options.enabledOptionalToolNames ?? new Set<string>();
 
   for (const tool of TOOL_REGISTRY) {
-    // Opt-in gate: optional tools (currently the agent trio) are excluded
-    // from the default surface and registered only when enabled via the
-    // `tools` query param. Applied BEFORE the per-client filters below so a
-    // disabled tool never reaches client-variant selection.
+    // Opt-in gate: optional tools (see `OPTIONAL_TOOL_ALIASES` in
+    // `_optional.ts`) are excluded from the default surface and registered
+    // only when enabled via the `tools` query param — except tools ChatGPT
+    // keeps by default (`CHATGPT_DEFAULT_ON_TOOL_NAMES`). Applied BEFORE the
+    // per-client filters below so a disabled tool never reaches
+    // client-variant selection.
     if (
       OPTIONAL_TOOL_NAMES.has(tool.name) &&
-      !enabledOptionalToolNames.has(tool.name)
+      !enabledOptionalToolNames.has(tool.name) &&
+      !(client === "chatgpt" && CHATGPT_DEFAULT_ON_TOOL_NAMES.has(tool.name))
     ) {
       continue;
     }

--- a/workers/src/tools/_optional.test.ts
+++ b/workers/src/tools/_optional.test.ts
@@ -10,9 +10,24 @@ import {
 // mapping fails these tests loudly rather than silently passing.
 const AGENT_TOOLS = ["tako_agent", "tako_agent_start", "tako_agent_wait"];
 
+// The single-tool aliases: context-heavy or rarely-needed tools kept off the
+// default surface. Same loud-failure rationale as AGENT_TOOLS.
+const SINGLE_TOOL_ALIASES: Record<string, string> = {
+  visualize: "tako_visualize",
+  graph_node: "tako_graph_node",
+  credits: "get_credit_balance",
+};
+
+const ALL_OPTIONAL_TOOLS = [
+  ...AGENT_TOOLS,
+  ...Object.values(SINGLE_TOOL_ALIASES),
+];
+
 describe("OPTIONAL_TOOL_NAMES", () => {
   it("is the flattened union of every alias's tool names", () => {
-    expect([...OPTIONAL_TOOL_NAMES].sort()).toEqual([...AGENT_TOOLS].sort());
+    expect([...OPTIONAL_TOOL_NAMES].sort()).toEqual(
+      [...ALL_OPTIONAL_TOOLS].sort(),
+    );
   });
 });
 
@@ -32,10 +47,28 @@ describe("parseEnabledOptionalToolNames", () => {
     );
   });
 
+  it.each(Object.entries(SINGLE_TOOL_ALIASES))(
+    "expands the `%s` alias to %s",
+    (alias, toolName) => {
+      expect([...parseEnabledOptionalToolNames(alias)]).toEqual([toolName]);
+    },
+  );
+
+  it("composes multiple aliases in one list", () => {
+    expect(
+      [...parseEnabledOptionalToolNames("agent,visualize,credits")].sort(),
+    ).toEqual(
+      [...AGENT_TOOLS, "tako_visualize", "get_credit_balance"].sort(),
+    );
+  });
+
   it("trims surrounding whitespace and lowercases tokens", () => {
     expect([...parseEnabledOptionalToolNames("  Agent ")].sort()).toEqual(
       [...AGENT_TOOLS].sort(),
     );
+    expect([...parseEnabledOptionalToolNames(" Visualize ")]).toEqual([
+      "tako_visualize",
+    ]);
   });
 
   it("de-duplicates a repeated alias", () => {
@@ -49,9 +82,12 @@ describe("parseEnabledOptionalToolNames", () => {
   });
 
   it("ignores raw tool names — only aliases are recognized", () => {
-    // `tako_agent` is a tool name, not an alias key; alias-only recognition
-    // means it resolves to nothing. Enabling the agent requires `agent`.
+    // `tako_agent` and `tako_visualize` are tool names, not alias keys;
+    // alias-only recognition means they resolve to nothing. Enabling a tool
+    // requires its alias (`agent`, `visualize`, ...).
     expect(parseEnabledOptionalToolNames("tako_agent").size).toBe(0);
+    expect(parseEnabledOptionalToolNames("tako_visualize").size).toBe(0);
+    expect(parseEnabledOptionalToolNames("get_credit_balance").size).toBe(0);
   });
 
   it("keeps recognized aliases and drops unknown tokens in a mixed list", () => {

--- a/workers/src/tools/_optional.ts
+++ b/workers/src/tools/_optional.ts
@@ -21,6 +21,13 @@
  * then narrow to the correct variant for the calling client. Users never need
  * to know the split exists — they enable `agent` and get the right tool.
  *
+ * `visualize`, `graph_node`, and `credits` are single-tool aliases: these
+ * tools are useful but rarely needed, so they are kept off the default
+ * surface to save per-session context. They compose freely, e.g.
+ * `?tools=visualize,credits`. Exception: `tako_visualize` stays on the
+ * default surface for ChatGPT clients (it powers the chart widget) — see
+ * `CHATGPT_DEFAULT_ON_TOOL_NAMES` in `mcp.ts`.
+ *
  * Only aliases are recognized on the wire (not raw tool names), so this table
  * is also the complete, closed set of tokens `?tools=` accepts.
  */
@@ -28,6 +35,9 @@ export const OPTIONAL_TOOL_ALIASES: Readonly<
   Record<string, readonly string[]>
 > = {
   agent: ["tako_agent", "tako_agent_start", "tako_agent_wait"],
+  visualize: ["tako_visualize"],
+  graph_node: ["tako_graph_node"],
+  credits: ["get_credit_balance"],
 };
 
 /**


### PR DESCRIPTION
## Summary

Moves three rarely-needed tools off the default MCP surface to cut per-session context and tool-choice noise, reusing the existing `?tools=` opt-in mechanism (the one `agent` already uses).

> **Stacked on #139** — based on `docs/clarify-when-to-call-contents` since this builds on the slimming/description work there. GitHub will retarget to `main` once #139 merges.

### New opt-in aliases (`workers/src/tools/_optional.ts`)

| Alias | Enables | Notes |
|---|---|---|
| `visualize` | `tako_visualize` | ~700 tokens of description+schema — the heaviest tool. **Stays default-on for ChatGPT**, where it powers the chart widget (`CHATGPT_DEFAULT_ON_TOOL_NAMES` in `mcp.ts`). |
| `graph_node` | `tako_graph_node` | Node-detail hydration; `tako_graph_search` / `tako_graph_related` stay default. |
| `credits` | `get_credit_balance` | |

Aliases compose: `https://mcp.tako.com/mcp?tools=agent,visualize,credits`. Unknown tokens are still ignored (never breaks `initialize`).

### Resulting default surface

- Non-ChatGPT: **5 tools** — `tako_search`, `tako_answer`, `tako_contents`, `tako_graph_search`, `tako_graph_related` (was 8)
- ChatGPT: those 5 + `tako_visualize` = **6**

### Also in this PR

- **Smoke-test fix**: `workers/scripts/smoke.ts` was never updated when the agent became opt-in (8713944) — its agent-presence assertion was stale, and it calls `tako_visualize` / `get_credit_balance` directly. It now connects with `?tools=agent,visualize,credits`, which also exercises the opt-in path end-to-end.
- **Docs**: README (agent-only opt-in section generalized to an "Optional tools" section with the alias table), `llms.txt`, `llms-full.txt`, `agent.json`, `AGENTS.md`.
- `registry/server.json` intentionally unchanged — it lists all tools for discovery; gating is per-request at runtime.

### ⚠️ Breaking change

Existing connectors that use `tako_visualize`, `tako_graph_node`, or `get_credit_balance` must add the alias to their MCP URL (except ChatGPT + visualize).

## Test plan

- [x] `npm test` — 286/286 passing, incl. new unit tests for each alias + composition, and e2e `tools/list` tests: default 5, `?tools=visualize` → 6 with widget `_meta` intact, `?tools=graph_node,credits` → 7, ChatGPT default → 6 (visualize present without opt-in), ChatGPT + `?tools=agent` → 8, unknown alias → 5
- [x] `npm run typecheck` (covers `scripts/`, incl. smoke.ts)
- [ ] Post-deploy: confirm the smoke test passes against staging with the new `?tools=agent,visualize,credits` connection
- [ ] Verify a live Claude.ai / Claude Code connector with no `?tools=` sees the 5-tool surface