### PR TITLE
feat(mcp): render charts as inline MCP Apps widgets on Claude clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,8 @@ Step 2: Add this Claude skill
 
 ---
 name: tako-financial-research
-description: Company financials and markets via Tako (sources vary by metric — S&P Global, Fiscal.ai, Xignite, Visible Alpha, and others). Revenue, earnings vs. estimates, margins, valuation, stock performance, and head-to-head company comparisons as citation-backed charts. Use for equity research, company deep-dives, competitor financial comparison, or any "what are/were <company>'s <financial metric>" question.
+description: >-
+  Company financials and markets via Tako (sources vary by metric — S&P Global, Fiscal.ai, Xignite, Visible Alpha, and others). Revenue, earnings vs. estimates, margins, valuation, stock performance, and head-to-head company comparisons as citation-backed charts. Use for equity research, company deep-dives, competitor financial comparison, or any "what are/were <company>'s <financial metric>" question.
 ---
 
 # Financial Research (Tako)
@@ -382,7 +383,8 @@ Step 2: Add this Claude skill
 
 ---
 name: tako-web-traffic
-description: Website and app traffic via Tako (source: SimilarWeb). Monthly visits, traffic trends, and top-sites rankings for any domain as citation-backed charts. Use for competitive traffic analysis, share-of-attention, or any "how much traffic does <site> get" question.
+description: >-
+  Website and app traffic via Tako (source: SimilarWeb). Monthly visits, traffic trends, and top-sites rankings for any domain as citation-backed charts. Use for competitive traffic analysis, share-of-attention, or any "how much traffic does <site> get" question.
 ---
 
 # Web & App Traffic (Tako)
@@ -443,7 +445,8 @@ Step 2: Add this Claude skill
 
 ---
 name: tako-macroeconomics
-description: Macroeconomic indicators via Tako (sources: FRED, OECD, BIS). Inflation (CPI/PCE), unemployment, GDP, interest and policy rates, and cross-country comparisons as citation-backed charts. Use for macro monitoring, economic briefings, or any "what is/was <country>'s <indicator>" question.
+description: >-
+  Macroeconomic indicators via Tako (sources: FRED, OECD, BIS). Inflation (CPI/PCE), unemployment, GDP, interest and policy rates, and cross-country comparisons as citation-backed charts. Use for macro monitoring, economic briefings, or any "what is/was <country>'s <indicator>" question.
 ---
 
 # Macroeconomics (Tako)

--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tako-mcp-workers",
-  "version": "0.8.3",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tako-mcp-workers",
-      "version": "0.8.3",
+      "version": "0.13.0",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -19,6 +19,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.9.0",
         "js-yaml": "^4.1.0",
+        "jsdom": "^30.0.0",
         "json-schema-to-zod": "^2.6.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.2",
