### PR TITLE
docs: sharpen agent skills per QA review

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,29 +314,30 @@ Step 2: Add this Claude skill
 
 ---
 name: tako-financial-research
-description: Company financials and markets via Tako (source: S&P Global). Revenue, earnings vs. estimates, margins, valuation, stock performance, and head-to-head company comparisons as citation-backed charts. Use for equity research, company deep-dives, competitor financial comparison, or any "what are/were <company>'s <financial metric>" question.
+description: Company financials and markets via Tako (sources include S&P Global and Fiscal.ai). Revenue, earnings vs. estimates, margins, valuation, stock performance, and head-to-head company comparisons as citation-backed charts. Use for equity research, company deep-dives, competitor financial comparison, or any "what are/were <company>'s <financial metric>" question.
 ---
 
 # Financial Research (Tako)
 
-Tako serves proprietary company financials (source: S&P Global) as interactive, citation-backed charts.
+Tako serves proprietary company financials (sources include S&P Global and Fiscal.ai) as interactive, citation-backed charts.
 
 ## Pick the tool by what you want back
-- `tako_search` — the data as a chart. Default for "<company> <metric>" and "<A> vs <B> <metric>". The top result renders inline.
+- `tako_search` — the data as a chart. Default for "<company> <metric>" and "<A> vs <B> <metric>". The intent-matched card renders inline (see Rendering).
 - `tako_answer` — one specific known value, in prose ("What was Apple's FY24 revenue?"). Relay the `answer` verbatim; no need to recompute.
 - `tako_agent` — a cohort/ranking that must be figured out ("which of the largest US chipmakers grew revenue fastest since 2020?"). Slower (~30–90s).
 - `tako_available_data` — FREE pre-check: confirm a metric exists and grab its exact name + `node_id` before spending a priced call.
 
 ## Query patterns (Critical)
-- Query is ENTITY + METRIC: `"Nvidia revenue"`, `"Apple gross margin"`, `"Tesla free cash flow"`. Keep it to one entity + one metric per call.
-- Comparisons are first-class: `"Intel vs Nvidia revenue"` returns a single two-series comparison card.
+- Query is ENTITY + METRIC: `"Nvidia revenue"`, `"Apple gross margin"`, `"Tesla free cash flow"`. Keep it to one entity + one metric per call, and add a cadence word (`quarterly`/`annual`) to steer the period.
+- Comparisons are first-class: `"Intel vs Nvidia revenue"` returns a two-series comparison card — but it is not always ranked first (see Rendering), and comparisons default to annual (say `quarterly` for quarterly).
 - Multi-metric or multi-company asks → fire PARALLEL narrow searches and synthesize yourself. Do not send a multi-part question as one query.
 - Ground in Tako data with `sources: ["data"]` for proprietary financials; add `"web"` only for news/context.
 
 ## Rendering (Critical)
-- The top result renders inline automatically — an interactive widget on ChatGPT, a chart image on other hosts. Reference it in prose ("as the chart above shows"); do NOT paste `![](image_url)` for the top card — that double-renders it.
-- Cite the source on the card (e.g. S&P Global) and its as-of date.
-- Point at any extra cards by linking their titles as `[Title](webpage_url)` — embed only the top card.
+- Match the card to intent — don't blindly trust index 0. Tako auto-renders the #0 card, but ranking ≠ intent: `"<A> vs <B>"` often ranks a single-entity card above the real two-series comparison. Scan the returned cards and use the one whose title/`nodes` match the question (BOTH entities for a comparison). If the intended card isn't #0, reference it explicitly with `[Title](webpage_url)` and say it is the authoritative one.
+- Reference the chart in prose ("as the chart above shows"); do NOT paste `![](image_url)` for a card — that double-renders the inline chart.
+- Cite whatever `sources[].source_name` the card returns (often S&P Global, but financials can come from Fiscal.ai or others) and its `data_as_of` date.
+- `tako_answer` prose may cite a different fiscal period than the embedded card's latest point (e.g. the answer says FY24 while the card headline is FY25) — reconcile them so text and chart agree.
 
 ## Examples
 - Single metric → tako_search {"query": "Nvidia quarterly revenue", "sources": ["data"]}
