### PR TITLE
fix: align ChatGPT tool annotations for app review

### DIFF
--- a/.github/workflows/workers-ci.yml
+++ b/.github/workflows/workers-ci.yml
@@ -1,15 +1,23 @@
 name: workers-ci
 
 on:
+  # The two root files are guarded by `registry:check` (see
+  # `gen-registry.ts`: `assertChatgptSubmissionParity`,
+  # `assertLlmsFullCoverage`) — they must trigger this workflow or a PR
+  # editing only a guarded file skips the very guard that protects it.
   push:
     branches: [main]
     paths:
       - 'workers/**'
       - 'registry/**'
+      - 'chatgpt-app-submission.json'
+      - 'llms-full.txt'
   pull_request:
     paths:
       - 'workers/**'
       - 'registry/**'
+      - 'chatgpt-app-submission.json'
+      - 'llms-full.txt'
   workflow_dispatch:
 
 concurrency:

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -87,8 +87,8 @@
       "expected_output_url": null
     },
     {
-      "description": "Retrieve the underlying text from a supplied web result URL.",
-      "user_prompt": "Use Tako to fetch the page text behind https://www.bls.gov/cpi/.",
+      "description": "Retrieve the underlying page text behind a web result URL as a post-search follow-up.",
+      "user_prompt": "I got this web result URL from a Tako search earlier: https://www.bls.gov/cpi/. Use Tako to fetch the full page text behind it.",
       "file_attachment_urls": null,
       "tools_triggered": "tako_contents",
       "expected_output": "Returns readable page text from the supplied URL with enough context to use in a follow-up answer.",

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "schema_version": 1,
+  "app_info": {
+    "display_name": "Tako",
+    "subtitle": "Search live data and charts",
+    "description": "Tako helps users find current data and metrics from proprietary datasets and the live web, get citation-backed answers, retrieve underlying result content, check available data coverage, and create charts from structured data.",
+    "category": "PRODUCTIVITY"
+  },
+  "tools": {
+    "tako_search": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Searches Tako's data index and the live web and returns matching cards and links without modifying records or external state.",
+        "open_world_justification": "Does not publish content or change publicly visible or third-party state.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "tako_answer": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves source material and returns a synthesized, citation-backed answer without changing stored or external data.",
+        "open_world_justification": "Does not publish the answer or modify publicly visible or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "tako_contents": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Retrieves CSV data or page text from a supplied result URL without modifying the source.",
+        "open_world_justification": "Does not publish content or change the supplied website or any third-party system.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "tako_available_data": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Looks up Tako's structured-data coverage for an entity or metric and returns matching names without changing data.",
+        "open_world_justification": "Does not publish content or modify publicly visible or third-party state.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "tako_visualize": {
+      "annotations": {
+        "readOnlyHint": false,
+        "openWorldHint": true,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Creates a persistent Tako chart card from structured data supplied by the user.",
+        "open_world_justification": "Creates a chart card with publicly accessible webpage and embed URLs.",
+        "destructive_justification": "Creates a new card but does not delete, overwrite, revoke access, or perform irreversible transactions."
+      }
+    }
+  },
+  "test_cases": [
+    {
+      "description": "Retrieve a current metric as structured data with a chart.",
+      "user_prompt": "Show me the latest US consumer price index and its recent trend as a chart.",
+      "file_attachment_urls": null,
+      "tools_triggered": "tako_search",
+      "expected_output": "Returns a relevant CPI data card with recent values, source attribution, and an inline chart when available.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Answer a specific data question with supporting citations.",
+      "user_prompt": "What was US real GDP growth in 2025? Give me a concise answer with citations.",
+      "file_attachment_urls": null,
+      "tools_triggered": "tako_answer",
+      "expected_output": "Returns one concise, citation-backed answer grounded in relevant data or web sources.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Retrieve the underlying text from a supplied web result URL.",
+      "user_prompt": "Use Tako to fetch the page text behind https://www.bls.gov/cpi/.",
+      "file_attachment_urls": null,
+      "tools_triggered": "tako_contents",
+      "expected_output": "Returns readable page text from the supplied URL with enough context to use in a follow-up answer.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Check which structured metrics are available before running a priced search.",
+      "user_prompt": "What proprietary structured data does Tako have for Tesla?",
+      "file_attachment_urls": null,
+      "tools_triggered": "tako_available_data",
+      "expected_output": "Returns whether coverage exists, matching entities, and the exact available metric names for a follow-up search.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Create a chart from data supplied directly by the user.",
+      "user_prompt": "Create a bar chart titled Regional Sales using North America: 500, Europe: 300, and Asia: 450, with units of USD millions.",
+      "file_attachment_urls": null,
+      "tools_triggered": "tako_visualize",
+      "expected_output": "Creates and displays a regional sales bar chart and provides a link to open the resulting Tako card.",
+      "expected_output_url": null
+    }
+  ],
+  "negative_test_cases": [
+    {
+      "description": "Do not trigger for unrelated creative-writing requests.",
+      "user_prompt": "Write a short bedtime story about a friendly lighthouse.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because the request does not involve data discovery, data retrieval, or visualization.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for calendar-management requests.",
+      "user_prompt": "Schedule a meeting with my design team tomorrow at 10 AM.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because it cannot access or modify calendars.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for sending messages through another service.",
+      "user_prompt": "Email this market summary to my team.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because it cannot send email or messages.",
+      "expected_output_url": null
+    }
+  ]
+}

--- a/chatgpt-app-submission.json
+++ b/chatgpt-app-submission.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "$schema": "https://developers.openai.com/plugins/schemas/chatgpt-app-submission.v1.json",
   "schema_version": 1,
   "app_info": {
     "display_name": "Tako",

--- a/registry/server.json
+++ b/registry/server.json
@@ -72,7 +72,7 @@
       },
       "annotations": {
         "title": "Tako: Answer Agent",
-        "readOnlyHint": true,
+        "readOnlyHint": false,
         "destructiveHint": false,
         "openWorldHint": true
       }
@@ -101,7 +101,7 @@
       },
       "annotations": {
         "title": "Tako: Start Agent Run",
-        "readOnlyHint": true,
+        "readOnlyHint": false,
         "destructiveHint": false,
         "openWorldHint": true
       }

--- a/workers/scripts/gen-registry.test.ts
+++ b/workers/scripts/gen-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { TOOL_REGISTRY } from "../src/tools/_registry.js";
 import {
   assertAllToolsDescribed,
+  assertChatgptSubmissionParity,
   assertLlmsFullCoverage,
   MCP_TOOL_ALLOWLIST,
 } from "./gen-registry.js";
@@ -58,4 +59,89 @@ describe("assertLlmsFullCoverage", () => {
       assertLlmsFullCoverage([tool("tako_agent_start", "query")], doc),
     ).toThrow(/tako_agent_start.*never mentioned/);
   });
+});
+
+describe("assertChatgptSubmissionParity", () => {
+  // Fixture tool on ChatGPT's default authenticated surface: not optional,
+  // not chatgpt-only/excluded, not a free-tier name — so the only gates it
+  // exercises are the ones under test here.
+  const tool = (
+    name: string,
+    overrides?: { chatgpt?: { openWorldHint?: boolean; readOnlyHint?: boolean } },
+  ) => ({
+    name,
+    annotations: {
+      title: name,
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: true,
+    },
+    ...(overrides !== undefined ? { annotationsByClient: overrides } : {}),
+  });
+  const submission = (
+    tools: Record<string, { annotations?: Record<string, unknown> }>,
+  ) => JSON.stringify({ tools });
+
+  it("passes when the declared tools and hints match the runtime descriptors", () => {
+    const t = tool("tako_x", { chatgpt: { openWorldHint: false } });
+    const declared = submission({
+      tako_x: {
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          openWorldHint: false,
+        },
+      },
+    });
+    expect(() => assertChatgptSubmissionParity([t], declared)).not.toThrow();
+  });
+
+  it("throws when the top-level tools object is missing", () => {
+    expect(() => assertChatgptSubmissionParity([tool("tako_x")], "{}")).toThrow(
+      /missing top-level "tools"/,
+    );
+  });
+
+  it("fails on a surface tool the submission does not declare", () => {
+    expect(() =>
+      assertChatgptSubmissionParity([tool("tako_x")], submission({})),
+    ).toThrow(/missing tool "tako_x"/);
+  });
+
+  it("fails on a declared tool that is not on ChatGPT's default surface", () => {
+    expect(() =>
+      assertChatgptSubmissionParity(
+        [],
+        submission({ tako_ghost: { annotations: {} } }),
+      ),
+    ).toThrow(/extra tool "tako_ghost"/);
+  });
+
+  it("fails on a hint mismatch with a per-tool, per-hint message", () => {
+    const t = tool("tako_x", { chatgpt: { openWorldHint: false } });
+    const declared = submission({
+      tako_x: {
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          openWorldHint: true, // runtime serves false for chatgpt
+        },
+      },
+    });
+    expect(() => assertChatgptSubmissionParity([t], declared)).toThrow(
+      /tool "tako_x" openWorldHint: submission declares true, runtime serves false/,
+    );
+  });
+
+  it("fails when a free-tier surface tool is missing from the submission", () => {
+    // `tako_search` is in FREE_TIER_TOOL_NAMES: anonymous connections must
+    // never see a tool the submission does not declare.
+    expect(() =>
+      assertChatgptSubmissionParity([tool("tako_search")], submission({})),
+    ).toThrow(/anonymous free-tier ChatGPT surface but not declared/);
+  });
+
+  // NOTE: parity against the REAL registry + committed submission file is
+  // asserted by `npm run registry:check` (CI), not here — this suite runs
+  // in the Workers pool, which has no filesystem.
 });