@@ -78,6 +79,52 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.0.tgz",
+      "integrity": "sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@cfworker/json-schema": {
@@ -219,6 +266,146 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -645,6 +832,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -1811,6 +2016,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/birpc": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
@@ -2037,6 +2252,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2052,6 +2310,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2109,6 +2374,19 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-stack-parser-es": {
@@ -2504,6 +2782,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2565,6 +2856,13 @@
       "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "dev": true
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2612,6 +2910,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-JQHfRGmmKmaZoUAvIgff5jjG/0SzTQlGz8c7t72KzBzo8ZULEjAjnYE0sNwBOUA4QtWwYE2xoYitg8NFsmiYxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.2.5",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.7.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-schema-to-zod": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz",
@@ -2647,6 +2986,16 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2663,6 +3012,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -2818,6 +3174,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2922,6 +3291,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3040,6 +3419,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -3305,6 +3697,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3360,12 +3759,58 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -4083,6 +4528,54 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -5197,6 +5690,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",

--- a/workers/package.json
+++ b/workers/package.json
@@ -5,8 +5,8 @@
   "description": "Tako MCP server on Cloudflare Workers (mcp.tako.com).",
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p scripts/tsconfig.json",
-    "test": "vitest run",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p scripts/tsconfig.json && tsc --noEmit -p test/widget/tsconfig.json",
+    "test": "vitest run && vitest run -c vitest.widget.config.ts",
     "test:watch": "vitest",
     "dev": "wrangler dev",
     "dev:staging": "wrangler dev --env staging",
@@ -28,6 +28,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.9.0",
     "js-yaml": "^4.1.0",
+    "jsdom": "^30.0.0",
     "json-schema-to-zod": "^2.6.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.2",

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -704,6 +704,17 @@ describe("worker routing", () => {
     expect(widget?._meta).toMatchObject({
       ui: { csp: { frameDomains: ["http://localhost:8000"] } },
     });
+    // Pin `resourceDomains` present for ChatGPT explicitly. This is the
+    // one ADDITIVE change to ChatGPT's wire surface in the Claude-widget
+    // rollout (`csp` is built client-agnostically); `toMatchObject` above
+    // passes whether or not the key exists, so without this assertion a
+    // regression that drops it — or a strict-validating Apps SDK build
+    // that would reject it — has no test signal.
+    const chatgptResourceDomains = (
+      widget?._meta as { ui?: { csp?: { resourceDomains?: unknown } } }
+    )?.ui?.csp?.resourceDomains;
+    expect(Array.isArray(chatgptResourceDomains)).toBe(true);
+    expect((chatgptResourceDomains as string[]).length).toBeGreaterThan(0);
   });
 
   it("POST /mcp resources/read returns the widget HTML at the MCP Apps mimeType (ChatGPT)", async () => {

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -709,37 +709,73 @@ describe("worker routing", () => {
     expect(item.text).toContain("tako-embed");
   });
 
-  it("POST /mcp resources/list returns an empty list (not -32601) for non-ChatGPT clients", async () => {
-    // The chart widget resource registers only for ChatGPT (the sole host
-    // that renders it), so no `registerResource` call ever happens on a
-    // non-ChatGPT server instance — and without this the SDK would never
-    // advertise the `resources` capability, turning `resources/list` into
-    // a hard -32601 for capability-probing clients (Smithery's scan, some
-    // hosts). Mirror of the prompts/list guarantee below.
-    for (const userAgent of [undefined, "claude-mcp-client/1.0"]) {
-      const res = await SELF.fetch("https://example.com/mcp", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "application/json, text/event-stream",
-          authorization: AUTH_HEADER,
-          ...(userAgent !== undefined ? { "user-agent": userAgent } : {}),
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 12,
-          method: "resources/list",
-          params: {},
-        }),
-      });
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as {
-        result?: { resources: unknown[] };
-        error?: { code: number };
+  it("POST /mcp resources/list returns an empty list (not -32601) for unknown clients", async () => {
+    // The chart widget resource registers for ChatGPT and Claude clients —
+    // the two hosts that render MCP Apps widgets (see `widgetSuppressed`
+    // in mcp.ts) — so no `registerResource` call ever happens on an
+    // unknown-client server instance — and without this the SDK would
+    // never advertise the `resources` capability, turning `resources/list`
+    // into a hard -32601 for capability-probing clients (Smithery's scan,
+    // some hosts). Mirror of the prompts/list guarantee below.
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 12,
+        method: "resources/list",
+        params: {},
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result?: { resources: unknown[] };
+      error?: { code: number };
+    };
+    expect(body.error).toBeUndefined();
+    expect(body.result?.resources).toEqual([]);
+  });
+
+  it("POST /mcp resources/list includes the chart widget bundle (Claude)", async () => {
+    // Claude clients now get the same widget resource registration as
+    // ChatGPT (the gate flip in mcp.ts) — claude.ai renders MCP Apps
+    // widgets inline in the chat body, unlike its collapsed treatment of
+    // `image` content blocks, so the widget resource must be discoverable
+    // via `resources/list` for a claude-mcp-client user agent too.
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+        "user-agent": "claude-mcp-client/1.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 13,
+        method: "resources/list",
+        params: {},
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        resources: Array<{
+          uri: string;
+          mimeType?: string;
+          _meta?: Record<string, unknown>;
+        }>;
       };
-      expect(body.error).toBeUndefined();
-      expect(body.result?.resources).toEqual([]);
-    }
+    };
+    const widget = body.result.resources.find(
+      (r) => r.uri === "ui://tako/embed/chart",
+    );
+    expect(widget).toBeDefined();
+    expect(widget?.mimeType).toBe("text/html;profile=mcp-app");
   });
 
   it("POST /mcp prompts/list returns an empty list (not -32601) for capability-probing clients", async () => {

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -776,6 +776,28 @@ describe("worker routing", () => {
     );
     expect(widget).toBeDefined();
     expect(widget?.mimeType).toBe("text/html;profile=mcp-app");
+    // CSP-allowed iframe domain mirrors `resolvePublicBase(env)` (which in
+    // tests resolves to `DJANGO_BASE_URL` / `http://localhost:8000`). The
+    // server declares this identically for every client — Claude clients
+    // don't get a restricted `frameDomains` list; claude.ai's own
+    // host-side sandbox is what blocks the iframe, not this metadata.
+    expect(widget?._meta).toMatchObject({
+      ui: { csp: { frameDomains: ["http://localhost:8000"] } },
+    });
+    // `resourceDomains` allow-lists the origins the image-branch fallback
+    // is permitted to fetch/embed from (the remote `image_url` and the
+    // server-fetched `image_data_url`) — must be a non-empty array of
+    // valid origins (staging/production always resolve to `https://`;
+    // the local test config's `DJANGO_BASE_URL` is `http://localhost:8000`,
+    // same as the `frameDomains` assertion above).
+    const resourceDomains = (
+      widget?._meta as { ui?: { csp?: { resourceDomains?: unknown } } }
+    )?.ui?.csp?.resourceDomains;
+    expect(Array.isArray(resourceDomains)).toBe(true);
+    expect((resourceDomains as string[]).length).toBeGreaterThan(0);
+    for (const origin of resourceDomains as string[]) {
+      expect(origin).toMatch(/^https?:\/\//);
+    }
   });
 
   it("POST /mcp prompts/list returns an empty list (not -32601) for capability-probing clients", async () => {

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -396,8 +396,9 @@ describe("worker routing", () => {
     // 4 defaults + tako_visualize = 5.
     expect(body.result.tools).toHaveLength(5);
 
-    // The widget is ChatGPT-only, so `tako_visualize`'s listing must
-    // declare the chart resource under all three metadata keys:
+    // The widget ships on ChatGPT (and Claude — see the claude tools/list
+    // test above), so `tako_visualize`'s listing must declare the chart
+    // resource under all three metadata keys:
     // `_meta.ui.resourceUri` (open MCP Apps spec), the legacy flat
     // `_meta["ui/resourceUri"]` (older host readers), and
     // `_meta["openai/outputTemplate"]` (ChatGPT's Apps SDK — without it
@@ -483,10 +484,11 @@ describe("worker routing", () => {
   });
 
   it("POST /mcp?tools=visualize adds tako_visualize without widget metadata (non-ChatGPT)", async () => {
-    // No User-Agent → client "unknown". The chart widget is ChatGPT-only
-    // (see `widgetSuppressed` in mcp.ts); non-ChatGPT clients render the
-    // chart via the inline PNG image content block on tool results, so
-    // the listing must NOT declare widget metadata.
+    // No User-Agent → client "unknown", the one bucket still denied the
+    // widget (see `widgetSuppressed` in mcp.ts — ChatGPT and Claude both
+    // get it). Unknown clients render the chart via the inline PNG image
+    // content block on tool results instead, so the listing must NOT
+    // declare widget metadata.
     const res = await SELF.fetch("https://example.com/mcp?tools=visualize", {
       method: "POST",
       headers: {
@@ -518,9 +520,10 @@ describe("worker routing", () => {
     // 4 default tools + tako_visualize = 5.
     expect(body.result.tools).toHaveLength(5);
 
-    // Widget metadata is ChatGPT-only — the unknown-client listing carries
-    // none of the three widget keys (the ChatGPT default-surface test
-    // asserts their presence there).
+    // Widget metadata ships for ChatGPT and Claude only — the
+    // unknown-client listing carries none of the three widget keys (the
+    // ChatGPT default-surface and claude tools/list tests assert their
+    // presence there).
     const visualizeTool = body.result.tools.find(
       (t) => t.name === "tako_visualize",
     );
@@ -658,8 +661,9 @@ describe("worker routing", () => {
   });
 
   it("POST /mcp resources/list includes the chart widget bundle (ChatGPT)", async () => {
-    // The widget resource registers only for ChatGPT clients — the sole
-    // host that renders it (see `widgetSuppressed` in mcp.ts).
+    // The widget resource registers for ChatGPT here; the Claude
+    // registration is asserted separately below (see `widgetSuppressed`
+    // in mcp.ts — unknown clients are the only ones that don't get it).
     const res = await SELF.fetch("https://example.com/mcp", {
       method: "POST",
       headers: {

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -239,13 +239,16 @@ describe("worker routing", () => {
       ]);
     }
 
-    // MCP Apps: the chart widget is ChatGPT-only (see `widgetSuppressed`
-    // in mcp.ts). Non-ChatGPT clients — claude AND the unknown long tail
-    // (Cursor, Windsurf, Gemini CLI, …) — get the chart as an inline PNG
-    // `image` content block on tool results instead, so NO tool in this
-    // listing declares widget metadata under any of the three keys.
-    // The ChatGPT-side widget metadata is asserted in the ChatGPT
-    // tools/list tests below.
+    // MCP Apps: this request carries no User-Agent, so `detectMcpClient`
+    // falls through to "unknown" — the one bucket still denied the chart
+    // widget (see `widgetSuppressed` in mcp.ts). ChatGPT and Claude both
+    // get the widget now (interactive iframe on ChatGPT, image-branch
+    // render on Claude); only the unknown long tail (Cursor, Windsurf,
+    // Gemini CLI, …) falls back to the inline PNG `image` content block
+    // on tool results, so NO tool in this listing declares widget
+    // metadata under any of the three keys. The ChatGPT- and Claude-side
+    // widget metadata is asserted in the respective tools/list tests
+    // below.
     for (const t of body.result.tools) {
       const meta = t._meta as
         | {
@@ -258,6 +261,46 @@ describe("worker routing", () => {
       expect(meta?.["ui/resourceUri"]).toBeUndefined();
       expect(meta?.["openai/outputTemplate"]).toBeUndefined();
     }
+  });
+
+  it("POST /mcp tools/list declares the chart widget _meta for claude clients", async () => {
+    // claude.ai loads the widget URI from the `tools/list` registration
+    // `_meta`, not from a separate handshake (see the mcp.ts April
+    // findings on Claude's Apps loading path) — so registration `_meta`
+    // is the load-bearing wire surface for inline charts on claude.ai,
+    // same as it is for ChatGPT. This pins `tako_search`'s listing to
+    // carry all three widget keys for a claude User-Agent, mirroring the
+    // ChatGPT assertion above.
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+        "user-agent": "claude-mcp-client/1.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        tools: Array<{ name: string; _meta?: Record<string, unknown> }>;
+      };
+    };
+    const takoSearchTool = body.result.tools.find(
+      (t) => t.name === "tako_search",
+    );
+    expect(takoSearchTool?._meta).toMatchObject({
+      ui: { resourceUri: "ui://tako/embed/chart" },
+      "ui/resourceUri": "ui://tako/embed/chart",
+      "openai/outputTemplate": "ui://tako/embed/chart",
+    });
   });
 
   it("POST /mcp?tools=agent adds the agent split pair on ChatGPT clients", async () => {

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -290,10 +290,12 @@ describe("extractErrorDetail", () => {
  *
  *   - `widgetSuppressed` — skip the MCP Apps widget (`appUiResource`).
  *     ChatGPT and Claude clients both keep this OFF now: claude.ai
- *     renders MCP Apps widgets inline in the chat body (via the image
- *     branch — its restricted `frameDomains` rule out the iframe route
- *     ChatGPT uses), so both get widget `_meta`. Unknown clients keep
- *     it ON — the long tail of MCP hosts rarely implements MCP Apps.
+ *     renders MCP Apps widgets inline in the chat body via the image
+ *     branch (claude.ai's own outer CSP ignores our `frameDomains`
+ *     declaration, so the bundle's runtime `window.openai` check falls
+ *     back from iframe to image there), so both get widget `_meta`.
+ *     Unknown clients keep it ON — the long tail of MCP hosts rarely
+ *     implements MCP Apps.
  *   - `inlinePngFallbackSuppressed` — skip the `extraContentBlocks`
  *     PNG image content block. Attaching the widget (`ui !== undefined`)
  *     already suppresses this hook for ChatGPT and Claude, so only

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -13,7 +13,11 @@ import {
   extractErrorDetail,
 } from "./django.js";
 import type { Env } from "./env.js";
-import { createMcpServer, djangoErrorToToolResult } from "./mcp.js";
+import {
+  createMcpServer,
+  detectMcpClient,
+  djangoErrorToToolResult,
+} from "./mcp.js";
 import {
   jsonResponse,
   mockFetchSequence,
@@ -483,6 +487,36 @@ describe("chart render gates per client", () => {
     const result = await callSearch("claude");
 
     expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
+  });
+});
+
+describe("detectMcpClient", () => {
+  // The "claude" bucket is widget-ONLY: it suppresses the inline PNG
+  // content block. Every UA asserted into it must belong to a surface
+  // that actually renders MCP Apps widgets (claude.ai / Claude Desktop
+  // custom connectors — server-to-server from Anthropic's backend as
+  // `Claude-User`). UAs are real observed strings, not invented ones.
+  it("buckets the claude.ai/Desktop connector UAs as claude", () => {
+    expect(detectMcpClient("Claude-User")).toBe("claude");
+    expect(detectMcpClient("claude-mcp-client/1.0")).toBe("claude");
+    expect(detectMcpClient("Anthropic/1.0")).toBe("claude");
+  });
+
+  it("keeps Claude Code (and the Agent SDK it powers) on the PNG path", () => {
+    // Observed UA of claude-code 2.1.220's streamable-HTTP MCP client.
+    // A terminal, not an MCP Apps host: bucketing it "claude" would ship
+    // widget _meta it can't render AND drop the PNG block — no chart.
+    expect(detectMcpClient("claude-code/2.1.220 (sdk-cli)")).toBe("unknown");
+  });
+
+  it("buckets ChatGPT UAs as chatgpt and everything else as unknown", () => {
+    expect(detectMcpClient("ChatGPT/1.0 (+https://chatgpt.com)")).toBe(
+      "chatgpt",
+    );
+    expect(detectMcpClient("openai-mcp/1.0")).toBe("chatgpt");
+    expect(detectMcpClient("python-httpx/0.27")).toBe("unknown");
+    expect(detectMcpClient(null)).toBe("unknown");
+    expect(detectMcpClient("")).toBe("unknown");
   });
 });
 

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -416,6 +416,26 @@ describe("chart render gates per client", () => {
     expect(meta?.image_data_url).toMatch(/^data:image\/png;base64,/);
   });
 
+  it("claude client: PNG fetch failure degrades gracefully (widget _meta stays, no image_data_url)", async () => {
+    // Call 1: v3 search succeeds. Call 2: PNG fetch fails (500).
+    mockFetchSequence([
+      searchResponse(),
+      new Response("error", { status: 500 }),
+    ]);
+
+    const result = await callSearch("claude");
+
+    // Graceful degradation: the tool call still resolves, the widget
+    // metadata is still attached (claude stays on the static URI), and
+    // `image_data_url` is simply absent — no throw, no partial data.
+    expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
+    const meta = result._meta as
+      | { ui?: { resourceUri?: string }; image_data_url?: string }
+      | undefined;
+    expect(meta?.ui?.resourceUri).toMatch(/^ui:\/\/tako\/embed\/chart/);
+    expect(meta?.image_data_url).toBeUndefined();
+  });
+
   it("unknown client: chart ships as an inline image content block (no widget metadata)", async () => {
     // Unknown clients are the long tail of MCP hosts (Cursor, Windsurf,
     // Gemini CLI, LibreChat, …). Almost none of them implement the MCP

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -289,13 +289,15 @@ describe("extractErrorDetail", () => {
  * Two independent gates decide how a chart-bearing tool result renders:
  *
  *   - `widgetSuppressed` — skip the MCP Apps widget (`appUiResource`).
- *     Claude clients keep this ON: claude.ai's widget container clips
- *     the chart iframe, so no widget `_meta` ships there.
+ *     ChatGPT and Claude clients both keep this OFF now: claude.ai
+ *     renders MCP Apps widgets inline in the chat body (via the image
+ *     branch — its restricted `frameDomains` rule out the iframe route
+ *     ChatGPT uses), so both get widget `_meta`. Unknown clients keep
+ *     it ON — the long tail of MCP hosts rarely implements MCP Apps.
  *   - `inlinePngFallbackSuppressed` — skip the `extraContentBlocks`
- *     PNG image content block. Claude clients keep this OFF so charts
- *     render inline as images (claude.ai, Claude desktop, and Claude
- *     Code all render `image` content blocks in-chat, and the model
- *     can see the chart while composing its answer).
+ *     PNG image content block. Attaching the widget (`ui !== undefined`)
+ *     already suppresses this hook for ChatGPT and Claude, so only
+ *     unknown clients render `image` content blocks in-chat.
  *
  * Exercised end-to-end over an in-memory MCP transport: real server,
  * real tool registration, real `tools/call` — only the upstream
@@ -378,22 +380,38 @@ describe("chart render gates per client", () => {
     vi.restoreAllMocks();
   });
 
-  it("claude client: chart ships as an inline image content block (widget stays suppressed)", async () => {
-    // Call 1: v3 search. Call 2: chart PNG for the image content block.
-    mockFetchSequence([searchResponse(), pngResponse()]);
+  /**
+   * 1x1 transparent PNG — a REAL PNG (valid IHDR), because the widget
+   * `_meta` path (`fetchImageDataUrlAndDims`) parses dimensions and
+   * degrades to undefined on a bare signature.
+   */
+  function realPngResponse(): Response {
+    const b64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    return new Response(bytes, {
+      status: 200,
+      headers: { "content-type": "image/png" },
+    });
+  }
+
+  it("claude client: MCP Apps widget ships inline, no image content block", async () => {
+    // Call 1: v3 search. Call 2: chart PNG — now fetched by `extraMeta`
+    // (baked `_meta.image_data_url` for the widget's image branch)
+    // instead of `extraContentBlocks`. Still exactly two fetches.
+    mockFetchSequence([searchResponse(), realPngResponse()]);
 
     const result = await callSearch("claude");
 
-    const imageBlocks = result.content.filter((b) => b.type === "image");
-    expect(imageBlocks).toHaveLength(1);
-    expect(imageBlocks[0]?.mimeType).toBe("image/png");
-    expect(typeof imageBlocks[0]?.data).toBe("string");
-    expect((imageBlocks[0]?.data as string).length).toBeGreaterThan(0);
-    // Widget stays suppressed for claude — no MCP Apps resource URI in
-    // the result `_meta` (claude.ai's widget container clips charts).
-    expect(
-      (result._meta as { ui?: unknown } | undefined)?.ui,
-    ).toBeUndefined();
+    // Widget replaces the PNG content block on claude — MCP Apps inline
+    // cards render in the chat body; image blocks stay collapsed in the
+    // tool-call expander (the bug this change fixes).
+    expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
+    const meta = result._meta as
+      | { ui?: { resourceUri?: string }; image_data_url?: string }
+      | undefined;
+    expect(meta?.ui?.resourceUri).toMatch(/^ui:\/\/tako\/embed\/chart/);
+    expect(meta?.image_data_url).toMatch(/^data:image\/png;base64,/);
   });
 
   it("unknown client: chart ships as an inline image content block (no widget metadata)", async () => {
@@ -430,9 +448,10 @@ describe("chart render gates per client", () => {
   });
 
   it("claude client: no image block when the search returns zero cards", async () => {
-    // Empty result → no top card → no image_url → the PNG hook must not
-    // fire (queue holds only the search response; an unexpected second
-    // fetch would throw loudly).
+    // Empty result → no top card → no image_url → `extraMeta`'s PNG
+    // prefetch must not fire (queue holds only the search response; an
+    // unexpected second fetch would throw loudly) and no image content
+    // block ships either — both hold with the widget path too.
     mockFetchSequence([
       jsonResponse(200, { cards: [], web_results: [], request_id: "req-2" }),
     ]);

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -420,7 +420,9 @@ describe("chart render gates per client", () => {
     // Unknown clients are the long tail of MCP hosts (Cursor, Windsurf,
     // Gemini CLI, LibreChat, …). Almost none of them implement the MCP
     // Apps widget spec, but virtually all render `image` content
-    // blocks — so they get the same PNG treatment as Claude clients.
+    // blocks — so they're the one bucket that still gets the PNG
+    // fallback (Claude now gets the widget's image branch instead, see
+    // the "claude client" test above).
     // Call 1: v3 search. Call 2: chart PNG for the image content block.
     mockFetchSequence([searchResponse(), pngResponse()]);
 

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -123,9 +123,10 @@ const JSON_SCHEMA_VALIDATOR = new CfWorkerJsonSchemaValidator();
  *
  * The match is intentionally loose: we don't care about exact UA
  * strings, just whether the request smells like one of the major
- * MCP-app hosts. Unknown UAs fall through to the "render the widget"
- * default — better to over-render than to hide the chart from a host
- * that supports it.
+ * MCP-app hosts. Unknown UAs fall through to the inline-PNG `image`
+ * content block, not the widget — that path is the portable fallback
+ * that works on the long tail of MCP hosts that don't (yet) implement
+ * MCP Apps, so an unrecognized client still gets a chart it can render.
  */
 // `McpClientKind` is defined in `tools/types.ts` (re-exported below)
 // so tool modules can reference it without a circular import on
@@ -610,11 +611,15 @@ function registerTool(
       );
     }
     // Optional dynamic-resource variant. When defined, the same widget
-    // also gets a `ResourceTemplate` registration, and per-call tool
-    // results point claude.ai's `_meta.ui.resourceUri` at a specific
-    // instance of that template (so the widget HTML can have the
-    // chart's image + dimensions baked in at fetch time, sidestepping
-    // claude.ai's "snapshot offsetHeight once on mount" behavior). See
+    // also gets a `ResourceTemplate` registration so a per-call
+    // `_meta.ui.resourceUri` could point at a specific instance of that
+    // template (baking the chart's image + dimensions into the widget
+    // HTML at fetch time, sidestepping a host's "snapshot offsetHeight
+    // once on mount" behavior). claude.ai does NOT use this today — see
+    // the "Conclusion" comment below: it ignores per-call resourceUri
+    // overrides and stays on the static URI + baked
+    // `_meta.image_data_url` from `extraMeta`. The template stays
+    // registered for a future host that does honor per-call URIs. See
     // `AppUiResource.dynamic` for the rationale.
     if (
       ui.dynamic !== undefined &&

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -111,11 +111,15 @@ const JSON_SCHEMA_VALIDATOR = new CfWorkerJsonSchemaValidator();
  * Detect the calling MCP client from the HTTP `User-Agent` header.
  *
  * Used to gate per-client behavior that we'd otherwise have to ask the
- * LLM to figure out from prose — specifically, suppressing the chart
- * widget on claude.ai (where the constrained iframe container clips
- * the chart and the LLM's markdown link is strictly cleaner UX) and
- * routing ChatGPT through the agent split pair (its Apps SDK doesn't
- * reset tool-call timeouts on progress notifications).
+ * LLM to figure out from prose — specifically, routing the chart to
+ * the MCP Apps widget for ChatGPT and Claude (the two hosts that render
+ * it inline — ChatGPT via the interactive iframe branch, Claude via the
+ * image branch, since claude.ai's host-side CSP ignores declared
+ * `frameDomains` and the widget's runtime `window.openai` check falls
+ * back to the static image there) while unknown clients fall back to
+ * the inline PNG `image` content block, and routing ChatGPT through
+ * the agent split pair (its Apps SDK doesn't reset tool-call timeouts
+ * on progress notifications).
  *
  * The match is intentionally loose: we don't care about exact UA
  * strings, just whether the request smells like one of the major
@@ -266,8 +270,8 @@ export function createMcpServer(
     "tako_agent",
   ]);
   // Tools whose `appUiResource` should NOT ship on ChatGPT (separate
-  // from the blanket non-ChatGPT suppression in `widgetSuppressed` —
-  // ChatGPT is the only client that gets the widget at all).
+  // from the blanket unknown-client suppression in `widgetSuppressed` —
+  // ChatGPT and Claude are the only clients that get the widget at all).
   // The mechanism is kept in place for future per-tool gating, but
   // is currently empty: `tako_search` ships its widget on ChatGPT
   // and handles the empty-result case by throwing an actionable
@@ -329,11 +333,12 @@ export function createMcpServer(
   }
 
   // Resources parity for server instances that registered NO widget
-  // resource (every non-ChatGPT client, since the chart widget is
-  // ChatGPT-only). The SDK only wires the `resources` capability and its
-  // request handlers on the first `registerResource` call — without this
-  // block, `resources/list` / `resources/read` answer JSON-RPC -32601 on
-  // non-ChatGPT instances, which capability-probing clients (Smithery's
+  // resource (unknown clients only — ChatGPT and Claude both register
+  // it, and the fallback below only fires when neither did). The SDK
+  // only wires the `resources` capability and its request handlers on
+  // the first `registerResource` call — without this block,
+  // `resources/list` / `resources/read` answer JSON-RPC -32601 on
+  // unknown-client instances, which capability-probing clients (Smithery's
   // scan, some hosts) surface as a failure. Same rationale as the empty
   // `prompts` registration above: an empty list is the spec-clean answer.
   // `resources/read` still errors (there is nothing to read) but with the
@@ -544,8 +549,12 @@ function registerTool(
       uiMeta.csp = csp;
     }
     // Resource registration. CSP-allowed iframe domains live on
-    // `_meta.ui.csp.frameDomains` (open MCP Apps spec). The bundle's
-    // `_meta.ui` is set in TWO places by design (matches the official
+    // `_meta.ui.csp.frameDomains` (open MCP Apps spec); its sibling
+    // `_meta.ui.csp.resourceDomains` allow-lists the origins the
+    // remote-image fallback (`<img src=image_url>`) may fetch/embed
+    // from — the widget's image branch is what actually renders on
+    // Claude, where the iframe branch never gets a chance to load. The
+    // bundle's `_meta.ui` is set in TWO places by design (matches the official
     // `@modelcontextprotocol/ext-apps` helper):
     //
     //   1. Resource registration metadata (third arg to
@@ -1144,9 +1153,9 @@ export async function handleMcpRequest(
     // connectors from referencing prod URLs and vice versa.
     const url = new URL(request.url);
     const requestOrigin = url.origin;
-    // Detect calling client from User-Agent so we can suppress the
-    // chart widget on claude.ai (constrained iframe container) and
-    // route ChatGPT through the agent split pair. See
+    // Detect calling client from User-Agent so we can route the chart
+    // widget to ChatGPT and Claude (unknown clients fall back to the
+    // inline PNG) and route ChatGPT through the agent split pair. See
     // `detectMcpClient` for the matching rules.
     const client = detectMcpClient(request.headers.get("user-agent"));
     // Opt-in tools: the agent is off by default and enabled per-connection

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -515,8 +515,15 @@ function registerTool(
 
   if (ui !== undefined) {
     const uiMeta: Record<string, unknown> = {};
+    const csp: Record<string, unknown> = {};
     if (ui.frameDomains && ui.frameDomains.length > 0) {
-      uiMeta.csp = { frameDomains: ui.frameDomains };
+      csp.frameDomains = ui.frameDomains;
+    }
+    if (ui.resourceDomains && ui.resourceDomains.length > 0) {
+      csp.resourceDomains = ui.resourceDomains;
+    }
+    if (Object.keys(csp).length > 0) {
+      uiMeta.csp = csp;
     }
     // Resource registration. CSP-allowed iframe domains live on
     // `_meta.ui.csp.frameDomains` (open MCP Apps spec). The bundle's

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -138,11 +138,27 @@ export type { McpClientKind };
 export function detectMcpClient(userAgent: string | null): McpClientKind {
   if (userAgent === null || userAgent === "") return "unknown";
   const ua = userAgent.toLowerCase();
-  // Claude.ai's MCP server-to-server connector identifies itself as
-  // either `Claude-User`, `claude-mcp-client`, or similar — match on
-  // any "claude" / "anthropic" substring. The user's own browser UA
-  // never reaches /mcp directly (claude.ai proxies through its
-  // backend), so this won't false-positive on user browsers.
+  // Claude Code's HTTP MCP client (and the Agent SDK, which runs Claude
+  // Code under the hood) sends `claude-code/<version> (sdk-cli)` —
+  // verified empirically 2026-07-27 against claude-code 2.1.220. It is
+  // a terminal, not an MCP Apps host: it cannot render the widget, and
+  // `"claude"` is widget-only (the widget suppresses the PNG content
+  // block via the `ui === undefined` mutual exclusion). Bucket it as
+  // `"unknown"` so it keeps the portable inline-PNG path. Must run
+  // BEFORE the broad "claude" substring match below.
+  if (ua.includes("claude-code")) return "unknown";
+  // Claude.ai and Claude Desktop custom connectors are server-to-server
+  // from Anthropic's backend (egress 160.79.104.0/21) and identify as
+  // `Claude-User` (occasionally `python-httpx`, which falls through to
+  // "unknown" → PNG — acceptable, that path renders everywhere). Match
+  // on any remaining "claude" / "anthropic" substring. The user's own
+  // browser UA never reaches /mcp directly (claude.ai proxies through
+  // its backend), so this won't false-positive on user browsers.
+  //
+  // Known residual risk: the Messages API `mcp_servers` connector also
+  // egresses from Anthropic's backend and its UA is not publicly
+  // pinned. If it sends `Claude-User` it is indistinguishable from
+  // claude.ai here and gets widget `_meta` it cannot render.
   if (ua.includes("claude") || ua.includes("anthropic")) return "claude";
   // ChatGPT's Apps SDK connector typically advertises `ChatGPT-User`,
   // `openai-mcp`, or similar in UA.

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -473,15 +473,24 @@ function registerTool(
   //
   //   - `widgetSuppressed` → skip `appUiResource`. The host won't
   //     get a widget URI in the tool's `_meta`, so it won't load
-  //     the chart bundle. ChatGPT is the ONLY client that keeps the
-  //     widget: its Apps SDK renders the fully interactive iframe.
-  //     Claude clients suppress it (claude.ai's constrained iframe
-  //     container clips the chart and exposes an awkward scrollbar),
-  //     and unknown clients suppress it too — the long tail of MCP
-  //     hosts (Cursor, Windsurf, Gemini CLI, LibreChat, …) almost
-  //     never implements the MCP Apps spec, so shipping widget
-  //     metadata there just blocks the far more portable image
-  //     fallback below.
+  //     the chart bundle. Three-way policy, one widget bundle:
+  //
+  //       - ChatGPT keeps the widget its Apps SDK renders as a fully
+  //         interactive iframe (`frameDomains` populated, `embed_url`
+  //         loaded live inside the sandbox).
+  //       - Claude clients ALSO keep the widget, but render it via the
+  //         image branch, not an iframe: claude.ai restricts
+  //         `frameDomains` for custom connectors pending its own
+  //         security review, so `csp.frameDomains` stays empty for
+  //         claude and the bundle falls back to painting the
+  //         server-fetched `_meta.image_data_url` PNG (see the
+  //         `extraMeta` comment below) instead of embedding
+  //         `embed_url` in an `<iframe>`.
+  //       - Unknown clients still suppress the widget — the long tail
+  //         of MCP hosts (Cursor, Windsurf, Gemini CLI, LibreChat, …)
+  //         almost never implements the MCP Apps spec, so shipping
+  //         widget metadata there just blocks the far more portable
+  //         image content-block fallback below.
   //
   //   - `inlinePngFallbackSuppressed` → skip the
   //     `extraContentBlocks` PNG image content block. Without
@@ -489,14 +498,16 @@ function registerTool(
   //     `appUiResource` to provide a "render the chart inline as
   //     an image" fallback for hosts that don't support MCP UI.
   //
-  // Net effect: ChatGPT renders the interactive widget; every other
-  // client gets the chart inline as an `image` content block —
-  // rendered in-chat by claude.ai / Claude desktop / Claude Code and
-  // most generic MCP hosts, and visible to the model while it
-  // composes its answer. The `embed_url` in the structured content
-  // stays the click-through to the interactive chart everywhere.
-  // (Historically both gates fired together on claude — link-only —
-  // and unknown clients got widget metadata they couldn't render.)
+  // Net effect: ChatGPT and Claude both render the MCP Apps widget
+  // (interactive iframe on ChatGPT, image-branch card on Claude —
+  // both render inline in the chat body); unknown clients get the
+  // chart as an `image` content block instead, visible to the model
+  // while it composes its answer. The `embed_url` in the structured
+  // content stays the click-through to the interactive chart
+  // everywhere. (Historically both gates fired together on claude —
+  // link-only, no widget, no image — and unknown clients got widget
+  // metadata they couldn't render; see the 2026-07 note below for why
+  // claude.ai gets the widget now instead of the PNG block.)
   //
   // Per-tool ChatGPT suppression (`widgetSuppressedForTool`) still
   // fires both gates. That set exists for tools whose widget renders
@@ -506,7 +517,8 @@ function registerTool(
   // guaranteed by the `ui === undefined` condition at the call-time
   // `extraContentBlocks` gate.)
   const widgetSuppressed =
-    options.client !== "chatgpt" || options.widgetSuppressedForTool === true;
+    (options.client !== "chatgpt" && options.client !== "claude") ||
+    options.widgetSuppressedForTool === true;
   const inlinePngFallbackSuppressed = options.widgetSuppressedForTool === true;
   const ui =
     tool.appUiResource !== undefined && !widgetSuppressed
@@ -646,6 +658,10 @@ function registerTool(
     // support per-tool-call widget URI variation, so we stay on the
     // static URI for all three keys. The template resource is still
     // registered above for future hosts that may support it.
+    //
+    // 2026-07: widget re-enabled for Claude clients via the static URI
+    // + `ui/notifications/tool-result` data path; per-call dynamic
+    // URIs remain registered for hosts that support them.
     config._meta = {
       ...(config._meta as Record<string, unknown>),
       ui: { resourceUri: ui.uri },
@@ -775,13 +791,17 @@ function registerTool(
       // call.
       //
       // Fires only when this registration carries no widget
-      // (`ui === undefined` — widget-less tools everywhere, and ALL
-      // chart tools on Claude clients, where the widget is suppressed)
-      // AND the inline PNG fallback hasn't been independently
-      // suppressed for this tool. This is how Claude clients get the
-      // chart inline: the PNG image content block renders in-chat on
-      // claude.ai / Claude desktop / Claude Code, with `embed_url` in
-      // the structured content as the interactive click-through.
+      // (`ui === undefined` — widget-less tools everywhere, and now
+      // chart tools on UNKNOWN clients only, where the widget is
+      // suppressed) AND the inline PNG fallback hasn't been
+      // independently suppressed for this tool. This is how the long
+      // tail of MCP hosts (Cursor, Windsurf, Gemini CLI, LibreChat, …)
+      // gets the chart inline: the PNG image content block renders as
+      // a generic `image` block, with `embed_url` in the structured
+      // content as the interactive click-through. Claude clients no
+      // longer take this path — they get the MCP Apps widget instead
+      // (see `widgetSuppressed` above), so this hook never fires for
+      // `client === "claude"`.
       //
       // Pairing image content blocks with widget metadata in the
       // same result silently disabled ChatGPT's widget data flow, so
@@ -813,18 +833,20 @@ function registerTool(
       // context" guard.
       //
       // Gated on `ui !== undefined` — the inverse of `extraContentBlocks`
-      // above. When the widget is suppressed (every non-ChatGPT client),
-      // no widget will consume `_meta`, so running this hook would
+      // above. When the widget is suppressed (unknown clients), no
+      // widget will consume `_meta`, so running this hook would
       // inflate the JSON-RPC response with a ~330 KB unused data URL.
       //
-      // NB: with the widget now ChatGPT-only, this hook only fires for
-      // ChatGPT — and both chart tools' `extraMeta` implementations bail
-      // early on `ctx.client === "chatgpt"` (its widget loads `embed_url`
-      // directly and never reads the baked image). The `image_data_url`
-      // plumbing (here, in the tools' `extraMeta`, and the widget's
-      // baked-image render branch) is therefore currently unreachable;
-      // it's retained for a future re-enable of the widget on MCP-Apps
-      // hosts. Remove it if that plan is dropped.
+      // This hook now fires for both widget clients, but each does
+      // something different with it: ChatGPT's `extraMeta`
+      // implementations bail early on `ctx.client === "chatgpt"` (its
+      // iframe widget loads `embed_url` directly and never reads the
+      // baked image), while Claude's do not — `image_data_url` is
+      // Claude's PRIMARY chart data path. claude.ai restricts
+      // `frameDomains` for custom connectors pending its own security
+      // review, so the widget can't embed `embed_url` in an `<iframe>`
+      // there; instead it reads this baked `_meta.image_data_url` and
+      // paints the PNG directly in its image render branch.
       let resultMeta: Record<string, unknown> | undefined;
       if (tool.extraMeta !== undefined && ui !== undefined) {
         try {

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -479,10 +479,16 @@ function registerTool(
   //         interactive iframe (`frameDomains` populated, `embed_url`
   //         loaded live inside the sandbox).
   //       - Claude clients ALSO keep the widget, but render it via the
-  //         image branch, not an iframe: claude.ai restricts
-  //         `frameDomains` for custom connectors pending its own
-  //         security review, so `csp.frameDomains` stays empty for
-  //         claude and the bundle falls back to painting the
+  //         image branch, not an iframe: the server declares
+  //         `csp.frameDomains` identically for every client (see
+  //         `buildChartAppUiResource` — it always sets `frameDomains:
+  //         [webBase]`), but claude.ai's host-side sandbox currently
+  //         restricts third-party iframes regardless of what's
+  //         declared there, pending Claude's own MCP Apps security
+  //         review, so the iframe never loads on claude.ai. The
+  //         bundle's client-side JS feature-detects `window.openai` at
+  //         runtime (see `shouldUseInteractiveIframe` in
+  //         `_chart_widget.ts`) and falls back to painting the
   //         server-fetched `_meta.image_data_url` PNG (see the
   //         `extraMeta` comment below) instead of embedding
   //         `embed_url` in an `<iframe>`.
@@ -842,11 +848,14 @@ function registerTool(
       // implementations bail early on `ctx.client === "chatgpt"` (its
       // iframe widget loads `embed_url` directly and never reads the
       // baked image), while Claude's do not — `image_data_url` is
-      // Claude's PRIMARY chart data path. claude.ai restricts
-      // `frameDomains` for custom connectors pending its own security
-      // review, so the widget can't embed `embed_url` in an `<iframe>`
-      // there; instead it reads this baked `_meta.image_data_url` and
-      // paints the PNG directly in its image render branch.
+      // Claude's PRIMARY chart data path. The server declares the same
+      // `csp.frameDomains` for both clients, but claude.ai's host-side
+      // sandbox currently restricts third-party iframes regardless of
+      // that declaration, pending Claude's own MCP Apps security
+      // review, so the bundle's runtime `window.openai` feature
+      // detection picks the image branch there instead of embedding
+      // `embed_url` in an `<iframe>`; it reads this baked
+      // `_meta.image_data_url` and paints the PNG directly.
       let resultMeta: Record<string, unknown> | undefined;
       if (tool.extraMeta !== undefined && ui !== undefined) {
         try {

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import type { Env } from "../env.js";
+import { buildChartAppUiResourceFromOutputPubId } from "./_chart_widget.js";
+
+const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
+
+describe("chart widget HTML", () => {
+  it("notifies height via the MCP Apps size-changed notification", () => {
+    const ui = buildChartAppUiResourceFromOutputPubId(ENV);
+    // claude.ai tracks widget height via the open-spec JSON-RPC
+    // notification over postMessage; window.openai.notifyIntrinsicHeight
+    // covers ChatGPT only.
+    expect(ui.html).toContain('"ui/notifications/size-changed"');
+    expect(ui.html).toContain("notifyIntrinsicHeight");
+  });
+});

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -14,4 +14,15 @@ describe("chart widget HTML", () => {
     expect(ui.html).toContain('"ui/notifications/size-changed"');
     expect(ui.html).toContain("notifyIntrinsicHeight");
   });
+
+  it("declares resourceDomains so the remote image fallback loads on claude.ai", () => {
+    const ui = buildChartAppUiResourceFromOutputPubId(ENV);
+    // image_url is served from the public API base; the embed page from
+    // the web base. Both must be CSP-allowed for the <img> fallback.
+    expect(ui.resourceDomains).toBeDefined();
+    expect(ui.resourceDomains!.length).toBeGreaterThan(0);
+    for (const d of ui.resourceDomains!) {
+      expect(d).toMatch(/^https:\/\//);
+    }
+  });
 });

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { Env } from "../env.js";
-import { buildChartAppUiResourceFromOutputPubId } from "./_chart_widget.js";
+import {
+  __chart_widget_test_only__,
+  buildChartAppUiResourceFromOutputPubId,
+} from "./_chart_widget.js";
 
 const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
 
@@ -13,6 +16,23 @@ describe("chart widget HTML", () => {
     // covers ChatGPT only.
     expect(ui.html).toContain('"ui/notifications/size-changed"');
     expect(ui.html).toContain("notifyIntrinsicHeight");
+  });
+
+  it("bakes the size-changed notification into the per-pub_id variant too", () => {
+    // The static bundle (asserted above) and the baked variant are
+    // separate template strings — a size-changed regression in one is
+    // invisible to assertions on the other.
+    const html = __chart_widget_test_only__.buildBakedWidgetHtml({
+      embedUrl: "https://staging.trytako.com/embed/abc123/?dark_mode=auto",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      naturalWidth: 800,
+      naturalHeight: 600,
+    });
+    expect(html).toContain('"ui/notifications/size-changed"');
+    expect(html).toContain("notifyIntrinsicHeight");
+    // Re-notify after the <img> gets real dimensions — the initial
+    // notify() runs pre-load and can measure a pre-layout height.
+    expect(html).toContain('addEventListener("load"');
   });
 
   it("declares resourceDomains so the remote image fallback loads on claude.ai", () => {

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -54,14 +54,24 @@ export const HTTP_URL_REGEX = /^https?:\/\//;
 export const MAX_INLINE_PNG_BYTES = 4 * 1024 * 1024;
 
 // Cap for inline `image_data_url` in `_meta` — distinct from
-// `MAX_INLINE_PNG_BYTES`. The data URI ends up inside the JSON-RPC tool
-// result envelope, which the LLM also tokenizes and some clients have
-// observed to silently fail their widget data flow past ~400 KB encoded.
-// Cap at 250 KB raw → ~333 KB encoded for a margin under that threshold.
+// `MAX_INLINE_PNG_BYTES`. Sized to cover the real chart range: Tako
+// chart PNGs run 50-300 KB, and this data URI is now Claude's PRIMARY
+// chart path (claude.ai's outer CSP blocks the cross-origin `image_url`
+// fallback), so a cap below 300 KB silently drops the largest charts to
+// a text link there. 400 KB raw (~533 KB encoded) covers the range with
+// headroom.
+//
+// Why the old 250 KB cap is safe to lift: `_meta` is not tokenized by
+// the model, and the ~400 KB-encoded silent widget-data failure that
+// motivated it was observed on ChatGPT — whose `extraMeta` hook is now
+// skipped entirely (see tako_search/tako_visualize), so this field never
+// ships there. The remaining ceiling is the host's message-size limit;
+// the staging ">250 KB chart renders on claude.ai" check is the
+// empirical gate on this number.
 // Charts above the cap fall back to `image_url` only, which is fine for
-// hosts whose CSP allows cross-origin images (ChatGPT) but means
-// claude.ai users see no chart for the largest charts.
-export const MAX_INLINE_DATA_URL_BYTES = 250 * 1024;
+// hosts whose CSP allows cross-origin images but means claude.ai users
+// see no chart — keep the cap comfortably above real chart sizes.
+export const MAX_INLINE_DATA_URL_BYTES = 400 * 1024;
 
 // Bound how long we'll wait on the PNG endpoint before giving up. The
 // content block / data URL is "nice to have" — better to ship the URL
@@ -222,6 +232,14 @@ function buildBakedWidgetHtml(opts: {
   }
   notify();
   window.addEventListener("resize", notify);
+  // The script runs before the <img> has necessarily loaded, so the
+  // initial notify() can measure a pre-layout height (the explicit
+  // width/height attributes reserve layout in most cases, but not when
+  // width:100% shrinks the image in a narrow container). Re-notify once
+  // the image has real dimensions — mirrors the static variant's load
+  // listener.
+  var img = document.getElementById("tako-embed-img");
+  if (img) img.addEventListener("load", notify);
 })();
 </script>
 </body>
@@ -761,13 +779,24 @@ const WIDGET_HTML = `<!doctype html>
     var msg = event.data;
     if (!msg || typeof msg !== "object") return;
     // MCP Apps host messages (handshake + tool-result) come from the
-    // parent frame. Reject anything else — a co-installed sibling
-    // connector's iframe can postMessage to us via parent.frames[] and
-    // would otherwise be able to inject a spoofed tool-result (fake chart
-    // image + arbitrary click-through URL; render() is one-shot). The
+    // host's own browsing context — \`window.parent\`, or \`window.top\`
+    // if the host nests the widget inside a wrapper frame. Reject
+    // anything else — a co-installed sibling connector's iframe can
+    // postMessage to us via parent.frames[] and would otherwise be able
+    // to inject a spoofed tool-result (fake chart image + arbitrary
+    // click-through URL; render() is one-shot). A sibling's
+    // \`event.source\` is the sibling's own window, never parent or top,
+    // so widening to \`top\` keeps the injection blocked. The
     // \`tako-embed-height\` branch below is separately origin-gated to the
     // embed iframe, so leave it reachable regardless.
-    var fromHost = event.source === window.parent;
+    var fromHost = event.source === window.parent || event.source === window.top;
+    // This gate guards Claude's only chart data path. If a host ever
+    // delivers JSON-RPC from a context we don't trust, dropping it
+    // silently would strand the widget on "Loading chart…" with no
+    // signal — warn so devtools / host logs show the drop.
+    if (!fromHost && msg.jsonrpc === "2.0") {
+      console.warn("[tako-widget] dropped JSON-RPC message from untrusted source", msg.method || msg.id);
+    }
     // Init response → send the \`initialized\` notification so the host
     // starts piping tool-result messages. Don't gate on response
     // contents — any matching id (success or error) is sufficient

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -744,11 +744,20 @@ const WIDGET_HTML = `<!doctype html>
   window.addEventListener("message", function (event) {
     var msg = event.data;
     if (!msg || typeof msg !== "object") return;
+    // MCP Apps host messages (handshake + tool-result) come from the
+    // parent frame. Reject anything else — a co-installed sibling
+    // connector's iframe can postMessage to us via parent.frames[] and
+    // would otherwise be able to inject a spoofed tool-result (fake chart
+    // image + arbitrary click-through URL; render() is one-shot). The
+    // \`tako-embed-height\` branch below is separately origin-gated to the
+    // embed iframe, so leave it reachable regardless.
+    var fromHost = event.source === window.parent;
     // Init response → send the \`initialized\` notification so the host
     // starts piping tool-result messages. Don't gate on response
     // contents — any matching id (success or error) is sufficient
     // signal that the host saw our \`ui/initialize\`.
     if (
+      fromHost &&
       msg.jsonrpc === "2.0" &&
       msg.id === INIT_REQUEST_ID &&
       (msg.result !== undefined || msg.error !== undefined)
@@ -756,7 +765,7 @@ const WIDGET_HTML = `<!doctype html>
       sendInitializedNotification();
       return;
     }
-    if (msg.jsonrpc === "2.0" && msg.method === "ui/notifications/tool-result") {
+    if (fromHost && msg.jsonrpc === "2.0" && msg.method === "ui/notifications/tool-result") {
       var params = msg.params || {};
       // Forward both \`structuredContent\` (LLM-visible payload) and
       // \`_meta\` (metadata-only payload, where \`image_data_url\` lives).

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -1013,10 +1013,15 @@ export async function fetchPngContentBlock(
  * repeat registrations of the same URI so the SDK doesn't throw
  * `Resource ui://... is already registered`.
  *
- * The static URI loads the iframe widget (used by ChatGPT). The
- * dynamic per-pub_id URI bakes the chart image into the resource HTML
- * (used by claude.ai, where the host snapshots `documentElement.
- * offsetHeight` once on widget mount and ignores later updates).
+ * The static URI loads the iframe widget (used by ChatGPT, and by
+ * claude.ai today — see the "Conclusion" comment in `mcp.ts` near the
+ * dynamic ResourceTemplate registration). The dynamic per-pub_id URI
+ * bakes the chart image into the resource HTML instead; it's retained
+ * for a future host that honors per-call `resourceUri` overrides (the
+ * host would snapshot `documentElement.offsetHeight` once on widget
+ * mount, so baking the image in up front avoids a missed resize), but
+ * claude.ai currently ignores per-call overrides and stays on the
+ * static URI + baked `_meta.image_data_url` from `extraMeta`.
  *
  * `resolveUriFromInput` reads the top card's `pub_id` from the tool
  * output (the search input is a query, not a pub_id) and falls back to

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -916,10 +916,10 @@ export async function fetchImageDataUrlAndDims(
 
 /**
  * Fetch the chart PNG and return it as a single MCP `image` content
- * block. Used by both tools' `extraContentBlocks` hook on hosts where
- * the widget bundle is suppressed (claude.ai for custom connectors,
- * which crops the widget iframe to ~200 px tall — strictly worse than
- * an inline image block).
+ * block. Used by both tools' `extraContentBlocks` hook on unknown
+ * clients — the one bucket where the widget bundle is suppressed
+ * entirely (ChatGPT and Claude both get the widget; see
+ * `widgetSuppressed` in mcp.ts).
  *
  * All failure modes (timeout, !ok, wrong content-type, 0-byte body,
  * oversize, network error) return `[]` so the tool call still resolves

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -913,17 +913,38 @@ export async function fetchImageDataUrlAndDims(
   const timeout = setTimeout(() => controller.abort(), PNG_FETCH_TIMEOUT_MS);
   try {
     const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) return undefined;
+    if (!response.ok) {
+      console.warn(
+        `[tako] chart image_data_url fetch failed: HTTP ${response.status} from ${url}`,
+      );
+      return undefined;
+    }
     const contentType = response.headers.get("content-type") ?? "";
     // Reject anything that's not an image — an upstream redirect to an
     // HTML error page would otherwise let us base64 HTML and ship it
     // as a `data:image/...` URI the client can't render.
-    if (!contentType.startsWith("image/")) return undefined;
+    if (!contentType.startsWith("image/")) {
+      console.warn(
+        `[tako] chart image_data_url fetch failed: unexpected content-type "${contentType}" from ${url}`,
+      );
+      return undefined;
+    }
     const buffer = await response.arrayBuffer();
-    if (buffer.byteLength === 0) return undefined;
-    if (buffer.byteLength > MAX_INLINE_DATA_URL_BYTES) return undefined;
+    if (buffer.byteLength === 0) {
+      console.warn(`[tako] chart image_data_url fetch failed: empty body from ${url}`);
+      return undefined;
+    }
+    if (buffer.byteLength > MAX_INLINE_DATA_URL_BYTES) {
+      console.warn(
+        `[tako] chart image_data_url fetch failed: oversize body (${buffer.byteLength} bytes) from ${url}`,
+      );
+      return undefined;
+    }
     const dims = parsePngDimensions(buffer);
-    if (dims === undefined) return undefined;
+    if (dims === undefined) {
+      console.warn(`[tako] chart image_data_url fetch failed: invalid PNG header from ${url}`);
+      return undefined;
+    }
     // `parsePngDimensions` validated the PNG signature (89 50 4E 47…),
     // so the buffer is always `image/png` by here — no need to derive
     // the MIME type from the response header.
@@ -932,7 +953,8 @@ export async function fetchImageDataUrlAndDims(
       naturalWidth: dims.width,
       naturalHeight: dims.height,
     };
-  } catch {
+  } catch (e) {
+    console.warn(`[tako] chart image_data_url fetch failed: ${String(e)} for ${url}`);
     return undefined;
   } finally {
     clearTimeout(timeout);

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -995,6 +995,11 @@ export function buildChartAppUiResource(
     // tool also writes into `embed_url`, so the two move together. No
     // wildcards: the widget only ever embeds Tako's own embed page.
     frameDomains: [webBase],
+    // Remote-image fallback (`<img src=image_url>`) loads from the API
+    // base; the primary data-URI path needs no CSP. webBase covers any
+    // future web-hosted asset. Deduped — staging/prod use one host for
+    // both.
+    resourceDomains: [...new Set([webBase, resolvePublicApiBase(env)])],
     // Dynamic-resource variant — registered as a `ResourceTemplate`,
     // one URI per pub_id. Per-call tool result overrides
     // `_meta.ui.resourceUri` to point claude.ai at a specific

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -197,11 +197,27 @@ function buildBakedWidgetHtml(opts: {
 (function(){
   "use strict";
   function notify(){
+    var h = document.documentElement.offsetHeight;
+    // ChatGPT Apps SDK mechanism.
     try {
       if (window.openai && typeof window.openai.notifyIntrinsicHeight === "function") {
-        var h = document.documentElement.offsetHeight;
         if (h > 0) window.openai.notifyIntrinsicHeight(h);
       }
+    } catch (e) { /* host gone — nothing to do */ }
+    // MCP Apps open-spec mechanism (claude.ai, VS Code Insiders, Goose):
+    // the static widget's notifyHeight sends this same notification —
+    // mirrored here so open-spec hosts get sizing info from the baked
+    // per-pub_id variant too, not just the static iframe/img bundle.
+    // Hosts that don't implement it (ChatGPT) ignore unknown messages.
+    try {
+      window.parent.postMessage({
+        jsonrpc: "2.0",
+        method: "ui/notifications/size-changed",
+        params: {
+          width: (document.documentElement && document.documentElement.clientWidth) || 0,
+          height: h,
+        },
+      }, "*");
     } catch (e) { /* host gone — nothing to do */ }
   }
   notify();

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -371,11 +371,28 @@ const WIDGET_HTML = `<!doctype html>
   // intrinsic height. We notify on load (placeholder height) and again
   // after rendering. No-op on hosts that don't expose the function.
   function notifyHeight(h) {
+    // ChatGPT Apps SDK mechanism.
     try {
       if (window.openai && typeof window.openai.notifyIntrinsicHeight === "function") {
         window.openai.notifyIntrinsicHeight(h);
       }
     } catch (e) { /* ignore */ }
+    // MCP Apps open-spec mechanism (claude.ai, VS Code Insiders, Goose):
+    // JSON-RPC notification over postMessage. Hosts that don't implement
+    // it (ChatGPT) ignore unknown messages — same pattern as the
+    // ui/initialize handshake below. Sent best-effort even before the
+    // handshake completes; render() re-notifies after data arrives, so a
+    // pre-handshake miss self-corrects.
+    try {
+      window.parent.postMessage({
+        jsonrpc: "2.0",
+        method: "ui/notifications/size-changed",
+        params: {
+          width: (document.documentElement && document.documentElement.clientWidth) || 0,
+          height: h,
+        },
+      }, "*");
+    } catch (e) { /* host gone — nothing to do */ }
   }
 
   function render(structuredContent, meta) {

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -164,6 +164,12 @@ export interface AppUiResource {
    */
   frameDomains?: string[];
   /**
+   * Origins the widget may load subresources (images, media) from —
+   * surfaces as `_meta.ui.csp.resourceDomains`. Data URIs are always
+   * allowed; this is only needed for remote `<img src>` fallbacks.
+   */
+  resourceDomains?: string[];
+  /**
    * Optional dynamic-resource variant — registered as a `ResourceTemplate`
    * (one URI per per-call substitution). Used when the widget needs to
    * have call-specific data (chart image, dimensions) baked into the HTML

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -22,11 +22,14 @@ import type { Tier } from "../freetier.js";
 /**
  * Calling-client kind detected from the request's User-Agent. Used by
  * tools and `mcp.ts` to gate behavior that's known to differ across
- * MCP host implementations (e.g., widget suppression on Claude.ai's
- * cropped iframe; the kickoff/wait deep-search flow on ChatGPT, whose
- * Apps SDK doesn't honor `notifications/progress` for timeout
- * extension). Detection is best-effort by UA substring match — when
- * we can't classify, `"unknown"` keeps the default behavior.
+ * MCP host implementations (e.g., routing the MCP Apps chart widget
+ * to ChatGPT and Claude — interactive iframe on ChatGPT, static image
+ * branch on Claude, since claude.ai's host-side CSP ignores declared
+ * `frameDomains` — while unknown clients fall back to an inline PNG;
+ * the kickoff/wait deep-search flow on ChatGPT, whose Apps SDK doesn't
+ * honor `notifications/progress` for timeout extension). Detection is
+ * best-effort by UA substring match — when we can't classify,
+ * `"unknown"` keeps the default (PNG) behavior.
  */
 export type McpClientKind = "claude" | "chatgpt" | "unknown";
 

--- a/workers/test/widget/jsdom.d.ts
+++ b/workers/test/widget/jsdom.d.ts
@@ -1,0 +1,29 @@
+// Minimal local typings for the jsdom API surface the widget DOM tests
+// use, instead of @types/jsdom. The real @types/jsdom CANNOT be installed
+// in this repo: vitest's `optional-types.d.ts` does an optional
+// `import "jsdom"` that resolves the moment the package exists in
+// node_modules, dragging `/// <reference lib="dom" />` into EVERY tsc
+// program that touches vitest types — and lib.dom's CacheStorage /
+// BufferSource globals conflict with @cloudflare/workers-types, breaking
+// the root and test typecheck passes on files as far away as
+// src/oauth/*. Scoped here (only test/widget/tsconfig.json includes it)
+// so the other projects never see it.
+declare module "jsdom" {
+  interface JsdomOptions {
+    url?: string;
+    runScripts?: "dangerously" | "outside-only";
+    pretendToBeVisual?: boolean;
+    virtualConsole?: VirtualConsole;
+  }
+
+  type DOMWindow = Window & typeof globalThis & { close(): void };
+
+  class JSDOM {
+    constructor(html?: string, options?: JsdomOptions);
+    readonly window: DOMWindow;
+  }
+
+  class VirtualConsole {
+    on(event: string, callback: (...args: unknown[]) => void): this;
+  }
+}

--- a/workers/test/widget/tsconfig.json
+++ b/workers/test/widget/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  // Fourth typecheck project (root, tsconfig.test.json, scripts, this).
+  // The widget DOM tests run under jsdom in plain Node
+  // (vitest.widget.config.ts), so they typecheck against the DOM lib —
+  // which cannot coexist with @cloudflare/workers-types in one program
+  // (CacheStorage/BufferSource global conflicts). Hence the root
+  // tsconfig excludes this directory and this project owns it. jsdom's
+  // types come from the local ./jsdom.d.ts shim — see its header for
+  // why @types/jsdom must NOT be installed in this repo.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2022", "dom", "dom.iterable"],
+    "types": []
+  },
+  "include": ["./**/*.test.ts", "./jsdom.d.ts"],
+  "exclude": []
+}

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -1,0 +1,284 @@
+import { JSDOM, VirtualConsole } from "jsdom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { Env } from "../../src/env.js";
+import {
+  __chart_widget_test_only__,
+  buildChartAppUiResourceFromOutputPubId,
+} from "../../src/tools/_chart_widget.js";
+
+// Executable coverage for the widget bundle. The main suite's string
+// assertions confirm the template CONTAINS the right code; these tests
+// actually RUN it under jsdom and drive the postMessage wire protocol —
+// the thing claude.ai depends on and the thing a broken bundle would
+// silently take down (Claude Desktop caches widget URIs beyond connector
+// lifecycle, so a shipped-broken bundle is expensive to walk back).
+//
+// Frame topology mirrors a nesting host:
+//
+//   outer (window.top)
+//   └── wrapper (window.parent of the widget)
+//       ├── widget    ← WIDGET_HTML runs here
+//       └── sibling   ← stand-in for a co-installed hostile connector
+//
+// Host messages are delivered as synthetic MessageEvents with an explicit
+// `source` (jsdom's real postMessage doesn't populate `event.source`), so
+// each test controls exactly which browsing context "sent" the message.
+// Outbound traffic is captured by stubbing `wrapper.postMessage` — the
+// widget only ever posts to `window.parent`.
+
+const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
+
+const EMBED_URL = "https://staging.trytako.com/embed/abc123/?dark_mode=auto";
+const IMAGE_URL =
+  "https://staging.trytako.com/api/v1/image/abc123/?dark_mode=true";
+const DATA_URL = "data:image/png;base64,AAAA";
+
+interface Mounted {
+  dom: JSDOM;
+  outerWin: Window & typeof globalThis;
+  wrapperWin: Window;
+  widgetWin: Window;
+  siblingWin: Window;
+  /** Messages the widget posted to window.parent, in order. */
+  toParent: unknown[];
+  warnings: string[];
+}
+
+const mounted: JSDOM[] = [];
+
+function mountWidget(html: string): Mounted {
+  const virtualConsole = new VirtualConsole();
+  const warnings: string[] = [];
+  virtualConsole.on("warn", (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  });
+  // Swallow the rest — the widget logs routinely via console.log.
+  virtualConsole.on("log", () => {});
+  virtualConsole.on("error", () => {});
+  virtualConsole.on("jsdomError", () => {});
+
+  const dom = new JSDOM(
+    '<!doctype html><html><body><iframe id="wrapper"></iframe></body></html>',
+    {
+      url: "https://host.example/",
+      runScripts: "dangerously",
+      pretendToBeVisual: true,
+      virtualConsole,
+    },
+  );
+  mounted.push(dom);
+  const outerWin = dom.window as unknown as Window & typeof globalThis;
+  const wrapperFrame = outerWin.document.getElementById(
+    "wrapper",
+  ) as HTMLIFrameElement;
+  const wrapperWin = wrapperFrame.contentWindow!;
+  const wrapperDoc = wrapperFrame.contentDocument!;
+  const widgetFrame = wrapperDoc.createElement("iframe");
+  const siblingFrame = wrapperDoc.createElement("iframe");
+  wrapperDoc.body.appendChild(widgetFrame);
+  wrapperDoc.body.appendChild(siblingFrame);
+
+  const toParent: unknown[] = [];
+  // Capture outbound host traffic. Assignment, not spyOn: the widget
+  // grabs `window.parent` lazily on each call, so patching the wrapper
+  // window's own method is sufficient and survives document.write.
+  (wrapperWin as unknown as { postMessage: (msg: unknown) => void }).postMessage =
+    (msg: unknown) => {
+      toParent.push(msg);
+    };
+
+  const widgetDoc = widgetFrame.contentDocument!;
+  widgetDoc.open();
+  widgetDoc.write(html);
+  widgetDoc.close();
+
+  return {
+    dom,
+    outerWin,
+    wrapperWin,
+    widgetWin: widgetFrame.contentWindow!,
+    siblingWin: siblingFrame.contentWindow!,
+    toParent,
+    warnings,
+  };
+}
+
+/** Deliver a message to the widget as if `source` had postMessage'd it. */
+function deliver(m: Mounted, data: unknown, source: Window): void {
+  const WidgetMessageEvent = (
+    m.widgetWin as unknown as { MessageEvent: typeof MessageEvent }
+  ).MessageEvent;
+  m.widgetWin.dispatchEvent(
+    new WidgetMessageEvent("message", {
+      data,
+      source: source as unknown as MessageEventSource,
+    }),
+  );
+}
+
+function toolResult(structuredContent: unknown, _meta?: unknown): unknown {
+  return {
+    jsonrpc: "2.0",
+    method: "ui/notifications/tool-result",
+    params: { structuredContent, _meta },
+  };
+}
+
+function methodsSent(m: Mounted): string[] {
+  return m.toParent
+    .map((msg) => (msg as { method?: string }).method)
+    .filter((x): x is string => typeof x === "string");
+}
+
+function widgetImg(m: Mounted): HTMLImageElement {
+  return m.widgetWin.document.getElementById(
+    "tako-embed-img",
+  ) as HTMLImageElement;
+}
+
+function widgetLink(m: Mounted): HTMLAnchorElement {
+  return m.widgetWin.document.getElementById(
+    "tako-embed-link",
+  ) as HTMLAnchorElement;
+}
+
+function staticWidgetHtml(): string {
+  return buildChartAppUiResourceFromOutputPubId(ENV).html;
+}
+
+afterEach(() => {
+  // Close every mounted JSDOM so the widget's 250 ms `window.openai`
+  // polling interval (10 s worth of ticks) doesn't outlive the test.
+  for (const dom of mounted.splice(0)) {
+    dom.window.close();
+  }
+});
+
+describe("static widget bundle (executed)", () => {
+  it("kicks off the MCP Apps handshake and completes it on a parent response", () => {
+    const m = mountWidget(staticWidgetHtml());
+    // Script ran: ui/initialize went to the parent, plus the initial
+    // 1-px size notification.
+    expect(methodsSent(m)).toContain("ui/initialize");
+    expect(methodsSent(m)).toContain("ui/notifications/size-changed");
+    expect(methodsSent(m)).not.toContain("ui/notifications/initialized");
+    // Host responds to ui/initialize → widget must send `initialized`
+    // (the spec gates all tool-result delivery on it).
+    deliver(
+      m,
+      { jsonrpc: "2.0", id: "tako-ui-init", result: { hostInfo: {} } },
+      m.wrapperWin,
+    );
+    expect(methodsSent(m)).toContain("ui/notifications/initialized");
+  });
+
+  it("renders the chart image from a parent-delivered tool-result", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL },
+        {
+          image_data_url: DATA_URL,
+          image_natural_width: 800,
+          image_natural_height: 600,
+        },
+      ),
+      m.wrapperWin,
+    );
+    // Data URI preferred over the cross-origin image_url (claude.ai's
+    // outer CSP blocks the latter), click-through wired to the embed.
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+    expect(widgetLink(m).getAttribute("href")).toBe(EMBED_URL);
+  });
+
+  it("accepts a tool-result delivered from window.top (nested-wrapper hosts)", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, toolResult({ embed_url: EMBED_URL }, { image_data_url: DATA_URL }), m.outerWin);
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+  });
+
+  it("drops a forged tool-result from a sibling frame — and warns about it", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult(
+        { embed_url: "https://evil.example/phish" },
+        { image_data_url: DATA_URL },
+      ),
+      m.siblingWin,
+    );
+    // No render: a sibling connector must not be able to inject a chart
+    // or a click-through URL.
+    expect(widgetImg(m).getAttribute("src")).toBeNull();
+    expect(widgetLink(m).getAttribute("href")).toBeNull();
+    // ...but the drop is observable, not silent — this gate guards
+    // Claude's only chart data path.
+    expect(
+      m.warnings.some((w) => w.includes("dropped JSON-RPC message")),
+    ).toBe(true);
+  });
+
+  it("ignores a forged handshake response from a sibling frame", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      { jsonrpc: "2.0", id: "tako-ui-init", result: {} },
+      m.siblingWin,
+    );
+    expect(methodsSent(m)).not.toContain("ui/notifications/initialized");
+  });
+
+  it("refuses a javascript: embed_url as the click-through", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult(
+        // eslint-disable-next-line no-script-url
+        { embed_url: "javascript:alert(1)", image_url: IMAGE_URL },
+        { image_data_url: DATA_URL },
+      ),
+      m.wrapperWin,
+    );
+    // Image still renders (the data URI is independently validated) but
+    // the hostile scheme never lands in href.
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+    expect(widgetLink(m).getAttribute("href")).toBeNull();
+  });
+
+  it("collapses to zero height on a no-chart payload", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, toolResult({ request_id: "req-1" }), m.wrapperWin);
+    expect(
+      m.widgetWin.document.documentElement.style.height,
+    ).toBe("0px");
+    // Hosts honoring shrink notifications collapse the box fully.
+    const sizeChanges = m.toParent.filter(
+      (msg) =>
+        (msg as { method?: string }).method ===
+        "ui/notifications/size-changed",
+    ) as Array<{ params: { height: number } }>;
+    expect(sizeChanges.at(-1)?.params.height).toBe(0);
+  });
+});
+
+describe("baked widget variant (executed)", () => {
+  it("notifies size-changed to the parent on execution", () => {
+    const html = __chart_widget_test_only__.buildBakedWidgetHtml({
+      embedUrl: EMBED_URL,
+      imageDataUrl: DATA_URL,
+      naturalWidth: 800,
+      naturalHeight: 600,
+    });
+    const m = mountWidget(html);
+    expect(methodsSent(m)).toContain("ui/notifications/size-changed");
+    // The image and click-through are baked server-side.
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+    expect(
+      m.widgetWin.document
+        .getElementById("tako-embed-link")!
+        .getAttribute("href"),
+    ).toBe(EMBED_URL);
+  });
+});

--- a/workers/tsconfig.json
+++ b/workers/tsconfig.json
@@ -19,5 +19,8 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"],
-  "exclude": ["node_modules", "dist", ".wrangler"]
+  // test/widget is its own project (test/widget/tsconfig.json): those
+  // tests typecheck against lib.dom, whose CacheStorage/BufferSource
+  // globals conflict with @cloudflare/workers-types everywhere else.
+  "exclude": ["node_modules", "dist", ".wrangler", "test/widget"]
 }

--- a/workers/tsconfig.test.json
+++ b/workers/tsconfig.test.json
@@ -5,6 +5,9 @@
   // `freetier.test.ts` depends on would otherwise be outside this program.
   // The root `tsconfig.json` picks it up via `src/**/*.ts`, which is why
   // a bare `tsc --noEmit` passes while this project fails.
+  // test/widget/**/*.test.ts is deliberately NOT here — it lives in its
+  // own project (test/widget/tsconfig.json) because its jsdom types
+  // conflict with @cloudflare/workers-types (see root tsconfig exclude).
   "include": ["src/**/*.test.ts", "src/raw-imports.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/workers/vitest.config.ts
+++ b/workers/vitest.config.ts
@@ -29,6 +29,12 @@ export default defineWorkersConfig({
     ],
   },
   test: {
+    // Scope to src/ explicitly: the widget DOM tests under test/widget/
+    // run in a separate node-environment project (vitest.widget.config.ts)
+    // because jsdom can't load inside the workers-pool runtime. Without
+    // this include, vitest's default glob would pull them into this pool
+    // and they'd fail on `require("jsdom")`.
+    include: ["src/**/*.test.ts"],
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },

--- a/workers/vitest.widget.config.ts
+++ b/workers/vitest.widget.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+// Second vitest project for the widget DOM tests (test/widget/). The main
+// suite runs inside @cloudflare/vitest-pool-workers, whose workerd runtime
+// cannot load jsdom (Node APIs) — and the widget HTML can't execute inside
+// workerd anyway. These tests run in plain Node and drive the widget
+// script through jsdom instead, so the template-literal bundle that ships
+// to claude.ai / ChatGPT actually EXECUTES in CI rather than being
+// string-matched. Wired into `npm test` after the main suite.
+export default defineConfig({
+  test: {
+    include: ["test/widget/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## TL;DR
Charts now render inline in the claude.ai / Claude Desktop chat body via the existing MCP Apps widget. Previously Claude clients got a PNG image content block, which claude.ai renders collapsed inside the tool-call expander (anthropics/claude-code#53256) — users saw no charts.

## What changed
- Widget gate admits `claude` clients (widget-only; the existing `ui === undefined` mutual exclusion drops the PNG block automatically). Unknown clients keep the PNG block; ChatGPT keeps its interactive iframe widget, unchanged.
- **Client bucketing is evidence-based, not substring-broad**: `claude-code/…` UAs (Claude Code's HTTP MCP client and the Agent SDK it powers — verified empirically: `claude-code/2.1.220 (sdk-cli)`) are carved out to the `unknown` bucket and keep the portable inline PNG. The widget bucket matches the claude.ai / Claude Desktop custom-connector traffic, which is server-to-server from Anthropic's backend (`160.79.104.0/21`) as `Claude-User`. Direct `detectMcpClient` unit tests pin the observed UAs.
- Widget emits the open-spec `ui/notifications/size-changed` (claude.ai's height mechanism; `notifyIntrinsicHeight` covers ChatGPT only) — the missing piece behind the 2026-05 clipping that led to suppressing the widget. Applied to both the static and baked widget variants; the baked variant also re-notifies on `img` load.
- Widget CSP declares `resourceDomains` so the remote-`image_url` fallback `<img>` loads when a chart exceeds the inline `image_data_url` cap. The cap itself is raised 250 KB → 400 KB raw: Tako charts run 50–300 KB, and the 250–300 KB band otherwise degrades to a text link on claude.ai (whose outer CSP blocks the cross-origin `image_url`). The ~400 KB-encoded failure that motivated the old cap was observed on ChatGPT, whose `extraMeta` hook is skipped entirely now, so the field never ships there.
- Security: the widget's inbound `ui/notifications/tool-result` / init-handshake postMessage handler is source-gated to `window.parent` **or `window.top`** (nested-wrapper hosts) so a co-installed sibling connector can't inject a spoofed chart image or click-through URL — a sibling's `event.source` is never parent or top. Rejected JSON-RPC messages `console.warn` instead of failing silently, since this gate guards Claude's only chart data path.
- **The widget bundle now executes in CI.** A second vitest project (`test/widget/`, plain Node + jsdom) mounts the bundle in a nested-iframe topology and drives the postMessage protocol: handshake completion, parent/top tool-result rendering, sibling-forgery rejection, `javascript:` scheme guard, no-chart collapse, and the baked variant's size-changed. (jsdom types are a local shim — `@types/jsdom` cannot be installed in this repo; vitest's `optional-types.d.ts` resolves it on sight and drags `lib.dom` into every tsc program, colliding with `@cloudflare/workers-types`. `npm run typecheck` is now four passes.)
- Observability: `console.warn` on `image_data_url` fetch failure (now Claude's primary chart path).
- Docs: swept stale "ChatGPT-only widget" comments; reconciled dynamic-URI docstrings; claude `tools/list` widget `_meta` pinned e2e (claude.ai loads the widget URI from registration metadata, so that's the load-bearing wire surface).

## Not changed
- ChatGPT tool results: byte-identical **except one additive change**: `_meta.ui.csp` now also carries `resourceDomains` (client-agnostic construction; ChatGPT's iframe branch never reads it). This is now pinned by an explicit test so a regression or a strict-validating Apps SDK build has a signal; the ChatGPT staging spot-check remains the behavioral gate. Everything else is pinned byte-identical (widget `_meta`, zero image blocks, zero PNG prefetch).
- Unknown clients (Cursor, Windsurf, …) **and now Claude Code / Agent SDK**: byte-identical to pre-PR (PNG block, no widget).
- Fetch count on Claude: still exactly 2 per chart call (PNG now fetched by `extraMeta` for the widget instead of `extraContentBlocks`) — enforced by tests that throw on any extra fetch.

## Known trade-offs (accepted)
- **Model visibility**: the PNG content block was model-visible; `_meta.image_data_url` is not. On Claude clients the model can no longer see the chart image while composing its answer — it works from the structured content (values, embed/image URLs) instead. Accepted: the user-visible chart is the point of this PR.
- **Messages API `mcp_servers` connector**: also egresses from Anthropic's backend; its UA is not publicly pinned. If it presents as `Claude-User` it is indistinguishable from claude.ai here and would get widget `_meta` it can't render. No UA-level fix available; revisit if log evidence shows it.

## Test plan
- [x] `npm test` — 456 workers-pool tests across 25 files + 8 executed-widget DOM tests; chart-gate matrix: claude → widget `_meta` + `_meta.image_data_url`, no image block, graceful degradation when the PNG fetch fails; `claude-code` → PNG path; chatgpt/unknown cases unmodified
- [x] `npm run typecheck` (four passes)
- [x] Local UA capture: `claude mcp add` against a header-logging server confirms Claude Code sends `claude-code/2.1.220 (sdk-cli)`
- [ ] Staging (auto-deploys on merge, or `npm run deploy:staging`): add `https://mcp.staging.tako.com/mcp` as a custom connector on **both claude.ai and Claude Desktop** (Desktop caches widget URIs beyond connector lifecycle — verify before the URI is burned in), run a chart query — chart renders inline in the chat body, height fits, no clipping; confirm a zero-result query collapses (no empty box)
- [ ] **Blocking** staging check: a large (>250 KB) chart renders on claude.ai — this is the empirical gate on the 400 KB cap and on whether claude.ai honors `csp.resourceDomains`
- [ ] ChatGPT spot-check on staging — widget still renders (gates the additive `resourceDomains` key)

Rollback: revert the gate commit (`bce1238`) alone — the widget/CSP/security commits are inert without it.
