### PR TITLE
fix(mcp): surface upstream 4xx error bodies (403/401/404/…) to the model

### DIFF
--- a/workers/src/django.test.ts
+++ b/workers/src/django.test.ts
@@ -136,11 +136,15 @@ describe("djangoGet", () => {
     expect((err as DjangoBadRequestError).body).toBe("bad field: foo");
   });
 
-  it("throws DjangoUnauthorizedError on 401", async () => {
-    mockFetchOnce(new Response("unauthorized", { status: 401 }));
+  it("throws DjangoUnauthorizedError on 401 carrying the body", async () => {
+    mockFetchOnce(
+      new Response('{"detail":"Invalid token."}', { status: 401 }),
+    );
     const err = await djangoGet(ENV, TOKEN, "/api/v1/x").catch((e) => e);
     expect(err).toBeInstanceOf(DjangoUnauthorizedError);
     expect((err as DjangoUnauthorizedError).status).toBe(401);
+    // The auth-failure reason is captured so the MCP boundary can relay it.
+    expect((err as DjangoUnauthorizedError).body).toBe('{"detail":"Invalid token."}');
   });
 
   it("throws DjangoResponseParseError when a 2xx body is not valid JSON", async () => {

--- a/workers/src/django.ts
+++ b/workers/src/django.ts
@@ -123,11 +123,21 @@ export class DjangoBadRequestError extends DjangoError {
 }
 
 export class DjangoUnauthorizedError extends DjangoError {
-  constructor(opts: { path: string; method: HttpMethod }) {
+  /**
+   * Response body as a string — the backend's auth-failure reason (e.g.
+   * DRF's `{"detail":"Invalid token."}` or "Authentication credentials were
+   * not provided."). Empty when no body was sent. Surfaced so the user can
+   * tell "bad/expired key" from "wrong environment" instead of an opaque 401.
+   */
+  readonly body: string;
+
+  constructor(opts: { path: string; method: HttpMethod; body?: string }) {
     super(`Django returned 401 for ${opts.method} ${opts.path}`, {
-      ...opts,
+      path: opts.path,
+      method: opts.method,
       status: 401,
     });
+    this.body = opts.body ?? "";
   }
 }
 
@@ -331,18 +341,20 @@ async function executeRequest<T>(
     }
   }
 
-  // Only read the body for error types that actually surface it.
-  // `DjangoUnauthorizedError` doesn't expose the body, so reading it
-  // would be wasted work. `DjangoNotFoundError` DOES carry the body
-  // now — Tako's `/api/v1/knowledge_search` overloads 404 to mean
-  // "search ran, 0 cards" (with an `error_type` discriminator in the
-  // payload) and callers need that body to distinguish the
-  // application-level no-results 404 from a real routing 404.
+  // Read the response body for every error subtype that surfaces it.
+  // `DjangoUnauthorizedError` carries it so the caller can relay the
+  // backend's auth-failure reason (bad key vs. wrong environment) rather
+  // than an opaque 401. `DjangoNotFoundError` carries it because Tako's
+  // `/api/v1/knowledge_search` overloads 404 to mean "search ran, 0 cards"
+  // (with an `error_type` discriminator in the payload) and callers need
+  // that body to distinguish the application-level no-results 404 from a
+  // real routing 404.
   switch (response.status) {
     case 401:
       throw new DjangoUnauthorizedError({
         path: ctx.path,
         method: ctx.method,
+        body: await safeReadText(response),
       });
     case 404:
       throw new DjangoNotFoundError({

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -8,7 +8,7 @@ import {
   DjangoTimeoutError,
   DjangoUnauthorizedError,
 } from "./django.js";
-import { djangoErrorToToolResult } from "./mcp.js";
+import { djangoErrorToToolResult, extractErrorDetail } from "./mcp.js";
 
 describe("djangoErrorToToolResult", () => {
   // Read tools (tako_search/tako_answer/tako_contents) declare an
@@ -42,7 +42,32 @@ describe("djangoErrorToToolResult", () => {
       method: "GET",
       status: 401,
     });
+    // No body captured → text stays body-free and `_meta` carries no `body`.
     expect(result.content[0]).toEqual({ type: "text", text: err.message });
+    expect(result._meta["tako/error"]).not.toHaveProperty("body");
+  });
+
+  it("surfaces a 401 auth-failure body in both _meta and text content", () => {
+    const detail = "Invalid token.";
+    const body = JSON.stringify({ detail });
+    const err = new DjangoUnauthorizedError({
+      path: "/api/v3/search/",
+      method: "POST",
+      body,
+    });
+    const result = djangoErrorToToolResult(err);
+    expect(result._meta["tako/error"]).toEqual({
+      kind: "unauthorized",
+      path: "/api/v3/search/",
+      method: "POST",
+      status: 401,
+      body,
+    });
+    // 401 is a 4xx client error → the lifted reason reaches the model text.
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `${err.message}: ${detail}`,
+    });
   });
 
   it("maps DjangoTimeoutError with no status and includes timeoutMs", () => {
@@ -73,6 +98,31 @@ describe("djangoErrorToToolResult", () => {
       path: "/api/v1/charts/missing",
       method: "GET",
       status: 404,
+    });
+    // No body on this construction → nothing spliced, no `body` key.
+    expect(result.content[0]).toEqual({ type: "text", text: err.message });
+    expect(result._meta["tako/error"]).not.toHaveProperty("body");
+  });
+
+  it("surfaces a 404 not-found body in both _meta and text content", () => {
+    const detail = "No card found for that URL.";
+    const body = JSON.stringify({ detail });
+    const err = new DjangoNotFoundError({
+      path: "/api/v1/contents/",
+      method: "POST",
+      body,
+    });
+    const result = djangoErrorToToolResult(err);
+    expect(result._meta["tako/error"]).toEqual({
+      kind: "not_found",
+      path: "/api/v1/contents/",
+      method: "POST",
+      status: 404,
+      body,
+    });
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `${err.message}: ${detail}`,
     });
   });
 
@@ -130,10 +180,79 @@ describe("djangoErrorToToolResult", () => {
       status: 503,
       body: "service unavailable",
     });
-    // 5xx body stays in `_meta` only — not spliced into the text content.
-    // Non-400 errors don't carry LLM-actionable retry guidance and a noisy
-    // upstream body would flood the text channel.
+    // 5xx SERVER-error body stays in `_meta` only — not spliced into the text
+    // content. It carries no LLM-actionable detail and a noisy upstream body
+    // (often an HTML error page) would flood the text channel.
     expect(result.content[0]).toEqual({ type: "text", text: err.message });
     expect(result.content[0]?.text).not.toContain("service unavailable");
+  });
+
+  it("splices a 403 (protected-source) body into the text content, not just _meta", () => {
+    // Regression: a 403 from /api/v1/contents on a protected source used to
+    // surface only the opaque "Django returned 403 for POST ..." message,
+    // burying the actionable reason in `_meta` where most clients never read
+    // it. 4xx CLIENT-error bodies are now spliced into the model-visible text.
+    const detail = "Data export is not available for this card (protected source).";
+    const body = JSON.stringify({ detail });
+    const err = new DjangoHttpError({
+      path: "/api/v1/contents/",
+      method: "POST",
+      status: 403,
+      body,
+    });
+    const result = djangoErrorToToolResult(err);
+    // `_meta` keeps the full raw JSON envelope untouched.
+    expect(result._meta["tako/error"]).toEqual({
+      kind: "http",
+      path: "/api/v1/contents/",
+      method: "POST",
+      status: 403,
+      body,
+    });
+    // The model-visible text carries the lifted `detail` message, not the
+    // raw `{"detail": …}` JSON envelope.
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `${err.message}: ${detail}`,
+    });
+    expect(result.content[0]?.text).toContain("protected source");
+    expect(result.content[0]?.text).not.toContain('{"detail"');
+  });
+
+  it("falls back to the raw body when a 4xx body is not a recognised JSON envelope", () => {
+    const err = new DjangoHttpError({
+      path: "/api/v1/contents/",
+      method: "POST",
+      status: 429,
+      body: "Too Many Requests",
+    });
+    const result = djangoErrorToToolResult(err);
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: `${err.message}: Too Many Requests`,
+    });
+  });
+});
+
+describe("extractErrorDetail", () => {
+  it("lifts DRF `detail`", () => {
+    expect(extractErrorDetail('{"detail":"nope"}')).toBe("nope");
+  });
+  it("lifts `error`", () => {
+    expect(extractErrorDetail('{"error":"boom"}')).toBe("boom");
+  });
+  it("joins a nested list of detail strings", () => {
+    expect(extractErrorDetail('{"detail":["a","b"]}')).toBe("a b");
+  });
+  it("returns the raw body for a field-keyed 400 validation map", () => {
+    const body = '{"query":["this field is required"]}';
+    expect(extractErrorDetail(body)).toBe(body);
+  });
+  it("returns the raw body for non-JSON text", () => {
+    expect(extractErrorDetail("service unavailable")).toBe("service unavailable");
+  });
+  it("returns the raw body for a truncated (unparseable) JSON body", () => {
+    const body = '{"detail":"long messag...[truncated]';
+    expect(extractErrorDetail(body)).toBe(body);
   });
 });

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -140,12 +140,12 @@ describe("djangoErrorToToolResult", () => {
       status: 400,
       body: '{"query":["this field is required"]}',
     });