--- a/workers/scripts/gen-registry.ts
+++ b/workers/scripts/gen-registry.ts
@@ -22,6 +22,10 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { z } from "zod";
 
+import {
+  isToolOnSurface,
+  toolAnnotationsForClient,
+} from "../src/tools/_surface.js";
 import type { ToolAnnotations, ToolModule } from "../src/tools/types.js";
 
 // ---------------------------------------------------------------------------
@@ -116,6 +120,80 @@ export function assertLlmsFullCoverage(
   }
 }
 
+/**
+ * Assert that `chatgpt-app-submission.json` matches the runtime ChatGPT
+ * descriptors. The submission file is hand-maintained (its justifications
+ * and test cases cannot be generated), so this validates instead of
+ * emitting: the declared tool set must equal ChatGPT's default tool
+ * surface, and each tool's annotation hints must equal what
+ * `toolAnnotationsForClient(tool, "chatgpt")` actually serves. Without
+ * this, an edit to a tool's annotations (canonical or `annotationsByClient`)
+ * would leave the submitted app metadata claiming something production no
+ * longer serves.
+ */
+export function assertChatgptSubmissionParity(
+  tools: ReadonlyArray<
+    Pick<ToolModule, "name" | "annotations" | "annotationsByClient">
+  >,
+  submissionJson: string,
+): void {
+  const submission = JSON.parse(submissionJson) as {
+    tools?: Record<string, { annotations?: Record<string, unknown> }>;
+  };
+  if (submission.tools === undefined || typeof submission.tools !== "object") {
+    throw new Error(
+      'chatgpt-app-submission.json: missing top-level "tools" object',
+    );
+  }
+  const declaredTools = submission.tools;
+
+  // The submission covers the DEFAULT production MCP URL: no `?tools=`
+  // opt-ins, client detected as chatgpt.
+  const noOptIns: ReadonlySet<string> = new Set();
+  const expected = new Map(
+    tools
+      .filter((t) => isToolOnSurface(t.name, "chatgpt", noOptIns))
+      .map((t) => [t.name, toolAnnotationsForClient(t, "chatgpt")]),
+  );
+
+  const problems: string[] = [];
+  const declaredNames = new Set(Object.keys(declaredTools));
+  for (const name of expected.keys()) {
+    if (!declaredNames.has(name)) {
+      problems.push(`missing tool "${name}" (on ChatGPT's default surface)`);
+    }
+  }
+  for (const name of declaredNames) {
+    if (!expected.has(name)) {
+      problems.push(`extra tool "${name}" (not on ChatGPT's default surface)`);
+    }
+  }
+
+  const HINT_KEYS = ["readOnlyHint", "openWorldHint", "destructiveHint"] as const;
+  for (const [name, resolved] of expected) {
+    const declared = declaredTools[name];
+    if (declared === undefined) continue;
+    const annotations = declared.annotations ?? {};
+    for (const hint of HINT_KEYS) {
+      if (annotations[hint] !== resolved[hint]) {
+        problems.push(
+          `tool "${name}" ${hint}: submission declares ${JSON.stringify(
+            annotations[hint],
+          )}, runtime serves ${JSON.stringify(resolved[hint])}`,
+        );
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `chatgpt-app-submission.json drift — submitted app metadata out of sync with runtime ChatGPT descriptors:\n  ${problems.join(
+        "\n  ",
+      )}\nUpdate chatgpt-app-submission.json so each tool's annotations equal toolAnnotationsForClient(tool, "chatgpt") for the default ChatGPT surface.`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
@@ -128,6 +206,7 @@ const METADATA_PATH = resolve(REPO_ROOT, "registry", "metadata.json");
 const REGISTRY_PATH = resolve(REPO_ROOT, "registry", "server.json");
 const BARREL_PATH = resolve(TOOLS_DIR, "_registry.ts");
 const LLMS_FULL_PATH = resolve(REPO_ROOT, "llms-full.txt");
+const SUBMISSION_PATH = resolve(REPO_ROOT, "chatgpt-app-submission.json");
 
 // Filename conventions for the tools/ directory. A tool module is any `.ts`
 // file that does NOT match one of the following:
@@ -407,6 +486,14 @@ async function main(): Promise<void> {
   // 3. llms-full.txt coverage: the hand-written doc must mention every tool,
   //    and any tool with a `### <name>` section must document all its params.
   assertLlmsFullCoverage(registryTools, readFileSync(LLMS_FULL_PATH, "utf8"));
+
+  // 4. ChatGPT app-submission parity: the hand-maintained submission
+  //    metadata must describe exactly the tools (and annotation hints)
+  //    ChatGPT receives from the default production MCP URL.
+  assertChatgptSubmissionParity(
+    modules.map((m) => m.tool),
+    readFileSync(SUBMISSION_PATH, "utf8"),
+  );
 
   const registry = buildRegistry(metadata, registryTools);
   const registryJson = serializeJson(registry);

--- a/workers/scripts/gen-registry.ts
+++ b/workers/scripts/gen-registry.ts
@@ -124,12 +124,18 @@ export function assertLlmsFullCoverage(
  * Assert that `chatgpt-app-submission.json` matches the runtime ChatGPT
  * descriptors. The submission file is hand-maintained (its justifications
  * and test cases cannot be generated), so this validates instead of
- * emitting: the declared tool set must equal ChatGPT's default tool
- * surface, and each tool's annotation hints must equal what
- * `toolAnnotationsForClient(tool, "chatgpt")` actually serves. Without
- * this, an edit to a tool's annotations (canonical or `annotationsByClient`)
- * would leave the submitted app metadata claiming something production no
- * longer serves.
+ * emitting: the declared tool set must equal ChatGPT's default
+ * AUTHENTICATED tool surface, and each tool's annotation hints must equal
+ * what `toolAnnotationsForClient(tool, "chatgpt")` actually serves.
+ * Without this, an edit to a tool's annotations (canonical or
+ * `annotationsByClient`) would leave the submitted app metadata claiming
+ * something production no longer serves.
+ *
+ * The anonymous free-tier surface is asserted separately (and more
+ * weakly): it must be a SUBSET of the declared tools. The reverse gap is
+ * expected — `tako_contents` and `tako_visualize` are absent for
+ * anonymous connections — which is why the submission's test cases
+ * assume an OAuth-linked connection.
  */
 export function assertChatgptSubmissionParity(
   tools: ReadonlyArray<
@@ -147,12 +153,13 @@ export function assertChatgptSubmissionParity(
   }
   const declaredTools = submission.tools;
 
-  // The submission covers the DEFAULT production MCP URL: no `?tools=`
-  // opt-ins, client detected as chatgpt.
+  // The submission covers the DEFAULT production MCP URL over an
+  // AUTHENTICATED (OAuth-linked) connection: no `?tools=` opt-ins, client
+  // detected as chatgpt, tier "authenticated".
   const noOptIns: ReadonlySet<string> = new Set();
   const expected = new Map(
     tools
-      .filter((t) => isToolOnSurface(t.name, "chatgpt", noOptIns))
+      .filter((t) => isToolOnSurface(t.name, "chatgpt", noOptIns, "authenticated"))
       .map((t) => [t.name, toolAnnotationsForClient(t, "chatgpt")]),
   );
 
@@ -166,6 +173,20 @@ export function assertChatgptSubmissionParity(
   for (const name of declaredNames) {
     if (!expected.has(name)) {
       problems.push(`extra tool "${name}" (not on ChatGPT's default surface)`);
+    }
+  }
+
+  // Anonymous connections must never serve a tool the submission does not
+  // declare — a free-tier surface that outgrew the submission would show
+  // OpenAI review tooling an undeclared tool.
+  for (const t of tools) {
+    if (
+      isToolOnSurface(t.name, "chatgpt", noOptIns, "free") &&
+      !declaredNames.has(t.name)
+    ) {
+      problems.push(
+        `tool "${t.name}" is on the anonymous free-tier ChatGPT surface but not declared in the submission`,
+      );
     }
   }
 

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -245,9 +245,13 @@ describe("worker routing", () => {
       expect(t._meta?.["com.tako/securitySchemes"]).toEqual([
         { type: "oauth2", scopes: ["mcp"] },
       ]);
-      // Non-ChatGPT clients retain the canonical MCP meaning, where live
-      // search/data lookup is an open-world interaction.
-      expect(t.annotations.openWorldHint).toBe(true);
+      // No User-Agent → client `unknown`, which resolves the ChatGPT
+      // override family (see `annotationClientFamily` in
+      // tools/_surface.ts): retrieval is closed-world under the Apps
+      // reading, so an OpenAI reviewer with an unrecognized UA never sees
+      // labels contradicting chatgpt-app-submission.json. Only `claude`
+      // retains the canonical MCP open-world meaning.
+      expect(t.annotations.openWorldHint).toBe(false);
     }
 
     // MCP Apps: this request carries no User-Agent, so `detectMcpClient`
@@ -312,6 +316,45 @@ describe("worker routing", () => {
       "ui/resourceUri": "ui://tako/embed/chart",
       "openai/outputTemplate": "ui://tako/embed/chart",
     });
+  });
+
+  it("POST /mcp tools/list serves canonical MCP annotations to claude UAs", async () => {
+    // `claude` is the one client family that keeps the canonical MCP
+    // hint readings — every other family, unknown included, resolves the
+    // ChatGPT override set (see `annotationClientFamily` in
+    // tools/_surface.ts). Pin the split end-to-end.
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+        "user-agent": "claude-mcp-client/1.0",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        tools: Array<{
+          name: string;
+          annotations: { openWorldHint: boolean; readOnlyHint: boolean };
+        }>;
+      };
+    };
+    // The 4 default retrieval tools keep the MCP spec's open-world,
+    // read-only meaning for claude.
+    expect(body.result.tools).toHaveLength(4);
+    for (const t of body.result.tools) {
+      expect(t.annotations.openWorldHint, t.name).toBe(true);
+      expect(t.annotations.readOnlyHint, t.name).toBe(true);
+    }
   });
 
   it("POST /mcp?tools=agent adds the agent split pair on ChatGPT clients", async () => {

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -212,7 +212,15 @@ describe("worker routing", () => {
 
     const body = (await res.json()) as {
       result: {
-        tools: Array<{ name: string; _meta?: Record<string, unknown> }>;
+        tools: Array<{
+          name: string;
+          annotations: {
+            readOnlyHint: boolean;
+            destructiveHint: boolean;
+            openWorldHint: boolean;
+          };
+          _meta?: Record<string, unknown>;
+        }>;
       };
     };
     const names = body.result.tools.map((t) => t.name).sort();
@@ -237,6 +245,9 @@ describe("worker routing", () => {
       expect(t._meta?.["com.tako/securitySchemes"]).toEqual([
         { type: "oauth2", scopes: ["mcp"] },
       ]);
+      // Non-ChatGPT clients retain the canonical MCP meaning, where live
+      // search/data lookup is an open-world interaction.
+      expect(t.annotations.openWorldHint).toBe(true);
     }
 
     // MCP Apps: this request carries no User-Agent, so `detectMcpClient`
@@ -326,7 +337,15 @@ describe("worker routing", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       result: {
-        tools: Array<{ name: string; _meta?: Record<string, unknown> }>;
+        tools: Array<{
+          name: string;
+          annotations: {
+            readOnlyHint: boolean;
+            destructiveHint: boolean;
+            openWorldHint: boolean;
+          };
+          _meta?: Record<string, unknown>;
+        }>;
       };
     };
     const names = new Set(body.result.tools.map((t) => t.name));
@@ -342,6 +361,23 @@ describe("worker routing", () => {
     expect(names.has("tako_visualize")).toBe(true);
     // 4 defaults + tako_visualize (ChatGPT default-on) + the split pair = 7.
     expect(body.result.tools).toHaveLength(7);
+
+    const agentStartTool = body.result.tools.find(
+      (t) => t.name === "tako_agent_start",
+    );
+    expect(agentStartTool?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
+    const agentWaitTool = body.result.tools.find(
+      (t) => t.name === "tako_agent_wait",
+    );
+    expect(agentWaitTool?.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+      openWorldHint: false,
+    });
 
     // `tako_search` is the sole chart-widget tool on ChatGPT after 0.3.0.
     // The empty-fast widget-gap problem (ChatGPT pins widget container
@@ -377,7 +413,16 @@ describe("worker routing", () => {
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      result: { tools: Array<{ name: string }> };
+      result: {
+        tools: Array<{
+          name: string;
+          annotations: {
+            readOnlyHint: boolean;
+            destructiveHint: boolean;
+            openWorldHint: boolean;
+          };
+        }>;
+      };
     };
     const names = new Set(body.result.tools.map((t) => t.name));
     // The agent is opt-in: without `?tools=agent`, ChatGPT gets neither the
@@ -395,6 +440,16 @@ describe("worker routing", () => {
     expect(names.has("get_credit_balance")).toBe(false);
     // 4 defaults + tako_visualize = 5.
     expect(body.result.tools).toHaveLength(5);
+
+    for (const tool of body.result.tools) {
+      expect(tool.annotations.destructiveHint, tool.name).toBe(false);
+      expect(tool.annotations.openWorldHint, tool.name).toBe(
+        tool.name === "tako_visualize",
+      );
+      expect(tool.annotations.readOnlyHint, tool.name).toBe(
+        tool.name !== "tako_visualize",
+      );
+    }
 
     // The widget ships on ChatGPT (and Claude — see the claude tools/list
     // test above), so `tako_visualize`'s listing must declare the chart

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -17,9 +17,9 @@ import {
   createMcpServer,
   detectMcpClient,
   djangoErrorToToolResult,
-  toolAnnotationsForClient,
 } from "./mcp.js";
 import { TOOL_REGISTRY } from "./tools/_registry.js";
+import { toolAnnotationsForClient } from "./tools/_surface.js";
 import {
   jsonResponse,
   mockFetchSequence,
@@ -50,14 +50,25 @@ describe("detectMcpClient", () => {
 });
 
 describe("toolAnnotationsForClient", () => {
-  it("preserves the canonical MCP annotations for non-ChatGPT clients", () => {
+  it("preserves the canonical MCP annotations for claude", () => {
     for (const tool of TOOL_REGISTRY) {
       expect(toolAnnotationsForClient(tool, "claude")).toEqual(tool.annotations);
-      expect(toolAnnotationsForClient(tool, "unknown")).toEqual(tool.annotations);
     }
   });
 
-  it("uses OpenAI Apps review semantics only for ChatGPT descriptors", () => {
+  it("resolves unknown clients to the ChatGPT override family", () => {
+    // An OpenAI reviewer or crawler with an unrecognized UA lands on
+    // `unknown` — it must see the same labels chatgpt-app-submission.json
+    // declares, never canonical labels that contradict it (see
+    // `annotationClientFamily` in tools/_surface.ts).
+    for (const tool of TOOL_REGISTRY) {
+      expect(toolAnnotationsForClient(tool, "unknown")).toEqual(
+        toolAnnotationsForClient(tool, "chatgpt"),
+      );
+    }
+  });
+
+  it("uses OpenAI Apps review semantics for ChatGPT descriptors", () => {
     for (const tool of TOOL_REGISTRY) {
       const annotations = toolAnnotationsForClient(tool, "chatgpt");
       expect(annotations.destructiveHint, tool.name).toBe(false);

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -27,6 +27,28 @@ import {
 } from "./tools/__test_helpers.js";
 import type { McpClientKind, ToolContext } from "./tools/types.js";
 
+describe("detectMcpClient", () => {
+  it("maps OpenAI-family user agents to chatgpt", () => {
+    // Apps SDK / ChatGPT connector families.
+    expect(detectMcpClient("ChatGPT/1.0 (+https://chatgpt.com)")).toBe(
+      "chatgpt",
+    );
+    expect(detectMcpClient("openai-mcp/1.0")).toBe("chatgpt");
+    // OpenAI's published crawler/agent UAs contain neither "chatgpt" nor
+    // "openai" in the product token — matched explicitly so OpenAI review
+    // tooling sees the descriptors chatgpt-app-submission.json declares.
+    expect(detectMcpClient("GPTBot/1.2")).toBe("chatgpt");
+    expect(detectMcpClient("OAI-SearchBot/1.0")).toBe("chatgpt");
+  });
+
+  it("maps claude/anthropic UAs to claude and everything else to unknown", () => {
+    expect(detectMcpClient("claude-mcp-client/1.0")).toBe("claude");
+    expect(detectMcpClient(null)).toBe("unknown");
+    expect(detectMcpClient("")).toBe("unknown");
+    expect(detectMcpClient("curl/8.4.0")).toBe("unknown");
+  });
+});
+
 describe("toolAnnotationsForClient", () => {
   it("preserves the canonical MCP annotations for non-ChatGPT clients", () => {
     for (const tool of TOOL_REGISTRY) {

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -17,13 +17,47 @@ import {
   createMcpServer,
   detectMcpClient,
   djangoErrorToToolResult,
+  toolAnnotationsForClient,
 } from "./mcp.js";
+import { TOOL_REGISTRY } from "./tools/_registry.js";
 import {
   jsonResponse,
   mockFetchSequence,
   noopSendProgress,
 } from "./tools/__test_helpers.js";
 import type { McpClientKind, ToolContext } from "./tools/types.js";
+
+describe("toolAnnotationsForClient", () => {
+  it("preserves the canonical MCP annotations for non-ChatGPT clients", () => {
+    for (const tool of TOOL_REGISTRY) {
+      expect(toolAnnotationsForClient(tool, "claude")).toEqual(tool.annotations);
+      expect(toolAnnotationsForClient(tool, "unknown")).toEqual(tool.annotations);
+    }
+  });
+
+  it("uses OpenAI Apps review semantics only for ChatGPT descriptors", () => {
+    for (const tool of TOOL_REGISTRY) {
+      const annotations = toolAnnotationsForClient(tool, "chatgpt");
+      expect(annotations.destructiveHint, tool.name).toBe(false);
+      expect(annotations.openWorldHint, tool.name).toBe(
+        tool.name === "tako_visualize",
+      );
+    }
+
+    expect(
+      toolAnnotationsForClient(
+        TOOL_REGISTRY.find((tool) => tool.name === "tako_agent_start")!,
+        "chatgpt",
+      ).readOnlyHint,
+    ).toBe(false);
+    expect(
+      toolAnnotationsForClient(
+        TOOL_REGISTRY.find((tool) => tool.name === "tako_agent")!,
+        "chatgpt",
+      ).readOnlyHint,
+    ).toBe(false);
+  });
+});
 
 describe("djangoErrorToToolResult", () => {
   // Read tools (tako_search/tako_answer/tako_contents) declare an

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -42,15 +42,15 @@ import {
   type Tier,
 } from "./freetier.js";
 import { tryResolveOAuthAccessToken } from "./oauth/access.js";
-import {
-  OPTIONAL_TOOL_NAMES,
-  parseEnabledOptionalToolNames,
-} from "./tools/_optional.js";
+import { parseEnabledOptionalToolNames } from "./tools/_optional.js";
 import { TOOL_REGISTRY } from "./tools/_registry.js";
+import {
+  isToolOnSurface,
+  toolAnnotationsForClient,
+} from "./tools/_surface.js";
 import type {
   AnyToolModule,
   McpClientKind,
-  ToolAnnotations,
   ToolContext,
 } from "./tools/types.js";
 
@@ -166,57 +166,33 @@ export function detectMcpClient(userAgent: string | null): McpClientKind {
   // claude.ai here and gets widget `_meta` it cannot render.
   if (ua.includes("claude") || ua.includes("anthropic")) return "claude";
   // ChatGPT's Apps SDK connector typically advertises `ChatGPT-User`,
-  // `openai-mcp`, or similar in UA.
-  if (ua.includes("chatgpt") || ua.includes("openai")) return "chatgpt";
+  // `openai-mcp`, or similar in UA. OpenAI's published crawler/agent UAs
+  // (`GPTBot`, `OAI-SearchBot`) contain neither substring, so match them
+  // explicitly: if any OpenAI-family tooling (directory crawler, app
+  // review harness) lists our tools, it must see the same descriptors
+  // `chatgpt-app-submission.json` declares — not the canonical MCP ones
+  // the unknown-UA fallback would serve. Residual risk: an OpenAI
+  // reviewer hitting /mcp with a UA outside these families still falls
+  // through to `unknown`; the actual connector UA should be confirmed
+  // against production request logs rather than the `"ChatGPT/1.0"`
+  // stand-in the tests use.
+  if (
+    ua.includes("chatgpt") ||
+    ua.includes("openai") ||
+    ua.includes("gptbot") ||
+    ua.includes("oai-searchbot")
+  ) {
+    return "chatgpt";
+  }
   return "unknown";
 }
 
-/**
- * OpenAI's ChatGPT Apps review guidance uses `openWorldHint` as a
- * public/external-state mutation label, which differs from the MCP protocol's
- * domain-of-interaction meaning (where web search is the canonical open-world
- * example). Keep each tool module's canonical MCP annotations untouched, then
- * adapt only the descriptors served to ChatGPT-class clients.
- *
- * `tako_agent_start` is also non-read-only under the Apps review meaning
- * because it enqueues a server-side workflow. The combined `tako_agent` gets
- * the same override for completeness even though ChatGPT receives the split
- * start/wait pair instead.
- */
-const CHATGPT_ANNOTATION_OVERRIDES: Readonly<
-  Record<
-    string,
-    Partial<
-      Pick<
-        ToolAnnotations,
-        "readOnlyHint" | "destructiveHint" | "openWorldHint"
-      >
-    >
-  >
-> = {
-  tako_search: { openWorldHint: false },
-  tako_answer: { openWorldHint: false },
-  tako_contents: { openWorldHint: false },
-  tako_available_data: { openWorldHint: false },
-  tako_graph_search: { openWorldHint: false },
-  tako_graph_related: { openWorldHint: false },
-  tako_graph_node: { openWorldHint: false },
-  tako_agent: { readOnlyHint: false, openWorldHint: false },
-  tako_agent_start: { readOnlyHint: false, openWorldHint: false },
-  tako_agent_wait: { openWorldHint: false },
-  tako_visualize: { openWorldHint: true },
-};
-
-export function toolAnnotationsForClient(
-  tool: AnyToolModule,
-  client: McpClientKind,
-): ToolAnnotations {
-  if (client !== "chatgpt") return tool.annotations;
-  return {
-    ...tool.annotations,
-    ...CHATGPT_ANNOTATION_OVERRIDES[tool.name],
-  };
-}
+// Per-client annotation resolution lives with the tool surface config in
+// `tools/_surface.ts` (each tool declares its own `annotationsByClient`
+// next to its canonical MCP annotations — see `annotationsByClient` in
+// `tools/types.ts` for the MCP-vs-Apps-review semantics). Re-exported here
+// so existing imports from `./mcp.js` keep working.
+export { toolAnnotationsForClient };
 
 export function createMcpServer(
   ctx: ToolContext,
@@ -310,34 +286,12 @@ export function createMcpServer(
   const registeredResourceUris = new Set<string>();
   const registeredTemplateNames = new Set<string>();
 
-  // Tools that should ONLY appear on ChatGPT-class clients.
+  // Which tools appear for which client — and the ChatGPT-only /
+  // ChatGPT-excluded / ChatGPT-default-on membership sets — live in
+  // `tools/_surface.ts`, shared with `gen-registry.ts` so the
+  // `chatgpt-app-submission.json` parity check validates the exact
+  // surface this loop registers.
   //
-  // ChatGPT's Apps SDK doesn't send a progressToken, so the single-tool
-  // `tako_agent` dispatch+poll path (which emits progress to keep the
-  // per-call timeout fresh) can't survive ChatGPT's ~60 s ceiling. The
-  // split pair `tako_agent_start` / `tako_agent_wait` is used instead.
-  //
-  // Hosting them only on the clients that need them keeps the
-  // Claude.ai tool surface minimal (no risk of the agent there
-  // accidentally choosing the slower split flow over the single-call
-  // path) and keeps the registry codegen unchanged (registry/server.json
-  // still lists everything for discovery; the runtime just filters per
-  // request).
-  const CHATGPT_ONLY_TOOL_NAMES = new Set([
-    // ChatGPT's Apps SDK doesn't send a progressToken, so the single-tool
-    // `tako_agent` dispatch+poll path (which emits progress to keep the
-    // per-call timeout fresh) can't survive ChatGPT's ~60 s ceiling. The
-    // split pair `tako_agent_start` / `tako_agent_wait` is used instead.
-    "tako_agent_start",
-    "tako_agent_wait",
-  ]);
-  // Tools registered for all clients EXCEPT ChatGPT. The dispatch+poll
-  // `tako_agent` relies on `notifications/progress` for timeout extension —
-  // suppress it for chatgpt (which doesn't support that mechanism) and
-  // route to the split pair instead.
-  const CHATGPT_EXCLUDED_TOOL_NAMES = new Set([
-    "tako_agent",
-  ]);
   // Tools whose `appUiResource` should NOT ship on ChatGPT (separate
   // from the blanket unknown-client suppression in `widgetSuppressed` —
   // ChatGPT and Claude are the only clients that get the widget at all).
@@ -352,12 +306,6 @@ export function createMcpServer(
   // success state. Most chart-conditional tools should rely on the
   // throw-on-empty pattern instead.
   const CHATGPT_NO_WIDGET_TOOL_NAMES = new Set<string>();
-  // Optional tools that stay on the DEFAULT surface for ChatGPT only.
-  // `tako_visualize` ships the chart widget ChatGPT renders; hiding it
-  // behind `?tools=` would silently break the ChatGPT app experience,
-  // so ChatGPT keeps it without opting in. Every other client must
-  // enable it via `?tools=visualize`.
-  const CHATGPT_DEFAULT_ON_TOOL_NAMES = new Set(["tako_visualize"]);
   const client = options.client ?? "unknown";
   const tier = options.tier ?? "authenticated";
   // Opt-in tools enabled for this request via `?tools=` (see `_optional.ts`).
@@ -373,23 +321,11 @@ export function createMcpServer(
     if (tier === "free" && !FREE_TIER_TOOL_NAMES.has(tool.name)) {
       continue;
     }
-    // Opt-in gate: optional tools (see `OPTIONAL_TOOL_ALIASES` in
-    // `_optional.ts`) are excluded from the default surface and registered
-    // only when enabled via the `tools` query param — except tools ChatGPT
-    // keeps by default (`CHATGPT_DEFAULT_ON_TOOL_NAMES`). Applied BEFORE the
-    // per-client filters below so a disabled tool never reaches
-    // client-variant selection.
-    if (
-      OPTIONAL_TOOL_NAMES.has(tool.name) &&
-      !enabledOptionalToolNames.has(tool.name) &&
-      !(client === "chatgpt" && CHATGPT_DEFAULT_ON_TOOL_NAMES.has(tool.name))
-    ) {
-      continue;
-    }
-    if (CHATGPT_ONLY_TOOL_NAMES.has(tool.name) && client !== "chatgpt") {
-      continue;
-    }
-    if (CHATGPT_EXCLUDED_TOOL_NAMES.has(tool.name) && client === "chatgpt") {
+    // Surface membership (opt-in gate + per-client filters) is decided by
+    // `isToolOnSurface` in `tools/_surface.ts` — shared with the codegen
+    // parity check so `chatgpt-app-submission.json` can't drift from what
+    // this loop actually registers.
+    if (!isToolOnSurface(tool.name, client, enabledOptionalToolNames)) {
       continue;
     }
     registerTool(server, tool, ctx, {

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -47,7 +47,12 @@ import {
   parseEnabledOptionalToolNames,
 } from "./tools/_optional.js";
 import { TOOL_REGISTRY } from "./tools/_registry.js";
-import type { AnyToolModule, McpClientKind, ToolContext } from "./tools/types.js";
+import type {
+  AnyToolModule,
+  McpClientKind,
+  ToolAnnotations,
+  ToolContext,
+} from "./tools/types.js";
 
 /**
  * Server identity. `registry/server.json` is the canonical source — versions are
@@ -164,6 +169,53 @@ export function detectMcpClient(userAgent: string | null): McpClientKind {
   // `openai-mcp`, or similar in UA.
   if (ua.includes("chatgpt") || ua.includes("openai")) return "chatgpt";
   return "unknown";
+}
+
+/**
+ * OpenAI's ChatGPT Apps review guidance uses `openWorldHint` as a
+ * public/external-state mutation label, which differs from the MCP protocol's
+ * domain-of-interaction meaning (where web search is the canonical open-world
+ * example). Keep each tool module's canonical MCP annotations untouched, then
+ * adapt only the descriptors served to ChatGPT-class clients.
+ *
+ * `tako_agent_start` is also non-read-only under the Apps review meaning
+ * because it enqueues a server-side workflow. The combined `tako_agent` gets
+ * the same override for completeness even though ChatGPT receives the split
+ * start/wait pair instead.
+ */
+const CHATGPT_ANNOTATION_OVERRIDES: Readonly<
+  Record<
+    string,
+    Partial<
+      Pick<
+        ToolAnnotations,
+        "readOnlyHint" | "destructiveHint" | "openWorldHint"
+      >
+    >
+  >
+> = {
+  tako_search: { openWorldHint: false },
+  tako_answer: { openWorldHint: false },
+  tako_contents: { openWorldHint: false },
+  tako_available_data: { openWorldHint: false },
+  tako_graph_search: { openWorldHint: false },
+  tako_graph_related: { openWorldHint: false },
+  tako_graph_node: { openWorldHint: false },
+  tako_agent: { readOnlyHint: false, openWorldHint: false },
+  tako_agent_start: { readOnlyHint: false, openWorldHint: false },
+  tako_agent_wait: { openWorldHint: false },
+  tako_visualize: { openWorldHint: true },
+};
+
+export function toolAnnotationsForClient(
+  tool: AnyToolModule,
+  client: McpClientKind,
+): ToolAnnotations {
+  if (client !== "chatgpt") return tool.annotations;
+  return {
+    ...tool.annotations,
+    ...CHATGPT_ANNOTATION_OVERRIDES[tool.name],
+  };
 }
 
 export function createMcpServer(
@@ -434,7 +486,7 @@ function registerTool(
     title: tool.annotations.title,
     description,
     inputSchema: tool.inputSchema.shape,
-    annotations: tool.annotations,
+    annotations: toolAnnotationsForClient(tool, options.client),
   };
 
   // Advertise per-tool OAuth on every runtime descriptor. This only survives

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -31,7 +31,6 @@ import {
 import type { Env } from "./env.js";
 import {
   checkFreeTierRateLimit,
-  FREE_TIER_TOOL_NAMES,
   type FreeTierConfig,
   freeTierBatchResponse,
   freeTierCreditsToolResult,
@@ -168,14 +167,21 @@ export function detectMcpClient(userAgent: string | null): McpClientKind {
   // ChatGPT's Apps SDK connector typically advertises `ChatGPT-User`,
   // `openai-mcp`, or similar in UA. OpenAI's published crawler/agent UAs
   // (`GPTBot`, `OAI-SearchBot`) contain neither substring, so match them
-  // explicitly: if any OpenAI-family tooling (directory crawler, app
-  // review harness) lists our tools, it must see the same descriptors
-  // `chatgpt-app-submission.json` declares — not the canonical MCP ones
-  // the unknown-UA fallback would serve. Residual risk: an OpenAI
-  // reviewer hitting /mcp with a UA outside these families still falls
-  // through to `unknown`; the actual connector UA should be confirmed
-  // against production request logs rather than the `"ChatGPT/1.0"`
-  // stand-in the tests use.
+  // explicitly — and deliberately at the full `chatgpt` classification,
+  // not just for annotations: `McpClientKind` also selects the tool set
+  // (`isToolOnSurface`), widget registration, and image content blocks,
+  // and if OpenAI-family tooling (directory crawler, app review harness)
+  // lists our tools it must see the same TOOL SURFACE
+  // `chatgpt-app-submission.json` declares, not the `unknown` surface
+  // (which swaps the split agent pair for `tako_agent` and drops
+  // `tako_visualize`). The extra levers are harmless to a crawler: the
+  // widget is inert metadata and image suppression only trims response
+  // bytes. Residual risk for a UA outside these families is narrow:
+  // `unknown` already serves the Apps-review annotation labels (see
+  // `annotationClientFamily` in `tools/_surface.ts`), so only the
+  // tool-set difference remains. The actual connector UA should still be
+  // confirmed against production request logs rather than the
+  // `"ChatGPT/1.0"` stand-in the tests use.
   if (
     ua.includes("chatgpt") ||
     ua.includes("openai") ||
@@ -190,9 +196,7 @@ export function detectMcpClient(userAgent: string | null): McpClientKind {
 // Per-client annotation resolution lives with the tool surface config in
 // `tools/_surface.ts` (each tool declares its own `annotationsByClient`
 // next to its canonical MCP annotations — see `annotationsByClient` in
-// `tools/types.ts` for the MCP-vs-Apps-review semantics). Re-exported here
-// so existing imports from `./mcp.js` keep working.
-export { toolAnnotationsForClient };
+// `tools/types.ts` for the MCP-vs-Apps-review semantics).
 
 export function createMcpServer(
   ctx: ToolContext,
@@ -314,18 +318,11 @@ export function createMcpServer(
     options.enabledOptionalToolNames ?? new Set<string>();
 
   for (const tool of TOOL_REGISTRY) {
-    // Free-tier surface: anonymous connections see ONLY the three free
-    // tools. Applied before every other gate so no client-specific rule
-    // (`?tools=` opt-ins, CHATGPT_DEFAULT_ON_TOOL_NAMES) can widen the
-    // anonymous surface.
-    if (tier === "free" && !FREE_TIER_TOOL_NAMES.has(tool.name)) {
-      continue;
-    }
-    // Surface membership (opt-in gate + per-client filters) is decided by
-    // `isToolOnSurface` in `tools/_surface.ts` — shared with the codegen
-    // parity check so `chatgpt-app-submission.json` can't drift from what
-    // this loop actually registers.
-    if (!isToolOnSurface(tool.name, client, enabledOptionalToolNames)) {
+    // Surface membership (free-tier gate + opt-in gate + per-client
+    // filters) is decided by `isToolOnSurface` in `tools/_surface.ts` —
+    // shared with the codegen parity check so `chatgpt-app-submission.json`
+    // can't drift from what this loop actually registers.
+    if (!isToolOnSurface(tool.name, client, enabledOptionalToolNames, tier)) {
       continue;
     }
     registerTool(server, tool, ctx, {

--- a/workers/src/tools/_optional.ts
+++ b/workers/src/tools/_optional.ts
@@ -17,7 +17,7 @@
  * `agent` spans all three agent tool files: the single-call `tako_agent`
  * (Claude / unknown clients) and the `tako_agent_start` / `tako_agent_wait`
  * split pair (ChatGPT). The alias enables the *feature*; the per-client
- * filters in `mcp.ts` (`CHATGPT_ONLY_TOOL_NAMES` / `CHATGPT_EXCLUDED_TOOL_NAMES`)
+ * filters in `_surface.ts` (`CHATGPT_ONLY_TOOL_NAMES` / `CHATGPT_EXCLUDED_TOOL_NAMES`)
  * then narrow to the correct variant for the calling client. Users never need
  * to know the split exists — they enable `agent` and get the right tool.
  *
@@ -26,7 +26,7 @@
  * surface to save per-session context. They compose freely, e.g.
  * `?tools=visualize,credits`. Exception: `tako_visualize` stays on the
  * default surface for ChatGPT clients (it powers the chart widget) — see
- * `CHATGPT_DEFAULT_ON_TOOL_NAMES` in `mcp.ts`.
+ * `CHATGPT_DEFAULT_ON_TOOL_NAMES` in `_surface.ts`.
  *
  * `graph` enables the three low-level graph primitives (search / related /
  * node). `tako_available_data` covers the common discovery path in one call,

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-client tool-surface membership and annotation resolution.
+ *
+ * `mcp.ts` uses {@link isToolOnSurface} to decide which tools to register
+ * for a request's detected client, and {@link toolAnnotationsForClient} to
+ * resolve the annotations that client sees. `scripts/gen-registry.ts` runs
+ * the same two functions to validate that `chatgpt-app-submission.json`
+ * describes exactly the tools (and annotations) ChatGPT receives from the
+ * default production MCP URL — sharing one module is what keeps the
+ * hand-maintained submission metadata from drifting.
+ *
+ * The leading underscore keeps this file out of the tool-module scan in
+ * `gen-registry.ts` (it is NOT a `ToolModule`).
+ */
+import { OPTIONAL_TOOL_NAMES } from "./_optional.js";
+import type {
+  AnyToolModule,
+  McpClientKind,
+  ToolAnnotations,
+} from "./types.js";
+
+/**
+ * Tools that should ONLY appear on ChatGPT-class clients.
+ *
+ * ChatGPT's Apps SDK doesn't send a progressToken, so the single-tool
+ * `tako_agent` dispatch+poll path (which emits progress to keep the
+ * per-call timeout fresh) can't survive ChatGPT's ~60 s ceiling. The
+ * split pair `tako_agent_start` / `tako_agent_wait` is used instead.
+ *
+ * Hosting them only on the clients that need them keeps the Claude.ai
+ * tool surface minimal (no risk of the agent there accidentally choosing
+ * the slower split flow over the single-call path) and keeps the registry
+ * codegen unchanged (registry/server.json still lists everything for
+ * discovery; the runtime just filters per request).
+ */
+export const CHATGPT_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "tako_agent_start",
+  "tako_agent_wait",
+]);
+
+/**
+ * Tools registered for all clients EXCEPT ChatGPT. The dispatch+poll
+ * `tako_agent` relies on `notifications/progress` for timeout extension —
+ * suppress it for chatgpt (which doesn't support that mechanism) and
+ * route to the split pair instead.
+ */
+export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "tako_agent",
+]);
+
+/**
+ * Optional tools that stay on the DEFAULT surface for ChatGPT only.
+ * `tako_visualize` ships the chart widget ChatGPT renders; hiding it
+ * behind `?tools=` would silently break the ChatGPT app experience,
+ * so ChatGPT keeps it without opting in. Every other client must
+ * enable it via `?tools=visualize`.
+ */
+export const CHATGPT_DEFAULT_ON_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "tako_visualize",
+]);
+
+/**
+ * Whether a tool is registered for a request. Three gates, in order:
+ *
+ * 1. Opt-in gate: optional tools (see `OPTIONAL_TOOL_ALIASES` in
+ *    `_optional.ts`) are excluded from the default surface and registered
+ *    only when enabled via the `tools` query param — except tools ChatGPT
+ *    keeps by default ({@link CHATGPT_DEFAULT_ON_TOOL_NAMES}). Applied
+ *    first so a disabled tool never reaches client-variant selection.
+ * 2. ChatGPT-only tools are hidden from everyone else.
+ * 3. ChatGPT-excluded tools are hidden from ChatGPT.
+ */
+export function isToolOnSurface(
+  name: string,
+  client: McpClientKind,
+  enabledOptionalToolNames: ReadonlySet<string>,
+): boolean {
+  if (
+    OPTIONAL_TOOL_NAMES.has(name) &&
+    !enabledOptionalToolNames.has(name) &&
+    !(client === "chatgpt" && CHATGPT_DEFAULT_ON_TOOL_NAMES.has(name))
+  ) {
+    return false;
+  }
+  if (CHATGPT_ONLY_TOOL_NAMES.has(name) && client !== "chatgpt") return false;
+  if (CHATGPT_EXCLUDED_TOOL_NAMES.has(name) && client === "chatgpt") return false;
+  return true;
+}
+
+/**
+ * Resolve the annotations a client sees for a tool: the canonical MCP
+ * annotations, merged with the tool's own per-client overrides (see
+ * `annotationsByClient` in `types.ts` for why the two exist and the rule
+ * that decides which hints diverge).
+ */
+export function toolAnnotationsForClient(
+  tool: Pick<AnyToolModule, "annotations" | "annotationsByClient">,
+  client: McpClientKind,
+): ToolAnnotations {
+  return { ...tool.annotations, ...tool.annotationsByClient?.[client] };
+}

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -6,12 +6,14 @@
  * resolve the annotations that client sees. `scripts/gen-registry.ts` runs
  * the same two functions to validate that `chatgpt-app-submission.json`
  * describes exactly the tools (and annotations) ChatGPT receives from the
- * default production MCP URL — sharing one module is what keeps the
- * hand-maintained submission metadata from drifting.
+ * default production MCP URL over an authenticated connection — sharing
+ * one module is what keeps the hand-maintained submission metadata from
+ * drifting.
  *
  * The leading underscore keeps this file out of the tool-module scan in
  * `gen-registry.ts` (it is NOT a `ToolModule`).
  */
+import { FREE_TIER_TOOL_NAMES, type Tier } from "../freetier.js";
 import { OPTIONAL_TOOL_NAMES } from "./_optional.js";
 import type {
   AnyToolModule,
@@ -60,21 +62,27 @@ export const CHATGPT_DEFAULT_ON_TOOL_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Whether a tool is registered for a request. Three gates, in order:
+ * Whether a tool is registered for a request. Four gates, in order:
  *
- * 1. Opt-in gate: optional tools (see `OPTIONAL_TOOL_ALIASES` in
+ * 1. Free-tier gate: anonymous connections (`tier: "free"`) see ONLY
+ *    `FREE_TIER_TOOL_NAMES`. Applied first so no client-specific rule
+ *    (`?tools=` opt-ins, {@link CHATGPT_DEFAULT_ON_TOOL_NAMES}) can
+ *    widen the anonymous surface.
+ * 2. Opt-in gate: optional tools (see `OPTIONAL_TOOL_ALIASES` in
  *    `_optional.ts`) are excluded from the default surface and registered
  *    only when enabled via the `tools` query param — except tools ChatGPT
  *    keeps by default ({@link CHATGPT_DEFAULT_ON_TOOL_NAMES}). Applied
- *    first so a disabled tool never reaches client-variant selection.
- * 2. ChatGPT-only tools are hidden from everyone else.
- * 3. ChatGPT-excluded tools are hidden from ChatGPT.
+ *    before client-variant selection so a disabled tool never reaches it.
+ * 3. ChatGPT-only tools are hidden from everyone else.
+ * 4. ChatGPT-excluded tools are hidden from ChatGPT.
  */
 export function isToolOnSurface(
   name: string,
   client: McpClientKind,
   enabledOptionalToolNames: ReadonlySet<string>,
+  tier: Tier = "authenticated",
 ): boolean {
+  if (tier === "free" && !FREE_TIER_TOOL_NAMES.has(name)) return false;
   if (
     OPTIONAL_TOOL_NAMES.has(name) &&
     !enabledOptionalToolNames.has(name) &&
@@ -88,14 +96,35 @@ export function isToolOnSurface(
 }
 
 /**
+ * Which `annotationsByClient` family a client's annotations resolve from.
+ *
+ * Canonical MCP annotations are reserved for `claude` — the one client
+ * family known to read the hints with the MCP spec's meanings. Everything
+ * else, INCLUDING `unknown`, resolves the `chatgpt` overrides. The two
+ * failure modes are not symmetric: an OpenAI reviewer or directory
+ * crawler whose UA `detectMcpClient` doesn't recognize lands on
+ * `unknown`, and serving it canonical labels would contradict
+ * `chatgpt-app-submission.json` — an app-rejection risk. Serving the
+ * Apps-review labels to a generic third-party MCP client merely
+ * understates `openWorldHint` on retrieval — cosmetic, and reversible.
+ */
+export function annotationClientFamily(client: McpClientKind): McpClientKind {
+  return client === "claude" ? "claude" : "chatgpt";
+}
+
+/**
  * Resolve the annotations a client sees for a tool: the canonical MCP
- * annotations, merged with the tool's own per-client overrides (see
- * `annotationsByClient` in `types.ts` for why the two exist and the rule
- * that decides which hints diverge).
+ * annotations, merged with the tool's own per-client overrides for the
+ * client's {@link annotationClientFamily} (see `annotationsByClient` in
+ * `types.ts` for why the two exist and the rule that decides which hints
+ * diverge).
  */
 export function toolAnnotationsForClient(
   tool: Pick<AnyToolModule, "annotations" | "annotationsByClient">,
   client: McpClientKind,
 ): ToolAnnotations {
-  return { ...tool.annotations, ...tool.annotationsByClient?.[client] };
+  return {
+    ...tool.annotations,
+    ...tool.annotationsByClient?.[annotationClientFamily(client)],
+  };
 }

--- a/workers/src/tools/annotations.test.ts
+++ b/workers/src/tools/annotations.test.ts
@@ -32,9 +32,18 @@ describe("tool annotations", () => {
     }
   });
 
-  it("tako_visualize is the write/publish tool (readOnlyHint false)", () => {
-    const viz = TOOL_REGISTRY.find((t) => t.name === "tako_visualize");
-    expect(viz?.annotations.readOnlyHint).toBe(false);
-    expect(viz?.annotations.openWorldHint).toBe(false);
+  it("readOnlyHint is false for exactly the durable-resource writers", () => {
+    // The write line (see `annotationsByClient` in types.ts) is drawn once,
+    // for every client: a call is a WRITE when it creates a durable,
+    // user-addressable resource — a chart card with public URLs
+    // (tako_visualize) or a queued agent run reachable later via
+    // `run_id`/`thread_id` (tako_agent, tako_agent_start). Everything else,
+    // including the run-polling tako_agent_wait, is a read.
+    const WRITERS = new Set(["tako_visualize", "tako_agent", "tako_agent_start"]);
+    for (const tool of TOOL_REGISTRY) {
+      expect(tool.annotations.readOnlyHint, tool.name).toBe(
+        !WRITERS.has(tool.name),
+      );
+    }
   });
 });

--- a/workers/src/tools/get_credit_balance.ts
+++ b/workers/src/tools/get_credit_balance.ts
@@ -53,6 +53,10 @@ const get_credit_balance = {
     destructiveHint: false,
     openWorldHint: false,
   },
+  // Deliberately no `annotationsByClient`: a private account lookup is
+  // read-only and closed-world under both the MCP and Apps review
+  // readings, so — uniquely among these tools — the canonical annotations
+  // already serve every client.
   async handler(_input, ctx) {
     const data = await djangoGet<Record<string, unknown>>(
       ctx.env,

--- a/workers/src/tools/tako_agent.ts
+++ b/workers/src/tools/tako_agent.ts
@@ -319,9 +319,21 @@ const takoAgent = {
   outputSchema: agentRunSchema,
   annotations: {
     title: "Tako: Answer Agent",
+    // Read-only under the MCP reading: the run only computes an answer;
+    // the queued-run record (`run_id`/`thread_id`) is server bookkeeping,
+    // not a mutation of the user's environment. Credit debits never flip
+    // the hint — every Tako tool, reads included, debits credits.
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: true,
+  },
+  annotationsByClient: {
+    // Apps review draws the write line at "creates a durable,
+    // user-addressable resource" — enqueueing a server-side run qualifies,
+    // so ChatGPT sees this as a non-destructive write. Override kept for
+    // completeness even though ChatGPT receives the split start/wait pair
+    // instead of this tool. See `annotationsByClient` in types.ts.
+    chatgpt: { readOnlyHint: false, openWorldHint: false },
   },
   async handler(input, ctx): Promise<AgentRun> {
     const runId = await dispatchAgentRun(ctx, input.query, input.sources, input.thread_id);

--- a/workers/src/tools/tako_agent.ts
+++ b/workers/src/tools/tako_agent.ts
@@ -319,21 +319,20 @@ const takoAgent = {
   outputSchema: agentRunSchema,
   annotations: {
     title: "Tako: Answer Agent",
-    // Read-only under the MCP reading: the run only computes an answer;
-    // the queued-run record (`run_id`/`thread_id`) is server bookkeeping,
-    // not a mutation of the user's environment. Credit debits never flip
-    // the hint — every Tako tool, reads included, debits credits.
-    readOnlyHint: true,
+    // WRITE under the shared rule in types.ts: the call creates a durable,
+    // user-addressable resource — a queued run reachable later via
+    // `run_id`/`thread_id`. Non-destructive: it only ever adds runs.
+    readOnlyHint: false,
     destructiveHint: false,
     openWorldHint: true,
   },
   annotationsByClient: {
-    // Apps review draws the write line at "creates a durable,
-    // user-addressable resource" — enqueueing a server-side run qualifies,
-    // so ChatGPT sees this as a non-destructive write. Override kept for
-    // completeness even though ChatGPT receives the split start/wait pair
-    // instead of this tool. See `annotationsByClient` in types.ts.
-    chatgpt: { readOnlyHint: false, openWorldHint: false },
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction, so the
+    // open-world retrieval flag drops for the ChatGPT family. Override
+    // kept even though ChatGPT receives the split start/wait pair instead
+    // of this tool. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
   },
   async handler(input, ctx): Promise<AgentRun> {
     const runId = await dispatchAgentRun(ctx, input.query, input.sources, input.thread_id);

--- a/workers/src/tools/tako_agent_start.ts
+++ b/workers/src/tools/tako_agent_start.ts
@@ -10,7 +10,7 @@
  *
  * On Claude.ai (which sends a `progressToken` and resets timeouts on
  * progress events), this tool is NOT registered — the single `tako_agent`
- * tool handles the full dispatch+poll in one call. See `mcp.ts`'s
+ * tool handles the full dispatch+poll in one call. See `_surface.ts`'s
  * `CHATGPT_ONLY_TOOL_NAMES` set.
  *
  * Wire path: POSTs to `/api/v1/agent/answer/runs` with `effort: "medium"`
@@ -48,9 +48,20 @@ const tako_agent_start = {
   outputSchema,
   annotations: {
     title: "Tako: Start Agent Run",
+    // Read-only under the MCP reading: the run only computes an answer;
+    // the queued-run record (`run_id`/`thread_id`) is server bookkeeping,
+    // not a mutation of the user's environment. Credit debits never flip
+    // the hint — every Tako tool, reads included, debits credits.
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: true,
+  },
+  annotationsByClient: {
+    // Apps review draws the write line at "creates a durable,
+    // user-addressable resource" — enqueueing a server-side run reachable
+    // later via `run_id` qualifies, so ChatGPT sees this as a
+    // non-destructive write. See `annotationsByClient` in types.ts.
+    chatgpt: { readOnlyHint: false, openWorldHint: false },
   },
   async handler(input, ctx): Promise<Output> {
     const runId = await dispatchAgentRun(ctx, input.query, input.sources, input.thread_id);

--- a/workers/src/tools/tako_agent_start.ts
+++ b/workers/src/tools/tako_agent_start.ts
@@ -48,20 +48,19 @@ const tako_agent_start = {
   outputSchema,
   annotations: {
     title: "Tako: Start Agent Run",
-    // Read-only under the MCP reading: the run only computes an answer;
-    // the queued-run record (`run_id`/`thread_id`) is server bookkeeping,
-    // not a mutation of the user's environment. Credit debits never flip
-    // the hint — every Tako tool, reads included, debits credits.
-    readOnlyHint: true,
+    // WRITE under the shared rule in types.ts: the call creates a durable,
+    // user-addressable resource — a queued run reachable later via
+    // `run_id`/`thread_id`. Non-destructive: it only ever adds runs.
+    readOnlyHint: false,
     destructiveHint: false,
     openWorldHint: true,
   },
   annotationsByClient: {
-    // Apps review draws the write line at "creates a durable,
-    // user-addressable resource" — enqueueing a server-side run reachable
-    // later via `run_id` qualifies, so ChatGPT sees this as a
-    // non-destructive write. See `annotationsByClient` in types.ts.
-    chatgpt: { readOnlyHint: false, openWorldHint: false },
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction, so the
+    // open-world retrieval flag drops for the ChatGPT family. See
+    // `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
   },
   async handler(input, ctx): Promise<Output> {
     const runId = await dispatchAgentRun(ctx, input.query, input.sources, input.thread_id);

--- a/workers/src/tools/tako_agent_wait.ts
+++ b/workers/src/tools/tako_agent_wait.ts
@@ -4,7 +4,7 @@
  *
  * Registered ONLY on clients that don't honor MCP
  * `notifications/progress` for tool-call timeout extension (currently:
- * ChatGPT). See `mcp.ts`'s `CHATGPT_ONLY_TOOL_NAMES` set and
+ * ChatGPT). See `_surface.ts`'s `CHATGPT_ONLY_TOOL_NAMES` set and
  * `tako_agent_start` for the full rationale.
  *
  * Internally calls `pollAgentRun`, which polls
@@ -54,6 +54,13 @@ const tako_agent_wait = {
     readOnlyHint: true,
     destructiveHint: false,
     openWorldHint: true,
+  },
+  annotationsByClient: {
+    // Polling an existing run creates nothing — read-only on both
+    // readings; only `openWorldHint` diverges (Apps review reads it as
+    // "publishes/mutates public state"). See `annotationsByClient` in
+    // types.ts.
+    chatgpt: { openWorldHint: false },
   },
   async handler(input, ctx): Promise<AgentRun> {
     return pollAgentRun(ctx, input.run_id, {

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -124,6 +124,12 @@ const takoAnswer = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input, ctx): Promise<Output> {
     // GA /api/v1/answer takes the v3 SearchRequest shape: top-level `query`
     // + a per-source `sources` OBJECT (an index is searched iff its key is

--- a/workers/src/tools/tako_available_data.ts
+++ b/workers/src/tools/tako_available_data.ts
@@ -110,6 +110,12 @@ const tako_available_data = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input: Input, ctx): Promise<Output> {
     // 1) Resolve the name to graph nodes.
     const searchQuery: Record<string, string | number | boolean> = {

--- a/workers/src/tools/tako_contents.ts
+++ b/workers/src/tools/tako_contents.ts
@@ -117,6 +117,12 @@ const takoContents = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input, ctx): Promise<Output> {
     // input conforms to the generated ContentsRequest contract (url + mode +
     // optional max_rows). max_rows, when omitted, is absent from `input` and so

--- a/workers/src/tools/tako_graph_node.ts
+++ b/workers/src/tools/tako_graph_node.ts
@@ -35,6 +35,12 @@ const tako_graph_node = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input: Input, ctx): Promise<Output> {
     const path = `/api/beta/graph/node/${encodeURIComponent(input.id)}`;
     let data: unknown;

--- a/workers/src/tools/tako_graph_related.ts
+++ b/workers/src/tools/tako_graph_related.ts
@@ -66,6 +66,12 @@ const tako_graph_related = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input: Input, ctx): Promise<Output> {
     const query: Record<string, string | number | boolean> = {
       node_id: input.node_id,

--- a/workers/src/tools/tako_graph_search.ts
+++ b/workers/src/tools/tako_graph_search.ts
@@ -60,6 +60,12 @@ const tako_graph_search = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input: Input, ctx): Promise<Output> {
     const query: Record<string, string | number | boolean> = { q: input.q };
     if (input.types !== undefined) query.types = input.types;

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -171,6 +171,12 @@ const tako_search = {
     destructiveHint: false,
     openWorldHint: true,
   },
+  annotationsByClient: {
+    // Apps review reads `openWorldHint` as "publishes/mutates public or
+    // third-party state", not MCP's domain-of-interaction — retrieval is
+    // closed-world there. See `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: false },
+  },
   async handler(input, ctx): Promise<Output> {
     // v3 SearchRequest takes a per-source `sources` OBJECT — an index is
     // searched iff its key is present, and `count` / `include_contents` are

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -164,6 +164,18 @@ const tako_visualize = {
     // open/unpredictable set of external entities the way a web search does.
     openWorldHint: false,
   },
+  annotationsByClient: {
+    // The one override that WIDENS a hint: Apps review reads
+    // `openWorldHint` as "publishes/mutates publicly visible state", and
+    // this call mints a card with publicly accessible webpage/embed URLs.
+    // Combined with `readOnlyHint: false` this marks the call
+    // confirmation-worthy in ChatGPT even though the tool sits on
+    // ChatGPT's default surface — intended: a user-visible prompt before
+    // creating a public URL is the honest label for review, and matches
+    // the justification in `chatgpt-app-submission.json`. See
+    // `annotationsByClient` in types.ts.
+    chatgpt: { openWorldHint: true },
+  },
   async handler(input, ctx): Promise<Output> {
     const body = buildVisualizeBody(input);
 

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -276,33 +276,34 @@ export interface ToolModule<
   annotations: ToolAnnotations;
   /**
    * Optional per-client annotation overrides, merged over
-   * {@link annotations} for the matching client — the same resolution
-   * shape as {@link descriptionByClient} (see `toolAnnotationsForClient`
-   * in `_surface.ts`). The canonical `annotations` follow the MCP spec's
-   * readings and are what every other client (and the generated registry)
-   * sees.
+   * {@link annotations} — the same resolution shape as
+   * {@link descriptionByClient} (see `toolAnnotationsForClient` in
+   * `_surface.ts`). The canonical `annotations` follow the MCP spec's
+   * readings; they are what `claude` clients and the generated registry
+   * see. `chatgpt` AND `unknown` clients resolve the `chatgpt` override
+   * family (see `annotationClientFamily` in `_surface.ts`), so OpenAI
+   * review tooling with an unrecognized UA can never see labels that
+   * contradict `chatgpt-app-submission.json`.
    *
-   * Exists because OpenAI's ChatGPT Apps review reads the hints
-   * differently from the MCP protocol:
+   * Exists because OpenAI's ChatGPT Apps review reads `openWorldHint`
+   * differently from the MCP protocol. MCP: domain of interaction (web
+   * search is the spec's canonical open-world example). Apps review:
+   * "does this call publish or mutate publicly visible / third-party
+   * state?" Retrieval tools are therefore open-world under MCP but
+   * closed-world under Apps review, and `tako_visualize` (mints public
+   * chart URLs) is the reverse.
    *
-   * - `openWorldHint` — MCP: domain of interaction (web search is the
-   *   spec's canonical open-world example). Apps review: "does this call
-   *   publish or mutate publicly visible / third-party state?" Retrieval
-   *   tools are therefore open-world under MCP but closed-world under
-   *   Apps review, and `tako_visualize` (mints public chart URLs) is the
-   *   reverse.
-   * - `readOnlyHint` — nominally the same in both ("does not modify its
-   *   environment"), but the two ecosystems draw the write line
-   *   differently. The rule used here: a call is a WRITE when it creates
-   *   a durable, user-addressable resource — an agent run reachable later
-   *   via `run_id`/`thread_id`, a chart card with public URLs. Metering
-   *   side effects do NOT flip the hint: every Tako tool, including pure
-   *   reads, debits a credit balance, so counting billing as a write
-   *   would make `readOnlyHint` vacuously false everywhere. Under the MCP
-   *   reading a queued agent run is ephemeral compute whose record is
-   *   bookkeeping (canonical stays `readOnlyHint: true`); Apps review
-   *   treats "enqueues background work on Tako's servers" as a write, so
-   *   the ChatGPT override flips it.
+   * `readOnlyHint` needs NO per-client override — its meaning is the
+   * same in both ecosystems ("does not modify its environment"), and the
+   * write line is drawn once, for every client: a call is a WRITE when
+   * it creates a durable, user-addressable resource — an agent run
+   * reachable later via `run_id`/`thread_id` (`tako_agent`,
+   * `tako_agent_start`), a chart card with public URLs
+   * (`tako_visualize`). Those tools declare canonical
+   * `readOnlyHint: false`. Metering side effects do NOT flip the hint:
+   * every Tako tool, including pure reads, debits a credit balance, so
+   * counting billing as a write would make `readOnlyHint` vacuously
+   * false everywhere.
    */
   annotationsByClient?: Partial<
     Record<McpClientKind, Partial<ToolAnnotations>>

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -274,6 +274,39 @@ export interface ToolModule<
   inputSchema: InputSchema;
   outputSchema?: z.ZodType<Output>;
   annotations: ToolAnnotations;
+  /**
+   * Optional per-client annotation overrides, merged over
+   * {@link annotations} for the matching client — the same resolution
+   * shape as {@link descriptionByClient} (see `toolAnnotationsForClient`
+   * in `_surface.ts`). The canonical `annotations` follow the MCP spec's
+   * readings and are what every other client (and the generated registry)
+   * sees.
+   *
+   * Exists because OpenAI's ChatGPT Apps review reads the hints
+   * differently from the MCP protocol:
+   *
+   * - `openWorldHint` — MCP: domain of interaction (web search is the
+   *   spec's canonical open-world example). Apps review: "does this call
+   *   publish or mutate publicly visible / third-party state?" Retrieval
+   *   tools are therefore open-world under MCP but closed-world under
+   *   Apps review, and `tako_visualize` (mints public chart URLs) is the
+   *   reverse.
+   * - `readOnlyHint` — nominally the same in both ("does not modify its
+   *   environment"), but the two ecosystems draw the write line
+   *   differently. The rule used here: a call is a WRITE when it creates
+   *   a durable, user-addressable resource — an agent run reachable later
+   *   via `run_id`/`thread_id`, a chart card with public URLs. Metering
+   *   side effects do NOT flip the hint: every Tako tool, including pure
+   *   reads, debits a credit balance, so counting billing as a write
+   *   would make `readOnlyHint` vacuously false everywhere. Under the MCP
+   *   reading a queued agent run is ephemeral compute whose record is
+   *   bookkeeping (canonical stays `readOnlyHint: true`); Apps review
+   *   treats "enqueues background work on Tako's servers" as a write, so
+   *   the ChatGPT override flips it.
+   */
+  annotationsByClient?: Partial<
+    Record<McpClientKind, Partial<ToolAnnotations>>
+  >;
   handler: (input: z.infer<InputSchema>, ctx: ToolContext) => Promise<Output>;
   /**
    * Optional hook to append extra MCP content blocks (image, audio, resource)
@@ -346,6 +379,10 @@ export interface AnyToolModule {
   inputSchema: z.ZodObject<z.ZodRawShape>;
   outputSchema?: z.ZodType<unknown>;
   annotations: ToolAnnotations;
+  /** Per-client annotation overrides — see {@link ToolModule.annotationsByClient}. */
+  annotationsByClient?: Partial<
+    Record<McpClientKind, Partial<ToolAnnotations>>
+  >;
   handler: (input: unknown, ctx: ToolContext) => Promise<unknown>;
   extraContentBlocks?: (
     output: unknown,


### PR DESCRIPTION
## Summary

- preserve the canonical MCP `openWorldHint` values for Claude and other MCP clients
- translate tool annotations only for ChatGPT descriptors using OpenAI Apps review semantics
- mark ChatGPT agent kickoff tools as write operations because they enqueue workflows
- add regression coverage for default and opt-in ChatGPT tool surfaces
- add `chatgpt-app-submission.json` with app metadata, five default tools, five positive tests, and three negative tests

## Why

The MCP protocol defines `openWorldHint` by domain of interaction and explicitly treats web search as open-world. OpenAI Apps review uses the hint as a public/external-state action label. Applying either interpretation globally makes the descriptors wrong for the other client family.

The adapter keeps the MCP-spec annotations as the source of truth and changes only the descriptors served to ChatGPT-class clients. This avoids degrading other MCP clients while making the production tool listing consistent with OpenAI's submission review expectations.

## Impact

ChatGPT sees retrieval tools as read-only, non-destructive, and closed-world, while `tako_visualize` is identified as a non-destructive write that creates publicly accessible chart URLs. Other clients and the generated MCP registry retain their existing annotations.

Optional agent and graph tools receive the same client-specific treatment if enabled, but the submission JSON covers only the five tools exposed by the default production MCP URL.

## Validation

- `npm run typecheck`
- `npm test` — 399 tests passed
- `npm run registry:check` — 12 tools synchronized
- submission JSON structure, subtitle length, tool count, and test-case counts validated with `jq`
- `git diff --check`