@@ -345,9 +346,9 @@ Tako serves proprietary company financials (source: S&P Global) as interactive, 
 - Ranking → tako_agent {"query": "Among the 10 largest US semiconductor companies, which grew revenue fastest since 2020?"}
 
 ## Output (tight and structured)
-1) A 1–2 line read of the finding, referencing the inline chart
-2) Source — as-of date
-3) A single `[Open in Tako](embed_url)` for the top card
+1) A 1–2 line read of the finding, referencing the intent-matched chart
+2) Source (`source_name`) — `data_as_of` date
+3) A single `[Open in Tako](embed_url)` for the card you embedded
 
 
 Step 3: Ask the user to restart Claude Code
@@ -382,7 +383,7 @@ description: Website and app traffic via Tako (source: SimilarWeb). Monthly visi
 Tako serves SimilarWeb traffic data as interactive, citation-backed charts.
 
 ## Query patterns (Critical)
-- Query by DOMAIN, not brand. `"netflix.com monthly visits"` resolves; `"Netflix traffic"` often does not. Always use the bare domain (`youtube.com`, `chatgpt.com`).
+- Query by DOMAIN, not brand. Brand names resolve to the wrong concept — under `sources: ["data"]` a brand query returns zero cards, and with `"web"` on it mis-resolves to subscriber counts or CDN/network-traffic articles. Always use the bare domain: `"netflix.com monthly visits"`, `"youtube.com"`, `"chatgpt.com"`.
 - The core metric is Visits (monthly, with ~1-month lag).
 - Comparisons: `"youtube.com vs netflix.com monthly visits"`. Rankings: `"top websites by visits"` returns a ranked card.
 - Ground in Tako data with `sources: ["data"]` (SimilarWeb is proprietary).
@@ -395,7 +396,8 @@ Tako serves SimilarWeb traffic data as interactive, citation-backed charts.
 
 ## Rendering (Critical)
 - The top result renders inline automatically — an interactive widget on ChatGPT, a chart image on other hosts. Reference it in prose; do NOT paste `![](image_url)` for the top card — that double-renders it.