-    // 400s are the only subtype whose body is spliced into `content[0].text`:
-    // DRF validation errors carry the guidance the LLM needs to retry, and
-    // not every MCP client surfaces structured detail to the model.
+    // A field-keyed DRF validation map is flattened to readable text (which
+    // field failed) rather than spliced as raw JSON — the guidance the LLM
+    // needs to retry, and not every MCP client surfaces structured detail.
     expect(result.content[0]).toEqual({
       type: "text",
-      text: `${err.message}: {"query":["this field is required"]}`,
+      text: `${err.message}: query: this field is required`,
     });
   });
 
@@ -219,18 +219,21 @@ describe("djangoErrorToToolResult", () => {
     expect(result.content[0]?.text).not.toContain('{"detail"');
   });
 
-  it("falls back to the raw body when a 4xx body is not a recognised JSON envelope", () => {
+  it("does NOT splice a non-JSON 4xx body (e.g. a Cloudflare HTML block page)", () => {
+    // A 4xx can carry a raw HTML edge/WAF page (403 block, 429 challenge).
+    // It stays on `_meta` for debugging but must not flood the model text —
+    // same failure mode the 5xx exclusion guards against, just on a 4xx.
+    const body = "<!DOCTYPE html><html><body>Access denied (Error 1020)</body></html>";
     const err = new DjangoHttpError({
       path: "/api/v1/contents/",
       method: "POST",
-      status: 429,
-      body: "Too Many Requests",
+      status: 403,
+      body,
     });
     const result = djangoErrorToToolResult(err);
-    expect(result.content[0]).toEqual({
-      type: "text",
-      text: `${err.message}: Too Many Requests`,
-    });
+    expect(result._meta["tako/error"]).toMatchObject({ status: 403, body });
+    expect(result.content[0]).toEqual({ type: "text", text: err.message });
+    expect(result.content[0]?.text).not.toContain("DOCTYPE");
   });
 });
 
