### PR TITLE
feat: Claude Code plugin — hosted MCP server + bundled research skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "tako",
+  "owner": {
+    "name": "Tako",
+    "url": "https://tako.com"
+  },
+  "metadata": {
+    "description": "Official Tako plugins — live financial, macroeconomic, and company data for Claude Code."
+  },
+  "plugins": [
+    {
+      "name": "tako",
+      "source": "./",
+      "description": "Tako's proprietary knowledge graph as MCP tools — live financial, macroeconomic, and company data as interactive, citation-backed charts — plus bundled research skills.",
+      "author": {
+        "name": "Tako"
+      },
+      "homepage": "https://docs.tako.com/documentation/integrations/mcp-server"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "tako",
   "description": "Tako's proprietary knowledge graph as MCP tools — live financial, macroeconomic, and company data as interactive, citation-backed charts — plus bundled research skills.",
-  "version": "0.1.0",
   "author": {
     "name": "Tako",
     "url": "https://tako.com"
@@ -9,7 +8,15 @@
   "homepage": "https://docs.tako.com/documentation/integrations/mcp-server",
   "repository": "https://github.com/TakoData/tako-mcp",
   "license": "MIT",
-  "keywords": ["tako", "mcp", "search", "finance", "macroeconomics", "charts", "data"],
+  "keywords": [
+    "tako",
+    "mcp",
+    "search",
+    "finance",
+    "macroeconomics",
+    "charts",
+    "data"
+  ],
   "mcpServers": {
     "tako": {
       "type": "http",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "tako",
+  "description": "Tako's proprietary knowledge graph as MCP tools — live financial, macroeconomic, and company data as interactive, citation-backed charts — plus bundled research skills.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Tako",
+    "url": "https://tako.com"
+  },
+  "homepage": "https://docs.tako.com/documentation/integrations/mcp-server",
+  "repository": "https://github.com/TakoData/tako-mcp",
+  "license": "MIT",
+  "keywords": ["tako", "mcp", "search", "finance", "macroeconomics", "charts", "data"],
+  "mcpServers": {
+    "tako": {
+      "type": "http",
+      "url": "https://mcp.tako.com/mcp?tools=agent",
+      "headers": {
+        "Authorization": "Bearer ${TAKO_API_KEY}"
+      }
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "tako",
   "description": "Tako's proprietary knowledge graph as MCP tools — live financial, macroeconomic, and company data as interactive, citation-backed charts — plus bundled research skills.",
+  "version": "0.11.0",
   "author": {
     "name": "Tako",
     "url": "https://tako.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,12 +18,21 @@
     "charts",
     "data"
   ],
+  "userConfig": {
+    "tako_api_key": {
+      "type": "string",
+      "title": "Tako API key",
+      "description": "Your Tako API key from https://tako.com/console/api-keys",
+      "sensitive": true,
+      "required": true
+    }
+  },
   "mcpServers": {
     "tako": {
       "type": "http",
       "url": "https://mcp.tako.com/mcp?tools=agent",
       "headers": {
-        "Authorization": "Bearer ${TAKO_API_KEY}"
+        "Authorization": "Bearer ${user_config.tako_api_key}"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -34,17 +34,14 @@ Every request authenticates with a Bearer token. **[Get your API key](https://ta
 <details>
 <summary><b>Claude Code</b></summary>
 
-**Plugin (recommended)** — installs the MCP connection plus Tako's bundled [research skills](#agent-skills) in one step. The plugin reads your key from `TAKO_API_KEY` (not `TAKO_API_TOKEN`):
+**Plugin (recommended)** — installs the MCP connection plus Tako's bundled [research skills](#agent-skills) in one step. Claude Code prompts for your API key when the plugin is enabled and stores it securely — no `export` or environment variable to manage:
 
 ```bash
-# Persist your key so every Claude Code launch can read it
-echo "export TAKO_API_KEY='<your-token>'" >> ~/.zshrc && source ~/.zshrc
-
 claude plugin marketplace add TakoData/tako-mcp
 claude plugin install tako@tako
 ```
 
-> Persist the variable in your shell profile (`~/.zshrc`, `~/.bashrc`, …) rather than running a one-off `export`. Unlike the `claude mcp add` path below — which bakes the resolved token into stored config at add-time — the plugin stores `${TAKO_API_KEY}` literally and re-expands it on **every** Claude Code launch. If the variable isn't set in the shell you launch from, the plugin sends `Authorization: Bearer ${TAKO_API_KEY}` verbatim and auth fails silently.
+When the plugin is enabled, Claude Code asks for your **Tako API key** and injects it as the Bearer token automatically. **[Get your API key](https://tako.com/console/api-keys)**.
 
 If you previously added the server with `claude mcp add`, remove it first (`claude mcp remove tako-mcp`) so you don't end up with two copies of every tool.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Every request authenticates with a Bearer token. **[Get your API key](https://ta
 <details>
 <summary><b>Claude Code</b></summary>
 
+**Plugin (recommended)** — installs the MCP connection plus Tako's bundled [research skills](#agent-skills) in one step:
+
+```bash
+export TAKO_API_KEY='<your-token>'
+
+claude plugin marketplace add TakoData/tako-mcp
+claude plugin install tako@tako
+```
+
+**Or add the MCP server directly:**
+
 ```bash
 export TAKO_API_TOKEN='<your-token>'
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Every request authenticates with a Bearer token. **[Get your API key](https://ta
 <details>
 <summary><b>Claude Code</b></summary>
 
-**Plugin (recommended)** — installs the MCP connection plus Tako's bundled [research skills](#agent-skills) in one step:
+**Plugin (recommended)** — installs the MCP connection plus Tako's bundled [research skills](#agent-skills) in one step. The plugin reads your key from `TAKO_API_KEY` (not `TAKO_API_TOKEN`):
 
 ```bash
 export TAKO_API_KEY='<your-token>'
@@ -42,6 +42,8 @@ export TAKO_API_KEY='<your-token>'
 claude plugin marketplace add TakoData/tako-mcp
 claude plugin install tako@tako
 ```
+
+If you previously added the server with `claude mcp add`, remove it first (`claude mcp remove tako-mcp`) so you don't end up with two copies of every tool.
 
 **Or add the MCP server directly:**
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ Every request authenticates with a Bearer token. **[Get your API key](https://ta
 **Plugin (recommended)** — installs the MCP connection plus Tako's bundled [research skills](#agent-skills) in one step. The plugin reads your key from `TAKO_API_KEY` (not `TAKO_API_TOKEN`):
 
 ```bash
-export TAKO_API_KEY='<your-token>'
+# Persist your key so every Claude Code launch can read it
+echo "export TAKO_API_KEY='<your-token>'" >> ~/.zshrc && source ~/.zshrc
 
 claude plugin marketplace add TakoData/tako-mcp
 claude plugin install tako@tako
 ```
+
+> Persist the variable in your shell profile (`~/.zshrc`, `~/.bashrc`, …) rather than running a one-off `export`. Unlike the `claude mcp add` path below — which bakes the resolved token into stored config at add-time — the plugin stores `${TAKO_API_KEY}` literally and re-expands it on **every** Claude Code launch. If the variable isn't set in the shell you launch from, the plugin sends `Authorization: Bearer ${TAKO_API_KEY}` verbatim and auth fails silently.
 
 If you previously added the server with `claude mcp add`, remove it first (`claude mcp remove tako-mcp`) so you don't end up with two copies of every tool.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,8 @@
         "workers/src/mcp.ts",
         { "type": "json", "path": "registry/metadata.json", "jsonpath": "$.version" },
         { "type": "json", "path": "registry/server.json", "jsonpath": "$.version" },
-        { "type": "yaml", "path": "registry/smithery.yaml", "jsonpath": "$.version" }
+        { "type": "yaml", "path": "registry/smithery.yaml", "jsonpath": "$.version" },
+        { "type": "json", "path": ".claude-plugin/plugin.json", "jsonpath": "$.version" }
       ]
     }
   },

--- a/skills/tako-financial-research/SKILL.md
+++ b/skills/tako-financial-research/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tako-financial-research
+description: Company financials and markets via Tako (sources vary by metric — S&P Global, Fiscal.ai, Xignite, Visible Alpha, and others). Revenue, earnings vs. estimates, margins, valuation, stock performance, and head-to-head company comparisons as citation-backed charts. Use for equity research, company deep-dives, competitor financial comparison, or any "what are/were <company>'s <financial metric>" question.
+---
+
+# Financial Research (Tako)
+
+Tako serves proprietary company financials (sources vary by metric — S&P Global, Fiscal.ai, Xignite, Visible Alpha, and others) as interactive, citation-backed charts. Always cite the source the card actually returns, not a fixed name.
+
+## Pick the tool by what you want back
+- `tako_search` — the data as a chart. Default for "<company> <metric>" and "<A> vs <B> <metric>". The intent-matched card renders inline (see Rendering).
+- `tako_answer` — one specific STATED value, in prose ("What was Apple's FY24 revenue?"). Relay the `answer` verbatim. It retrieves reported values; it does NOT compute derivations — for a growth rate, ratio, or margin change, pull the underlying levels (here or via `tako_search`) and compute it yourself.
+- `tako_agent` — a cohort/ranking that must be figured out ("which of the largest US chipmakers grew revenue fastest since 2020?"). Slower (~30–90s).
+- `tako_available_data` — FREE pre-check: confirm a metric exists and grab its exact name + `node_id` before spending a priced call.
+
+## Query patterns (Critical)
+- Query is ENTITY + METRIC: `"Nvidia revenue"`, `"Apple gross margin"`, `"Tesla free cash flow"`. Keep it to one entity + one metric per call, and add a cadence word (`quarterly`/`annual`) to steer the period.
+- Comparisons are first-class: `"Intel vs Nvidia revenue"` returns a two-series comparison card — but it is not always ranked first (see Rendering), and comparisons default to annual (say `quarterly` for quarterly). Pairwise (2-entity) comparisons are the most reliable; 3–4-way asks often mis-rank or drop a series — prefer pairwise and synthesize.
+- Multi-metric or multi-company asks → fire PARALLEL narrow searches and synthesize yourself. Do not send a multi-part question as one query (a compound query returns a single-metric top card and misses the rest).
+- Ground in Tako data with `sources: ["data"]` — this is the default for financials. Omitting `sources` also searches the web, returning ~10 billable pages of IR/filings/MacroTrends clutter per call; add `"web"` only when you deliberately want news or qualitative context.
+- Empty result (zero cards) means "not covered in Tako," NOT that the fact is false — the response looks identical for an uncovered metric and a genuinely-nonexistent one. Don't infer a business fact from it (e.g. a company with no dividend card may pay no dividend, but don't assert it from silence). Confirm with `tako_available_data`, or fall back to a web check.
+
+## Rendering (Critical)
+- Pick the card by intent — do NOT trust index 0. Tako auto-renders card #0, but it routinely ranks an "Overview" or "Earnings & Estimates" card above the plain metric chart (e.g. `"Lucid revenue"` puts "Lucid Group Earnings & Estimates Overview" at #0 and the actual "Lucid Revenues (Annual)" chart at #2). Choose the card whose `card_type` is `"chart"` and whose title matches the bare metric asked for. Overview/Estimates cards lead with a beat/miss "estimate vs. actual" narrative — NOT the value asked for; skip them unless the user asked about estimates. For a comparison, the right card has BOTH entities in its `nodes`/title. If the chosen card isn't #0, reference it with `[Title](webpage_url)` and say it is the authoritative one.
+- Actuals vs. estimates vs. projections — before quoting a number, confirm it's a reported actual: `data_as_of` must NOT be in the future (a future date like `2035-12-31` = a forward analyst projection), and the metric name must not be "Analyst Estimates (Mean)" or similar. Never relay a projection as a reported figure.
+- Cross-currency comparisons are a correctness trap: a `"<A> vs <B>"` chart can plot two currencies on one axis unnormalized (Toyota ¥43.6T vs Ford $174B reads as ~250× raw, but ≈1.7× once converted). For cross-border pairs, state each series' currency and convert before comparing — do NOT present the raw chart as apples-to-apples.
+- Period labels are calendar-normalized (Apple's annual points show "Dec 31" though its fiscal year ends in late September; a series may even show a future "Dec 31, 2026" point). Don't cite a label as the issuer's fiscal period; flag the normalization when precision matters.
+- Cite the card's actual `sources[].source_name` (S&P Global, Fiscal.ai, Xignite, Visible Alpha, …) and its `data_as_of` date — the source varies by metric; it is not always S&P Global.
+- Reference the chart in prose ("as the chart above shows"); do NOT paste `![](image_url)` for a card — that double-renders the inline chart.
+- `tako_answer` prose may cite a different fiscal period than the embedded card's latest point (e.g. the answer says FY24 while the card headline is FY25) — reconcile them so text and chart agree.
+
+## Examples
+- Single metric → tako_search {"query": "Nvidia quarterly revenue", "sources": ["data"]}
+- Comparison → tako_search {"query": "Intel vs Nvidia revenue", "sources": ["data"]}
+- Known value, prose → tako_answer {"query": "What was Microsoft's FY2024 net income?", "sources": ["data"]}
+- Growth rate / ratio → pull the levels, then compute yourself: tako_search {"query": "Apple annual revenue", "sources": ["data"]} → compute FY24 vs FY23 % change (tako_answer/tako_search return levels, not the rate)
+- Ranking → tako_agent {"query": "Among the 10 largest US semiconductor companies, which grew revenue fastest since 2020?"}
+
+## Output (tight and structured)
+1) A 1–2 line read of the finding, referencing the intent-matched chart
+2) Source (`source_name`) — `data_as_of` date
+3) A single `[Open in Tako](embed_url)` for the card you embedded

--- a/skills/tako-macroeconomics/SKILL.md
+++ b/skills/tako-macroeconomics/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: tako-macroeconomics
+description: Macroeconomic indicators via Tako (sources: FRED, OECD, BIS). Inflation (CPI/PCE), unemployment, GDP, interest and policy rates, and cross-country comparisons as citation-backed charts. Use for macro monitoring, economic briefings, or any "what is/was <country>'s <indicator>" question.
+---
+
+# Macroeconomics (Tako)
+
+Tako serves macro indicators (sources: FRED / St. Louis Fed, OECD, BIS) as interactive, citation-backed charts.
+
+## Query patterns (Critical)
+- Query is COUNTRY + INDICATOR: `"US CPI inflation"`, `"US unemployment rate"`, `"US federal funds rate"` (which resolves to the Effective Federal Funds Rate, not the FOMC target range).
+- Be specific — many variants exist (CPI all-items vs CPI-W vs core; unemployment headline vs U-6 vs by age/race). If intent is precise, name the variant; if unsure, use `tako_available_data` to list exact metric names first.
+- PCE is a trap: `"US PCE inflation"` / `"US core PCE inflation"` resolve to price-INDEX levels (~130 index points), never a rate. For the inflation rate, query the year-over-year variant (`"US core PCE price index % change"`) AND pick the card titled `… (% Change)` whose values are in percent. Run `tako_available_data` FIRST (mandatory here) to grab the exact `(% Change)` metric + `node_id`.
+- Parallelize multi-part asks: send each metric as its own narrow concurrent `tako_search`, then synthesize — not one query.
+- Cross-country comparison is built in: `"US vs China inflation"` returns a comparison card. For currency-denominated indicators (GDP, wages), a cross-country chart may plot different currencies on one axis unnormalized — state each series' currency and convert before comparing.
+- Ground in Tako data with `sources: ["data"]`.
+- Empty result (zero cards) means "not covered in Tako," NOT that the indicator doesn't exist — confirm with `tako_available_data` or a web check; don't infer a fact from silence.
+
+## Pick the tool
+- `tako_search` — indicator as a chart (default).
+- `tako_answer` — one known value, in prose ("What is the current US unemployment rate?"). Relay verbatim.
+- `tako_agent` — a cohort/ranking to figure out ("which G7 economy has the highest inflation right now?"). ~30–90s.
+- `tako_available_data` — FREE: resolve the exact indicator name + `node_id`.
+
+## Rendering (Critical)
+- Match the card to intent — don't blindly trust index 0. Tako auto-renders the #0 card, but the least-specific card often ranks first: `"US CPI inflation"` can rank a broad BIS country card (a different headline number) above the labeled FRED CPI card, and stale vintages can sneak in. Scan the cards and use the one whose title matches the exact variant with the freshest `data_as_of`; if it isn't #0, reference it with `[Title](webpage_url)` and say it is the authoritative one.
+- Reference the chart in prose; do NOT paste `![](image_url)` for a card — that double-renders the inline chart.
+- Cite the source (FRED / OECD / BIS) + `data_as_of` date.
+
+## Examples
+- Single → tako_search {"query": "US CPI inflation", "sources": ["data"]}
+- Parallel multi-metric → four calls: "US CPI inflation", "US core CPI inflation", "US core PCE price index % change", "US PCE price index % change" (pick each card titled "(% Change)" — the plain "PCE Price Index" cards are index levels, not rates)
+- Cross-country → tako_search {"query": "US vs China inflation", "sources": ["data"]}
+- Known value, prose → tako_answer {"query": "What is the current US federal funds rate?", "sources": ["data"]}
+
+## Output (tight and structured)
+1) A 1–2 line read of the indicator, referencing the intent-matched chart
+2) Source (FRED / OECD / BIS) — `data_as_of` date
+3) A single `[Open in Tako](embed_url)` for the card you embedded

--- a/skills/tako-web-traffic/SKILL.md
+++ b/skills/tako-web-traffic/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: tako-web-traffic
+description: Website and app traffic via Tako (source: SimilarWeb). Monthly visits, traffic trends, and top-sites rankings for any domain as citation-backed charts. Use for competitive traffic analysis, share-of-attention, or any "how much traffic does <site> get" question.
+---
+
+# Web & App Traffic (Tako)
+
+Tako serves SimilarWeb traffic data as interactive, citation-backed charts.
+
+## Query patterns (Critical)
+- Query by DOMAIN, not brand. Brand names resolve to the wrong concept — under `sources: ["data"]` a brand query returns zero cards, and with `"web"` on it mis-resolves to subscriber counts or CDN/network-traffic articles. Always use the bare domain: `"netflix.com monthly visits"`, `"youtube.com"`, `"chatgpt.com"`.
+- The core metric is Visits (monthly, with ~1-month lag).
+- Comparisons: `"youtube.com vs netflix.com monthly visits"`. Rankings: `"top websites by visits"` returns a ranked card.
+- Ground in Tako data with `sources: ["data"]` (SimilarWeb is proprietary).
+- Empty result (zero cards) means "not covered in Tako," NOT that the domain has no traffic — confirm coverage with `tako_available_data` or a web check; don't infer a fact from silence.
+
+## Pick the tool
+- `tako_search` — traffic as a chart (default; top result renders inline).
+- `tako_answer` — one number, in prose ("How many monthly visits does netflix.com get?").
+- `tako_agent` — a ranking/cohort to figure out ("top 5 streaming domains by visits, and which is growing fastest"). ~30–90s.
+- `tako_available_data` — FREE check that a domain is covered before a priced call.
+
+## Rendering (Critical)
+- The top result renders inline automatically — an interactive widget on ChatGPT, a chart image on other hosts. Reference it in prose; do NOT paste `![](image_url)` for the top card — that double-renders it.
+- Cite SimilarWeb + the as-of month (it's in `data_freshness.data_as_of`).
+- Comparison cards (`"A vs B"`) describe each series as a % change over the period — for absolute monthly visits, read the per-domain single-series card instead.
+- Point at any extra cards by linking their titles as `[Title](webpage_url)` — embed only the top card.
+
+## Examples
+- Single domain → tako_search {"query": "netflix.com monthly visits", "sources": ["data"]}
+- Head-to-head → tako_search {"query": "youtube.com vs netflix.com monthly visits", "sources": ["data"]}
+- Ranking → tako_search {"query": "top websites by visits", "sources": ["data"]}
+
+## Output (tight and structured)
+1) A 1–2 line read of the traffic, referencing the inline chart
+2) SimilarWeb — as-of month
+3) A single `[Open in Tako](embed_url)` for the top card


### PR DESCRIPTION
## What

Adds a Claude Code plugin so users can install Tako in one step:

```bash
claude plugin marketplace add TakoData/tako-mcp
claude plugin install tako@tako
```

- **`.claude-plugin/plugin.json`** — declares the hosted server (`https://mcp.tako.com/mcp?tools=agent`, Bearer auth via `${TAKO_API_KEY}` env interpolation). `?tools=agent` because the bundled skills use `tako_agent` for ranking questions.
- **`.claude-plugin/marketplace.json`** — makes this repo installable directly as a marketplace (`tako@tako`), and is the artifact needed to submit to `claude-plugins-community` (and pitch for `claude-plugins-official`, the Exa-style `tako@claude-plugins-official` path).
- **`skills/*/SKILL.md`** — the three README agent skills (financial research, web & app traffic, macroeconomics) extracted verbatim, so the plugin ships them natively instead of copy-paste blocks.
- **README** — plugin install path added to the Claude Code section (with the `TAKO_API_KEY` vs `TAKO_API_TOKEN` distinction and a note to remove a pre-existing `claude mcp add` server).

## Verification

- `claude plugin validate .` passes.
- End-to-end tested locally: `claude plugin marketplace add <path>` → `claude plugin install tako@tako` → skills present in the plugin cache → uninstalled cleanly.
- Skills diffed byte-identical against the README source blocks.
- Reviewed: no CI/codegen collisions (`skills/`, `.claude-plugin/` untouched by gen-registry/regenerate workflows).

## Follow-ups (deliberately out of scope)

- ~~plugin.json version~~ — resolved per review discussion: `version` is pinned to release-please (`.claude-plugin/plugin.json` added to `extra-files`, seeded at 0.11.0). Users receive plugin updates when a release is cut and bumps the version, with changelog — not on every push to main.
- No CI drift-check between README skill blocks and `skills/*/SKILL.md` yet; consider making `skills/` the source of truth and generating the README blocks.
- AGENTS.md repo-layout section doesn't mention `.claude-plugin/` / `skills/` yet.
- Submit to `claude-plugins-community` via https://platform.claude.com/plugins/submit once merged.