-- Cite SimilarWeb + the as-of month.
+- Cite SimilarWeb + the as-of month (it's in `data_freshness.data_as_of`).
+- Comparison cards (`"A vs B"`) describe each series as a % change over the period — for absolute monthly visits, read the per-domain single-series card instead.
 - Point at any extra cards by linking their titles as `[Title](webpage_url)` — embed only the top card.
 
 ## Examples
@@ -441,9 +443,10 @@ description: Macroeconomic indicators via Tako (sources: FRED, OECD, BIS). Infla
 Tako serves macro indicators (sources: FRED / St. Louis Fed, OECD, BIS) as interactive, citation-backed charts.
 
 ## Query patterns (Critical)
-- Query is COUNTRY + INDICATOR: `"US CPI inflation"`, `"US unemployment rate"`, `"US federal funds rate"`.
+- Query is COUNTRY + INDICATOR: `"US CPI inflation"`, `"US unemployment rate"`, `"US federal funds rate"` (which resolves to the Effective Federal Funds Rate, not the FOMC target range).
 - Be specific — many variants exist (CPI all-items vs CPI-W vs core; unemployment headline vs U-6 vs by age/race). If intent is precise, name the variant; if unsure, use `tako_available_data` to list exact metric names first.
-- Parallelize multi-part asks: send "CPI, core CPI, PCE, core PCE" as FOUR narrow concurrent `tako_search` calls, then synthesize — not one query.
+- PCE is a trap: `"US PCE inflation"` / `"US core PCE inflation"` resolve to price-INDEX levels (~130 index points), never a rate. For the inflation rate, query the year-over-year variant (`"US core PCE price index % change"`) AND pick the card titled `… (% Change)` whose values are in percent. Run `tako_available_data` FIRST (mandatory here) to grab the exact `(% Change)` metric + `node_id`.
+- Parallelize multi-part asks: send each metric as its own narrow concurrent `tako_search`, then synthesize — not one query.
 - Cross-country comparison is built in: `"US vs China inflation"` returns a comparison card.
 - Ground in Tako data with `sources: ["data"]`.
 
@@ -454,20 +457,20 @@ Tako serves macro indicators (sources: FRED / St. Louis Fed, OECD, BIS) as inter
 - `tako_available_data` — FREE: resolve the exact indicator name + `node_id`.
 
 ## Rendering (Critical)
-- The top result renders inline automatically — an interactive widget on ChatGPT, a chart image on other hosts. Reference it in prose; do NOT paste `![](image_url)` for the top card — that double-renders it.
-- Cite the source (FRED / OECD / BIS) + as-of date.
-- Point at any extra cards by linking their titles as `[Title](webpage_url)` — embed only the top card.
+- Match the card to intent — don't blindly trust index 0. Tako auto-renders the #0 card, but the least-specific card often ranks first: `"US CPI inflation"` can rank a broad BIS country card (a different headline number) above the labeled FRED CPI card, and stale vintages can sneak in. Scan the cards and use the one whose title matches the exact variant with the freshest `data_as_of`; if it isn't #0, reference it with `[Title](webpage_url)` and say it is the authoritative one.
+- Reference the chart in prose; do NOT paste `![](image_url)` for a card — that double-renders the inline chart.
+- Cite the source (FRED / OECD / BIS) + `data_as_of` date.
 
 ## Examples
 - Single → tako_search {"query": "US CPI inflation", "sources": ["data"]}
-- Parallel multi-metric → four calls: "US CPI inflation", "US core CPI inflation", "US PCE inflation", "US core PCE inflation"
+- Parallel multi-metric → four calls: "US CPI inflation", "US core CPI inflation", "US core PCE price index % change", "US PCE price index % change" (pick each card titled "(% Change)" — the plain "PCE Price Index" cards are index levels, not rates)
 - Cross-country → tako_search {"query": "US vs China inflation", "sources": ["data"]}
 - Known value, prose → tako_answer {"query": "What is the current US federal funds rate?", "sources": ["data"]}
 
 ## Output (tight and structured)
-1) A 1–2 line read of the indicator, referencing the inline chart
-2) Source — as-of date
-3) A single `[Open in Tako](embed_url)` for the top card
+1) A 1–2 line read of the indicator, referencing the intent-matched chart
+2) Source (FRED / OECD / BIS) — `data_as_of` date
+3) A single `[Open in Tako](embed_url)` for the card you embedded
 
 
 Step 3: Ask the user to restart Claude Code

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-io.github.TakoData%2Ftako--mcp-000000?style=flat-square)](https://registry.modelcontextprotocol.io)
 [![Smithery](https://img.shields.io/badge/Smithery-tako%2Ftako-4B8BF5?style=flat-square)](https://smithery.ai/servers/tako/tako)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](LICENSE)
+[![Benchmarks: +21% on VerticalRTK](https://img.shields.io/badge/Benchmarks-%2B21%25_on_VerticalRTK-6E56CF?style=flat-square)](https://tako.com/blog/evaluating-a-new-kind-of-search-api/)
 
 Connect AI agents to Tako's proprietary knowledge graph: live financial, macroeconomic, and company data — rendered as interactive, citation-backed charts.
 
@@ -17,6 +18,8 @@ Tako MCP lets an agent:
 - **Fetch** the underlying rows (CSV) or a page's text behind any result URL
 - **Visualize** your own structured data as an embeddable chart _(opt-in)_
 - **Run** Tako's Answer Agent for deep, multi-step research _(opt-in)_
+
+> **Why a data-native search API?** On Tako's [VerticalRTK benchmark](https://tako.com/blog/evaluating-a-new-kind-of-search-api/) of real-time domain questions (finance, economics, sports, weather), Tako outperforms the next-best web search API by **21%** — while using **~75% fewer tool calls at up to one-tenth the cost**, and answering research tasks in **15.5s vs 124.2s** for OpenAI web search. It reaches parity with Exa, Parallel, Nimble, and Tavily on standard web benchmarks (SimpleQA, FRAMES) and pulls ahead where structured, real-time data matters. **[Read the evals →](https://tako.com/blog/evaluating-a-new-kind-of-search-api/)**
 
 ## Installation
 
@@ -520,6 +523,7 @@ Tako is published to the official [MCP Registry](https://registry.modelcontextpr
 ## Links
 
 - **[Full Documentation](https://docs.tako.com/documentation/integrations/mcp-server)** — setup, tools, and integration guides
+- **[Evaluating a new kind of Search API](https://tako.com/blog/evaluating-a-new-kind-of-search-api/)** — benchmarks vs. Exa, Parallel, Nimble, Tavily; why data-native search wins
 - **[Get your API key](https://tako.com/console/api-keys)** — Tako console
 - [Tako](https://tako.com) — the data visualization platform
 - [Tako on Smithery](https://smithery.ai/servers/tako/tako) — MCP server listing


### PR DESCRIPTION
Sharpens the three agent skills (added in #154) after a QA pass. The QA found
the embedding contract was solid, but the skills sometimes told the model to
trust the **wrong card** — ranking ≠ intent. Every fix below was reproduced
against live Tako `[data]`.

## Fixes

**Systemic — Finance + Macro card selection**
Replaced *"reference the top card"* with **match-by-intent**: scan the returned
cards and embed the one whose title/`nodes` match the question; if it isn't
index 0, link it with `[Title](webpage_url)` and mark it authoritative.
- Reproduced: `Intel vs Nvidia revenue` → single-entity Nvidia card at #0, the real two-series comparison at #1.
- Reproduced: `US CPI inflation` → broad BIS country card (4.2%) at #0, labeled FRED CPI card (3.5%) below it.

**Macroeconomics**
- **PCE trap:** `US PCE inflation` / `US core PCE inflation` return price-**index levels** (~130 index pts), never a rate. Skill now prescribes the `% change` variant + **mandatory** `tako_available_data`. Verified: `US core PCE price index % change` → "Core PCE Price Index (% Change)" = **4.4%** at #0. ✅
- Fixed the flagship parallel example (was two broken PCE queries).
- Noted `federal funds rate` → **Effective FFR**, not the FOMC target range.
- **QA said Macro lacked an `## Output` section — it already had one, so no duplicate was added.**

**Financial Research**
- Cite the card's actual `sources[].source_name` — verified Microsoft net income comes from **Fiscal.ai**, not S&P Global.
- Warn that `tako_answer`'s fiscal period can differ from the card's latest point (answer FY24 $88.1B vs card FY25 $101.8B).
- Steer cadence with `quarterly`/`annual`; comparisons default to annual.

**Web & App Traffic** (was already the strongest)
- Strengthened domain-not-brand: brand names mis-resolve to subscriber counts / CDN articles — always use the bare domain.
- Noted the as-of month lives in `data_freshness.data_as_of`, and comparison cards are % change (read per-domain cards for absolute visits).

## Testing
- Data-path fixes reproduced/verified against live `tako_search [data]` (comparison ranking, CPI ranking, PCE index-vs-rate, Fiscal.ai source).
- README re-rendered through GitHub's `/markdown` API: 17 balanced `<details>`, 4 tables, 0 frontmatter leaks, skill blobs stay literal.
- **Not testable here:** `tako_available_data` and `tako_agent` aren't mounted on this connection. The Macro PCE fix leans on `tako_available_data`, so it warrants one live check against `mcp.tako.com/mcp?tools=agent` before publishing.