@@ -241,18 +244,30 @@ describe("extractErrorDetail", () => {
   it("lifts `error`", () => {
     expect(extractErrorDetail('{"error":"boom"}')).toBe("boom");
   });
+  it("lifts `message`", () => {
+    expect(extractErrorDetail('{"message":"kaboom"}')).toBe("kaboom");
+  });
   it("joins a nested list of detail strings", () => {
     expect(extractErrorDetail('{"detail":["a","b"]}')).toBe("a b");
   });
-  it("returns the raw body for a field-keyed 400 validation map", () => {
-    const body = '{"query":["this field is required"]}';
-    expect(extractErrorDetail(body)).toBe(body);
+  it("flattens a field-keyed 400 validation map to readable text", () => {
+    expect(extractErrorDetail('{"query":["this field is required"]}')).toBe(
+      "query: this field is required",
+    );
+    expect(
+      extractErrorDetail('{"query":["required"],"count":["must be an integer"]}'),
+    ).toBe("query: required; count: must be an integer");
   });
-  it("returns the raw body for non-JSON text", () => {
-    expect(extractErrorDetail("service unavailable")).toBe("service unavailable");
+  it("returns undefined for non-JSON text (e.g. an HTML edge page)", () => {
+    expect(extractErrorDetail("service unavailable")).toBeUndefined();
+    expect(extractErrorDetail("<html>Access denied</html>")).toBeUndefined();
   });
-  it("returns the raw body for a truncated (unparseable) JSON body", () => {
-    const body = '{"detail":"long messag...[truncated]';
-    expect(extractErrorDetail(body)).toBe(body);
+  it("returns undefined for a truncated (unparseable) JSON body", () => {
+    expect(extractErrorDetail('{"detail":"long messag...[truncated]')).toBeUndefined();
+  });
+  it("returns undefined for a JSON object with no recognised message (bare discriminator)", () => {
+    expect(
+      extractErrorDetail('{"error_type":"RELEVANT_RESULTS_NOT_FOUND"}'),
+    ).toBeUndefined();
   });
 });

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -734,25 +734,32 @@ function registerTool(
  */
 /**
  * Lift a human-readable message out of an upstream error body for the
- * model-visible text channel. Django/DRF errors arrive as JSON envelopes —
- * `{"detail": "…"}` (APIException), `{"error": "…"}` (custom handlers), or
- * `{"detail": ["…"]}` — and the raw JSON reads poorly to the model. When the
- * shape is recognisable we return just the message; otherwise (unrecognised
- * keys like a field-keyed 400 validation map, non-JSON text, or a body
- * `safeReadText` truncated so `JSON.parse` fails) we fall back to the raw body.
+ * model-visible text channel, or `undefined` when the body is NOT a
+ * recognisable structured envelope.
  *
- * Best-effort only: the full raw body always stays on
+ * Django/DRF errors arrive as JSON envelopes — `{"detail": "…"}`
+ * (APIException), `{"error": "…"}` / `{"message": "…"}` (custom handlers),
+ * `{"detail": ["…"]}` (nested list), or a field-keyed validation map
+ * `{"field": ["…"], …}`. We lift the message out of those.
+ *
+ * Anything else returns `undefined` so the caller keeps it OUT of the text
+ * channel: non-JSON bodies (e.g. a Cloudflare/edge HTML challenge or block
+ * page on a 4xx, or a body `safeReadText` truncated so `JSON.parse` fails)
+ * and JSON objects with no recognisable message (e.g. a bare discriminator
+ * like `{"error_type": "RELEVANT_RESULTS_NOT_FOUND"}`) would otherwise flood
+ * the model with raw HTML/JSON. The full raw body always stays on
  * `_meta["tako/error"].body` for clients that want the untouched envelope.
  */
-export function extractErrorDetail(body: string): string {
+export function extractErrorDetail(body: string): string | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(body);
   } catch {
-    return body;
+    // Not JSON — an HTML edge page or truncated body. Don't surface it.
+    return undefined;
   }
-  if (typeof parsed === "string" && parsed !== "") return parsed;
-  if (parsed === null || typeof parsed !== "object") return body;
+  if (typeof parsed === "string") return parsed !== "" ? parsed : undefined;
+  if (parsed === null || typeof parsed !== "object") return undefined;
   const obj = parsed as Record<string, unknown>;
   for (const key of ["detail", "error", "message"]) {
     const value = obj[key];
@@ -762,7 +769,24 @@ export function extractErrorDetail(body: string): string {
       return value.join(" ");
     }
   }
-  return body;
+  // DRF field-keyed validation map: {"field": ["msg", …], …}. Flatten to
+  // "field: msg; …" so the LLM sees which field failed without raw JSON.
+  const entries = Object.entries(obj);
+  if (
+    entries.length > 0 &&
+    entries.every(
+      ([, value]) =>
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((v) => typeof v === "string"),
+    )
+  ) {
+    return entries
+      .map(([key, value]) => `${key}: ${(value as string[]).join(" ")}`)
+      .join("; ");
+  }
+  // A JSON object with no recognisable message (e.g. a bare discriminator).
+  return undefined;
 }
 
 export function djangoErrorToToolResult(err: DjangoError): {
@@ -796,15 +820,22 @@ export function djangoErrorToToolResult(err: DjangoError): {
   //
   // SERVER errors (5xx) and transport errors (timeout — no status) stay
   // body-free: no LLM-actionable detail, and 5xx bodies are often noisy HTML
-  // error pages that would flood the text channel. `extractErrorDetail` lifts
-  // the message out of DRF JSON envelopes; `err.message` stays body-free by
-  // construction (log-injection guard in `django.ts`), so the splice happens
-  // only here at the MCP boundary.
+  // error pages that would flood the text channel.
+  //
+  // The splice is ALSO gated on `extractErrorDetail` recognising a structured
+  // message: a 4xx can still carry a raw HTML page (a Cloudflare/edge WAF 403
+  // or rate-limit 429) or a bare discriminator JSON, and we don't want that
+  // flooding the text channel either — same failure mode as a 5xx HTML body,
+  // just on a 4xx. Only DRF-shaped detail reaches the model; everything else
+  // stays on `_meta.body` only. `err.message` stays body-free by construction
+  // (log-injection guard in `django.ts`), so the splice happens only here at
+  // the MCP boundary.
   const is4xx =
     err.status !== undefined && err.status >= 400 && err.status < 500;
+  const detailText = body !== undefined ? extractErrorDetail(body) : undefined;
   const text =
-    is4xx && body !== undefined
-      ? `${err.message}: ${extractErrorDetail(body)}`
+    is4xx && detailText !== undefined
+      ? `${err.message}: ${detailText}`
       : err.message;
   return {
     content: [{ type: "text", text }],

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -732,6 +732,39 @@ function registerTool(
  * Exported for unit testing — the wire contract is stable enough that
  * Phase 2 tests can rely on the `kind` strings here.
  */
+/**
+ * Lift a human-readable message out of an upstream error body for the
+ * model-visible text channel. Django/DRF errors arrive as JSON envelopes —
+ * `{"detail": "…"}` (APIException), `{"error": "…"}` (custom handlers), or
+ * `{"detail": ["…"]}` — and the raw JSON reads poorly to the model. When the
+ * shape is recognisable we return just the message; otherwise (unrecognised
+ * keys like a field-keyed 400 validation map, non-JSON text, or a body
+ * `safeReadText` truncated so `JSON.parse` fails) we fall back to the raw body.
+ *
+ * Best-effort only: the full raw body always stays on
+ * `_meta["tako/error"].body` for clients that want the untouched envelope.
+ */
+export function extractErrorDetail(body: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+  if (typeof parsed === "string" && parsed !== "") return parsed;
+  if (parsed === null || typeof parsed !== "object") return body;
+  const obj = parsed as Record<string, unknown>;
+  for (const key of ["detail", "error", "message"]) {
+    const value = obj[key];
+    if (typeof value === "string" && value !== "") return value;
+    // DRF sometimes nests a list of strings, e.g. {"detail": ["…", "…"]}.
+    if (Array.isArray(value) && value.every((v) => typeof v === "string") && value.length > 0) {
+      return value.join(" ");
+    }
+  }
+  return body;
+}
+
 export function djangoErrorToToolResult(err: DjangoError): {
   content: Array<{ type: "text"; text: string }>;
   _meta: Record<string, unknown>;
@@ -744,28 +777,60 @@ export function djangoErrorToToolResult(err: DjangoError): {
   };
   if (err.status !== undefined) detail.status = err.status;
   if (err instanceof DjangoTimeoutError) detail.timeoutMs = err.timeoutMs;
-  if (err instanceof DjangoBadRequestError || err instanceof DjangoHttpError) {
-    detail.body = err.body;
-  }
-  // For 400s, splice the response body into the text content. DRF
-  // validation errors (missing fields, invalid enum values, bad
-  // component config) carry the guidance the LLM needs to retry;
-  // keeping it in `structuredContent.body` alone isn't enough because
-  // not every MCP client surfaces structured content to the model.
-  // Intentionally scoped to `DjangoBadRequestError` — other subtypes
-  // (404/401/5xx/timeout) don't carry LLM-actionable detail, so their
-  // text stays body-free to keep Workers Logs greppable. `err.message`
-  // stays body-free by construction (log-injection guard in
-  // `django.ts`); the splice happens here at the MCP boundary.
+  // Surface the upstream response body on `_meta` untouched for EVERY subtype
+  // that captured one (400/401/404/catch-all), regardless of status — clients
+  // that read structured detail always get the full envelope for debugging.
+  const body = errorResponseBody(err);
+  if (body !== undefined) detail.body = body;
+
+  // Splice the body into the model-visible text for CLIENT errors (any 4xx).
+  // These carry the guidance the LLM needs to act on or relay to the user:
+  //   - 400: DRF validation errors (missing fields, invalid enum, bad config).
+  //   - 401: the auth-failure reason (bad/expired key vs. wrong environment).
+  //   - 403: the refusal reason — e.g. "Data export is not available for this
+  //     card (protected source)".
+  //   - 404: the not-found reason (a real routing/resource 404).
+  //   - 409/429/…: conflict / rate-limit detail.
+  // Keeping it in `_meta` alone isn't enough — not every MCP client surfaces
+  // structured detail to the model.
+  //
+  // SERVER errors (5xx) and transport errors (timeout — no status) stay
+  // body-free: no LLM-actionable detail, and 5xx bodies are often noisy HTML
+  // error pages that would flood the text channel. `extractErrorDetail` lifts
+  // the message out of DRF JSON envelopes; `err.message` stays body-free by
+  // construction (log-injection guard in `django.ts`), so the splice happens
+  // only here at the MCP boundary.
+  const is4xx =
+    err.status !== undefined && err.status >= 400 && err.status < 500;
   const text =
-    err instanceof DjangoBadRequestError
-      ? `${err.message}: ${err.body}`
+    is4xx && body !== undefined
+      ? `${err.message}: ${extractErrorDetail(body)}`
       : err.message;
   return {
     content: [{ type: "text", text }],
     _meta: { "tako/error": detail },
     isError: true,
   };
+}
+
+/**
+ * The upstream response body captured on the error, or `undefined` for
+ * subtypes that carry none (timeout, unparseable-2xx). Every body-bearing
+ * subtype exposes it as `.body`; centralising the `instanceof` fan-out here
+ * keeps `_meta` population and the 4xx text-splice reading from one source.
+ */
+function errorResponseBody(err: DjangoError): string | undefined {
+  if (
+    err instanceof DjangoBadRequestError ||
+    err instanceof DjangoUnauthorizedError ||
+    err instanceof DjangoNotFoundError ||
+    err instanceof DjangoHttpError
+  ) {
+    // Treat an empty body as absent so it's omitted from `_meta` (no noisy
+    // `body: ""`) and never triggers the text splice.
+    return err.body === "" ? undefined : err.body;
+  }
+  return undefined;
 }
 
 function djangoErrorKind(err: DjangoError): string {


### PR DESCRIPTION
## Problem

Client-error (4xx) responses from the Tako backend carry actionable detail the model should relay to the user, but the MCP boundary was dropping most of it. The model saw only opaque messages like `Django returned 403 for POST /api/v1/contents/`.

This started from a specific report — a `403` on a **protected source** surfaced without Tako's real message (`Data export is not available for this card (protected source).`) — but a review of the whole error path found the same class of gap across **401, 403, and 404**.

## What was being dropped (before)

| Status | `_meta.body` | model-visible text | Notes |
|--------|:---:|:---:|-------|
| 400 | ✅ | ✅ (raw JSON) | only status spliced into text |
| 401 | ❌ | ❌ | body was **never even read** in `django.ts` |
| 403 | ✅ | ❌ | reason stranded in `_meta` (most clients don't surface it) |
| 404 | ❌ | ❌ | `django.ts` read the body, `djangoErrorToToolResult` **dropped** it |
| 5xx | ✅ | ❌ | correct — server errors stay body-free |

## Changes

1. **`django.ts`** — `DjangoUnauthorizedError` now captures the 401 response body (like the 400/404/catch-all subtypes already do).
2. **`mcp.ts` `djangoErrorToToolResult`**:
   - Surface the captured body on `_meta["tako/error"].body` for **every** body-bearing subtype (400/401/404/catch-all), via a single `errorResponseBody()` helper.
   - Splice the body into the model-visible text for **all 4xx** client errors (400/401/403/404/409/429/…), replacing the previous 400-only + 4xx-`HttpError` special-case.
   - `extractErrorDetail()` lifts the message out of DRF JSON envelopes (`{"detail":"…"}`, `{"error":"…"}`, `{"detail":["…"]}`) so the model sees clean text, not raw JSON. Falls back to the raw body for unrecognised shapes (field-keyed 400 validation maps, non-JSON text, truncated bodies).
   - **5xx server errors and transport errors (timeout) stay body-free** — no actionable detail, and 5xx bodies are often noisy HTML error pages.

The full raw envelope always stays on `_meta`. `err.message` remains body-free by construction (log-injection guard in `django.ts`) — the splice happens only at the MCP boundary. Graph tools already map Django errors to actionable messages via `graphErrorMessage()` and are unaffected.

The model now sees, e.g.:

> `Django returned 403 for POST /api/v1/contents/: Data export is not available for this card (protected source).`

## Test plan

- [x] `npm test` — full suite green (**273 passing**), incl. 17 mcp error-mapping tests
- [x] `tsc --noEmit` clean
- [x] Regression tests: protected-source 403, 401 auth-failure body, 404 not-found body — each splices the lifted `detail` into text and keeps the raw envelope on `_meta`
- [x] No-body 401/404 stay body-free with no noisy `body: ""` in `_meta`
- [x] Non-JSON 4xx body (429) falls back to raw body
- [x] `extractErrorDetail` unit tests: `detail` / `error` / nested list / field-keyed 400 map / non-JSON / truncated body
- [x] `django.ts`: 401 now captures the body
- [x] Existing 400-validation and 5xx body-free behaviour preserved