### PR TITLE
docs: reframe MCP registry description around agent access

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.TakoData/tako-mcp",
   "title": "Tako",
-  "description": "Proprietary, continuously-updated live data: 100K+ charts — search, answer, fetch, Answer Agent.",
+  "description": "Give your agent web search and authoritative datasets: S&P Global, FRED, OECD, SimilarWeb & more.",
   "version": "0.11.0",
   "repository": {
     "url": "https://github.com/TakoData/tako-mcp",


### PR DESCRIPTION
## Summary
- Rewrites the `description` in the root `server.json` (the official MCP Registry card) from a data-inventory blurb to what connecting the server gives your agent: **web search + authoritative datasets (S&P Global, FRED, OECD, SimilarWeb & more)**.
- 97 chars — under the registry's 100-char limit.
- The runtime server description in `workers/src/mcp.ts` is agent-steering copy and intentionally left unchanged.

## Ship mechanics
The publish workflow only pushes to registry.modelcontextprotocol.io on a version bump, so this description goes live with the next release-please release (no manual publish needed).

## Test plan
- [x] `server.json` parses as valid JSON
- [x] Description length verified ≤ 100 chars (registry schema limit)