### PR TITLE
feat: anonymous rate-limited free tier for /mcp

### DIFF
--- a/workers/README.md
+++ b/workers/README.md
@@ -45,16 +45,41 @@ Behavior when active:
 - Limiter runtime failures fail open (the shared account's Django-side
   limits are the spend backstop); missing configuration fails closed.
 
-Enabling on an environment:
+### Rollout checklist
 
-```bash
-# 1. Create/choose the free-tier Tako account, then:
-wrangler secret put FREE_TIER_API_KEY --env staging   # paste the API key
-wrangler secret put FREE_TIER_API_KEY --env production
-# 2. The FREE_TIER_RATE_LIMITER binding is already in wrangler.jsonc;
-#    deploy as usual. To change the limit, edit `simple.limit` there AND
-#    the FREE_TIER_LIMIT_MESSAGE copy in src/freetier.ts.
-```
+Setting the `FREE_TIER_API_KEY` secret is the on/off switch — until it is
+set on an environment, anonymous requests 401 exactly as before. There is
+nothing to configure in the Cloudflare dashboard: the rate limiter is
+config-as-code in `wrangler.jsonc` and deploys with the Worker.
+
+1. **Deploy the Worker** (normal deploy flow). The
+   `FREE_TIER_RATE_LIMITER` binding ships with it.
+2. **Create the dedicated free-tier Tako account** and generate its API
+   key from the account page. All anonymous traffic spends this one
+   account's credits.
+3. **Set Django-side limits/credits on that account.** This is the total
+   spend backstop: the Worker limiter fails *open* on limiter runtime
+   errors, so give the account a credit budget you can afford to lose.
+4. **Enable staging first:**
+   ```bash
+   wrangler secret put FREE_TIER_API_KEY --env staging   # paste the API key
+   ```
+5. **Verify on staging:** connect an MCP client to
+   `mcp.staging.tako.com/mcp` with no auth → `tools/list` shows exactly
+   the three free tools; make 11 `tools/call`s inside a minute → the
+   11th returns 429 with the upsell message.
+6. **Enable production** — after consciously accepting the operator
+   warning below:
+   ```bash
+   wrangler secret put FREE_TIER_API_KEY --env production
+   ```
+
+To change the per-IP limit later, edit `simple.limit` in **all three**
+`unsafe.bindings` blocks in `wrangler.jsonc` (dev/staging/production)
+AND the `FREE_TIER_LIMIT_MESSAGE` copy in `src/freetier.ts`, then
+redeploy. Counting is per-Cloudflare-colo and approximate (an IP whose
+traffic hits two colos can see roughly 2× the limit) — acceptable for
+abuse protection, not billing.
 
 **Operator warning:** OAuth-capable hosts (claude.ai and similar) decide
 whether to run their OAuth sign-in flow based on getting a 401 from the

--- a/workers/README.md
+++ b/workers/README.md
@@ -20,26 +20,47 @@ npm run dev
 
 `/mcp` requests with **no** `Authorization` header are served as a
 rate-limited free tier instead of a 401 — but only in environments that
-opt in. Two bindings gate it (fail-closed: with either missing, anonymous
+opt in. Three bindings gate it (fail-closed: with any missing, anonymous
 requests 401 exactly as before):
 
 | Binding | Kind | Purpose |
 |---|---|---|
-| `FREE_TIER_API_KEY` | secret | Tako API key of the dedicated free-tier account, forwarded to Django as `X-API-Key` |
-| `FREE_TIER_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | 10 metered requests / 60 s per client IP |
+| `FREE_TIER_API_KEY` | secret | Tako API key of the dedicated free-tier account, forwarded to Django as `X-API-Key` (trimmed, so a piped `wrangler secret put` newline can't break it) |
+| `FREE_TIER_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | per-IP fairness bucket: 10 free-tool `tools/call`s / 60 s |
+| `FREE_TIER_GLOBAL_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | global ceiling: 1000 anonymous requests / 60 s across ALL callers |
+
+The global ceiling is the actual spend/volume bound: per-IP keying means
+little for hosted MCP hosts (claude.ai, ChatGPT, and similar egress from
+a handful of platform IPs), and it also caps the otherwise-unmetered
+handshake methods. The per-IP bucket is the fairness layer on top.
 
 Behavior when active:
 
 - Anonymous connections see exactly three tools: `tako_available_data`,
   `tako_search`, `tako_answer`. Everything else is hidden.
-- Only `tools/call` is metered (per `CF-Connecting-IP`); `initialize` /
-  `tools/list` are always free. Over-limit calls get an HTTP 429 with an
-  upsell message pointing at https://trytako.com/account/. Each metered
-  request logs one line: `[free-tier] ip=<ip> allowed|limited`.
+- Every anonymous request counts against the global ceiling; the per-IP
+  bucket counts only `tools/call`s naming one of the three free tools
+  (the only requests that spend Tako credits). A `tools/call` for a
+  hidden tool returns "tool not found" without burning per-IP quota;
+  `initialize` / `tools/list` never burn it. IPv4 clients are keyed by
+  address, IPv6 by /64 prefix.
+- An over-limit free-tool call returns **HTTP 200 with a JSON-RPC tool
+  result** (`isError: true`) carrying the upsell message pointing at
+  https://trytako.com/account/ — deliberately not a 429, which MCP SDK
+  clients surface as a transport error the model never reads. The global
+  ceiling (which trips before the body is parsed) returns a plain 429.
+- If the shared account itself runs out of Tako credits (Django 402),
+  the tool result carries the same style of upsell copy instead of the
+  raw billing error.
+- Each per-IP-metered request logs one line:
+  `[free-tier] ip=<key> allowed|limited`.
 - JSON-RPC batch requests (array bodies) are rejected outright with an
   HTTP 400 — never metered, never forwarded to Django. Batching was
   removed from the MCP spec in 2025-06-18, and metering a batch as a
   single limiter hit would let it stand in for unlimited `tools/call`s.
+- Anonymous request bodies are capped at 128 KiB (HTTP 413 past that) —
+  the body peek is new unauthenticated surface and its read is bounded,
+  so a lying `Content-Length` doesn't help.
 - A malformed `Authorization` header still 401s — only a fully absent
   header selects the free tier.
 - Limiter runtime failures fail open (the shared account's Django-side
@@ -49,11 +70,12 @@ Behavior when active:
 
 Setting the `FREE_TIER_API_KEY` secret is the on/off switch — until it is
 set on an environment, anonymous requests 401 exactly as before. There is
-nothing to configure in the Cloudflare dashboard: the rate limiter is
-config-as-code in `wrangler.jsonc` and deploys with the Worker.
+nothing to configure in the Cloudflare dashboard: both rate limiters are
+config-as-code in `wrangler.jsonc` and deploy with the Worker.
 
 1. **Deploy the Worker** (normal deploy flow). The
-   `FREE_TIER_RATE_LIMITER` binding ships with it.
+   `FREE_TIER_RATE_LIMITER` and `FREE_TIER_GLOBAL_RATE_LIMITER` bindings
+   ship with it.
 2. **Create the dedicated free-tier Tako account** and generate its API
    key from the account page. All anonymous traffic spends this one
    account's credits.
@@ -66,20 +88,51 @@ config-as-code in `wrangler.jsonc` and deploys with the Worker.
    ```
 5. **Verify on staging:** connect an MCP client to
    `mcp.staging.tako.com/mcp` with no auth → `tools/list` shows exactly
-   the three free tools; make 11 `tools/call`s inside a minute → the
-   11th returns 429 with the upsell message.
+   the three free tools; make 11 free-tool `tools/call`s inside a minute
+   → the 11th returns a tool error carrying the upsell message.
 6. **Enable production** — after consciously accepting the operator
    warning below:
    ```bash
    wrangler secret put FREE_TIER_API_KEY --env production
    ```
 
-To change the per-IP limit later, edit `simple.limit` in **all three**
-`unsafe.bindings` blocks in `wrangler.jsonc` (dev/staging/production)
-AND the `FREE_TIER_LIMIT_MESSAGE` copy in `src/freetier.ts`, then
-redeploy. Counting is per-Cloudflare-colo and approximate (an IP whose
-traffic hits two colos can see roughly 2× the limit) — acceptable for
-abuse protection, not billing.
+**Kill switch (rollback):** deleting the secret instantly reverts the
+environment to the pre-free-tier behavior (anonymous → 401), no code
+change or redeploy needed:
+
+```bash
+wrangler secret delete FREE_TIER_API_KEY --env production
+```
+
+**Key rotation:** `wrangler secret put` over the top swaps what the
+Worker forwards, but the OLD key remains a valid full-privilege Tako API
+key until it is revoked/regenerated on the Tako account itself — do both.
+The three-tool restriction is Worker-side filtering, not an authorization
+boundary on the key, so treat the key's blast radius as the whole
+account.
+
+**Runbook — detecting fail-open:** the only signal that a limiter outage
+has the tier failing open is the Worker error log line. Check for it
+with:
+
+```bash
+wrangler tail tako-mcp-production --search "failing open"
+```
+
+Before production enablement, set up a Cloudflare Workers
+error-rate notification (Account → Notifications → Workers) so a
+sustained burst of these isn't something you discover by accident an
+hour later. The Django-side account cap (step 3) bounds the damage in
+the meantime.
+
+To change the limits later: the per-IP limit lives in the three
+`FREE_TIER_RATE_LIMITER` blocks in `wrangler.jsonc` AND in
+`FREE_TIER_LIMIT_MESSAGE` in `src/freetier.ts` (a drift test in
+`src/freetier.test.ts` fails if the message and bindings disagree); the
+global ceiling lives in the three `FREE_TIER_GLOBAL_RATE_LIMITER`
+blocks. Edit, then redeploy. Counting is per-Cloudflare-colo and
+approximate (an IP whose traffic hits two colos can see roughly 2× the
+limit) — acceptable for abuse protection, not billing.
 
 **Operator warning:** OAuth-capable hosts (claude.ai and similar) decide
 whether to run their OAuth sign-in flow based on getting a 401 from the

--- a/workers/README.md
+++ b/workers/README.md
@@ -34,7 +34,12 @@ Behavior when active:
   `tako_search`, `tako_answer`. Everything else is hidden.
 - Only `tools/call` is metered (per `CF-Connecting-IP`); `initialize` /
   `tools/list` are always free. Over-limit calls get an HTTP 429 with an
-  upsell message pointing at https://trytako.com/account/.
+  upsell message pointing at https://trytako.com/account/. Each metered
+  request logs one line: `[free-tier] ip=<ip> allowed|limited`.
+- JSON-RPC batch requests (array bodies) are rejected outright with an
+  HTTP 400 — never metered, never forwarded to Django. Batching was
+  removed from the MCP spec in 2025-06-18, and metering a batch as a
+  single limiter hit would let it stand in for unlimited `tools/call`s.
 - A malformed `Authorization` header still 401s — only a fully absent
   header selects the free tier.
 - Limiter runtime failures fail open (the shared account's Django-side
@@ -50,3 +55,13 @@ wrangler secret put FREE_TIER_API_KEY --env production
 #    deploy as usual. To change the limit, edit `simple.limit` there AND
 #    the FREE_TIER_LIMIT_MESSAGE copy in src/freetier.ts.
 ```
+
+**Operator warning:** OAuth-capable hosts (claude.ai and similar) decide
+whether to run their OAuth sign-in flow based on getting a 401 from the
+*first* request to `/mcp`. With the free tier active, that first request
+succeeds anonymously instead — so any newly added connector on such a
+host starts out running against the shared free-tier account (3 tools,
+shared quota) rather than prompting the user to sign in for their own
+account. Users must explicitly connect/re-authenticate to get off the
+anonymous tier. Consciously accept this onboarding change before setting
+`FREE_TIER_API_KEY` in production.

--- a/workers/README.md
+++ b/workers/README.md
@@ -15,3 +15,38 @@ npm test
 npm run typecheck
 npm run dev
 ```
+
+## Anonymous free tier
+
+`/mcp` requests with **no** `Authorization` header are served as a
+rate-limited free tier instead of a 401 — but only in environments that
+opt in. Two bindings gate it (fail-closed: with either missing, anonymous
+requests 401 exactly as before):
+
+| Binding | Kind | Purpose |
+|---|---|---|
+| `FREE_TIER_API_KEY` | secret | Tako API key of the dedicated free-tier account, forwarded to Django as `X-API-Key` |
+| `FREE_TIER_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | 10 metered requests / 60 s per client IP |
+
+Behavior when active:
+
+- Anonymous connections see exactly three tools: `tako_available_data`,
+  `tako_search`, `tako_answer`. Everything else is hidden.
+- Only `tools/call` is metered (per `CF-Connecting-IP`); `initialize` /
+  `tools/list` are always free. Over-limit calls get an HTTP 429 with an
+  upsell message pointing at https://trytako.com/account/.
+- A malformed `Authorization` header still 401s — only a fully absent
+  header selects the free tier.
+- Limiter runtime failures fail open (the shared account's Django-side
+  limits are the spend backstop); missing configuration fails closed.
+
+Enabling on an environment:
+
+```bash
+# 1. Create/choose the free-tier Tako account, then:
+wrangler secret put FREE_TIER_API_KEY --env staging   # paste the API key
+wrangler secret put FREE_TIER_API_KEY --env production
+# 2. The FREE_TIER_RATE_LIMITER binding is already in wrangler.jsonc;
+#    deploy as usual. To change the limit, edit `simple.limit` there AND
+#    the FREE_TIER_LIMIT_MESSAGE copy in src/freetier.ts.
+```

--- a/workers/README.md
+++ b/workers/README.md
@@ -27,12 +27,21 @@ requests 401 exactly as before):
 |---|---|---|
 | `FREE_TIER_API_KEY` | secret | Tako API key of the dedicated free-tier account, forwarded to Django as `X-API-Key` (trimmed, so a piped `wrangler secret put` newline can't break it) |
 | `FREE_TIER_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | per-IP fairness bucket: 10 free-tool `tools/call`s / 60 s |
-| `FREE_TIER_GLOBAL_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | global ceiling: 1000 anonymous requests / 60 s across ALL callers |
+| `FREE_TIER_GLOBAL_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | per-colo burst shaping: 1000 anonymous requests / 60 s / colo, all callers |
 
-The global ceiling is the actual spend/volume bound: per-IP keying means
-little for hosted MCP hosts (claude.ai, ChatGPT, and similar egress from
-a handful of platform IPs), and it also caps the otherwise-unmetered
-handshake methods. The per-IP bucket is the fairness layer on top.
+Neither Worker bucket is the platform-wide spend bound. Cloudflare's
+ratelimit binding counts per colo (no global mode), so the constant-key
+bucket enforces `1000/min × colos reached` — it exists to shape per-colo
+floods, including the otherwise-unmetered handshake methods. Per-IP
+keying means little for hosted MCP hosts (claude.ai, ChatGPT, and
+similar egress from a handful of platform IPs); it's a fairness layer.
+The **genuinely global ceiling is Django's Redis-backed per-user
+throttling on the free-tier account** — every anonymous request
+authenticates as that one user, landing on `_SEARCH_USER` (720/min,
+`/api/v3/search/`), `_DRF_USER` (720/min, `/api/v1/answer/`), and
+`_GRAPH_TIER` (180/min + 10,000/day, `/api/beta/graph/*`) in
+`app/backend/api/throttling/policy.py`. Note none of these weighs tool
+cost: the worst case is that many `tako_answer` calls.
 
 Behavior when active:
 
@@ -44,11 +53,12 @@ Behavior when active:
   hidden tool returns "tool not found" without burning per-IP quota;
   `initialize` / `tools/list` never burn it. IPv4 clients are keyed by
   address, IPv6 by /64 prefix.
-- An over-limit free-tool call returns **HTTP 200 with a JSON-RPC tool
-  result** (`isError: true`) carrying the upsell message pointing at
-  https://trytako.com/account/ — deliberately not a 429, which MCP SDK
-  clients surface as a transport error the model never reads. The global
-  ceiling (which trips before the body is parsed) returns a plain 429.
+- An over-limit `tools/call` (either bucket) returns **HTTP 200 with a
+  JSON-RPC tool result** (`isError: true`) carrying an upsell message
+  pointing at https://trytako.com/account/ — deliberately not a 429,
+  which MCP SDK clients surface as a transport error the model never
+  reads. Non-`tools/call` requests over the per-colo ceiling get a plain
+  429 (no valid readable shape exists for them).
 - If the shared account itself runs out of Tako credits (Django 402),
   the tool result carries the same style of upsell copy instead of the
   raw billing error.
@@ -79,9 +89,16 @@ config-as-code in `wrangler.jsonc` and deploy with the Worker.
 2. **Create the dedicated free-tier Tako account** and generate its API
    key from the account page. All anonymous traffic spends this one
    account's credits.
-3. **Set Django-side limits/credits on that account.** This is the total
-   spend backstop: the Worker limiter fails *open* on limiter runtime
-   errors, so give the account a credit budget you can afford to lose.
+3. **Put the account on a plan where the credit ceiling actually
+   enforces.** This is the total spend backstop (the Worker limiters
+   fail *open* on runtime errors and are per-colo anyway), and the
+   mechanism matters: Django's credit throttles (`_ANSWER_CREDIT`,
+   `_V3_CREDIT`, `_CONTENTS_CREDIT`) are **bypassed** for PAYG billing
+   (spend meters in USD forever and never 402s — unbounded dollars),
+   and for Enterprise/MPP accounts. So the free-tier account must be a
+   standard credit-capped plan with a budget you can afford to lose.
+   The per-user *rate* throttles (720/min search+answer, 180/min graph)
+   apply on every billing mode and are the floor either way.
 4. **Enable staging first:**
    ```bash
    wrangler secret put FREE_TIER_API_KEY --env staging   # paste the API key

--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -119,6 +119,17 @@ export interface Env {
    * fail-closed sense as `FREE_TIER_API_KEY`.
    */
   FREE_TIER_RATE_LIMITER?: RateLimit;
+  /**
+   * Cloudflare rate-limit binding for the GLOBAL anonymous ceiling —
+   * hit with one constant key for every anonymous request regardless of
+   * method, bounding total free-tier volume platform-wide (per-IP keying
+   * is meaningless for hosted MCP hosts whose traffic egresses from a few
+   * platform IPs). Declared under `unsafe.bindings` in `wrangler.jsonc`
+   * (1000 requests / 60 s). Optional in the same fail-closed sense as
+   * the other two free-tier bindings — all three must be present for the
+   * free tier to activate. See `freetier.ts`.
+   */
+  FREE_TIER_GLOBAL_RATE_LIMITER?: RateLimit;
 }
 
 /**

--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -120,14 +120,15 @@ export interface Env {
    */
   FREE_TIER_RATE_LIMITER?: RateLimit;
   /**
-   * Cloudflare rate-limit binding for the GLOBAL anonymous ceiling —
-   * hit with one constant key for every anonymous request regardless of
-   * method, bounding total free-tier volume platform-wide (per-IP keying
-   * is meaningless for hosted MCP hosts whose traffic egresses from a few
-   * platform IPs). Declared under `unsafe.bindings` in `wrangler.jsonc`
-   * (1000 requests / 60 s). Optional in the same fail-closed sense as
-   * the other two free-tier bindings — all three must be present for the
-   * free tier to activate. See `freetier.ts`.
+   * Cloudflare rate-limit binding hit with one constant key for every
+   * anonymous request regardless of method. PER-COLO burst shaping, not
+   * a true global ceiling — the binding counts per colo with no global
+   * mode, so the enforced number is `limit × colos reached`; the genuine
+   * platform-wide bound is Django's per-user throttling on the free-tier
+   * account (see `freetier.ts` module header). Declared under
+   * `unsafe.bindings` in `wrangler.jsonc` (1000 requests / 60 s / colo).
+   * Optional in the same fail-closed sense as the other two free-tier
+   * bindings — all three must be present for the free tier to activate.
    */
   FREE_TIER_GLOBAL_RATE_LIMITER?: RateLimit;
 }

--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -6,6 +6,20 @@
  * `django.ts`, `index.ts`, `mcp.ts`) can import it without creating
  * circular dependencies.
  */
+
+/**
+ * Structural type of Cloudflare's Workers rate-limiting binding
+ * (`unsafe.bindings` entries with `type: "ratelimit"` in `wrangler.jsonc`).
+ * Declared locally instead of relying on `@cloudflare/workers-types` so the
+ * shape is pinned to exactly what we call and tests can supply fakes.
+ * `limit()` counts one hit against `key`'s bucket and reports whether the
+ * request is within the configured limit. Counting is per-colo and
+ * approximate — acceptable for free-tier abuse protection, not billing.
+ */
+export interface RateLimit {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
 export interface Env {
   /**
    * Origin of the Django backend the Worker proxies to — e.g.
@@ -89,6 +103,22 @@ export interface Env {
    * for a connector that was never registered against them.
    */
   OPENAI_APPS_CHALLENGE_TOKEN?: string;
+  /**
+   * Tako API key of the dedicated free-tier account, forwarded to Django
+   * as `X-API-Key` for anonymous (no `Authorization` header) `/mcp`
+   * requests. A Worker secret (`wrangler secret put FREE_TIER_API_KEY
+   * --env <env>`). Optional and fail-closed: when unset (or when
+   * `FREE_TIER_RATE_LIMITER` is unbound), anonymous requests get the
+   * same 401 as before the free tier existed. See `freetier.ts`.
+   */
+  FREE_TIER_API_KEY?: string;
+  /**
+   * Cloudflare rate-limit binding metering anonymous free-tier usage,
+   * keyed per client IP. Declared under `unsafe.bindings` in
+   * `wrangler.jsonc` (10 requests / 60 s). Optional in the same
+   * fail-closed sense as `FREE_TIER_API_KEY`.
+   */
+  FREE_TIER_RATE_LIMITER?: RateLimit;
 }
 
 /**

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -1,14 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import wranglerRaw from "../wrangler.jsonc?raw";
 import type { Env, RateLimit } from "./env.js";
 import {
   checkFreeTierRateLimit,
   FREE_TIER_BATCH_MESSAGE,
+  FREE_TIER_CREDITS_MESSAGE,
+  FREE_TIER_GLOBAL_LIMIT_MESSAGE,
   FREE_TIER_LIMIT_MESSAGE,
   FREE_TIER_TOOL_NAMES,
+  type FreeTierConfig,
   freeTierBatchResponse,
+  freeTierGlobalLimitResponse,
   freeTierLimitResponse,
+  freeTierRateLimitKey,
+  freeTierTooLargeResponse,
   isMeteredJsonRpcBody,
+  MAX_FREE_TIER_BODY_BYTES,
   resolveFreeTierConfig,
 } from "./freetier.js";
 import worker from "./index.js";
@@ -23,6 +31,25 @@ function fakeLimiter(success: boolean): RateLimit & { keys: string[] } {
       keys.push(key);
       return { success };
     },
+  };
+}
+
+/** A limiter whose `limit()` always throws — the fail-open path. */
+function throwingLimiter(): RateLimit {
+  return {
+    async limit() {
+      throw new Error("limiter unavailable");
+    },
+  };
+}
+
+/** Assemble a `FreeTierConfig` with sane defaults for unit tests. */
+function makeConfig(overrides: Partial<FreeTierConfig> = {}): FreeTierConfig {
+  return {
+    apiKey: "free-key",
+    limiter: fakeLimiter(true),
+    globalLimiter: fakeLimiter(true),
+    ...overrides,
   };
 }
 
@@ -53,48 +80,105 @@ describe("FREE_TIER_TOOL_NAMES", () => {
 
 describe("resolveFreeTierConfig", () => {
   const limiter = fakeLimiter(true);
+  const globalLimiter = fakeLimiter(true);
 
-  it("returns the config when both bindings are present", () => {
+  it("returns the config when all three bindings are present", () => {
     const env = {
       DJANGO_BASE_URL: "http://localhost:8000",
       FREE_TIER_API_KEY: "free-key",
       FREE_TIER_RATE_LIMITER: limiter,
+      FREE_TIER_GLOBAL_RATE_LIMITER: globalLimiter,
     } as Env;
     expect(resolveFreeTierConfig(env)).toEqual({
       apiKey: "free-key",
       limiter,
+      globalLimiter,
     });
   });
 
-  it("returns null when the API key is missing or empty (fail-closed)", () => {
-    expect(
-      resolveFreeTierConfig({
-        DJANGO_BASE_URL: "http://localhost:8000",
-        FREE_TIER_RATE_LIMITER: limiter,
-      } as Env),
-    ).toBeNull();
-    expect(
-      resolveFreeTierConfig({
-        DJANGO_BASE_URL: "http://localhost:8000",
-        FREE_TIER_API_KEY: "",
-        FREE_TIER_RATE_LIMITER: limiter,
-      } as Env),
-    ).toBeNull();
+  it("trims the API key — a piped `wrangler secret put` adds a trailing newline", () => {
+    const env = {
+      DJANGO_BASE_URL: "http://localhost:8000",
+      FREE_TIER_API_KEY: "  free-key\n",
+      FREE_TIER_RATE_LIMITER: limiter,
+      FREE_TIER_GLOBAL_RATE_LIMITER: globalLimiter,
+    } as Env;
+    expect(resolveFreeTierConfig(env)?.apiKey).toBe("free-key");
   });
 
-  it("returns null when the limiter binding is missing (fail-closed)", () => {
+  it("returns null when the API key is missing, empty, or whitespace-only (fail-closed)", () => {
+    for (const key of [undefined, "", "  \n"]) {
+      expect(
+        resolveFreeTierConfig({
+          DJANGO_BASE_URL: "http://localhost:8000",
+          ...(key !== undefined ? { FREE_TIER_API_KEY: key } : {}),
+          FREE_TIER_RATE_LIMITER: limiter,
+          FREE_TIER_GLOBAL_RATE_LIMITER: globalLimiter,
+        } as Env),
+      ).toBeNull();
+    }
+  });
+
+  it("returns null when the per-IP limiter binding is missing (fail-closed)", () => {
     expect(
       resolveFreeTierConfig({
         DJANGO_BASE_URL: "http://localhost:8000",
         FREE_TIER_API_KEY: "free-key",
+        FREE_TIER_GLOBAL_RATE_LIMITER: globalLimiter,
+      } as Env),
+    ).toBeNull();
+  });
+
+  it("returns null when the global limiter binding is missing (fail-closed)", () => {
+    expect(
+      resolveFreeTierConfig({
+        DJANGO_BASE_URL: "http://localhost:8000",
+        FREE_TIER_API_KEY: "free-key",
+        FREE_TIER_RATE_LIMITER: limiter,
       } as Env),
     ).toBeNull();
   });
 });
 
 describe("isMeteredJsonRpcBody", () => {
-  it("meters tools/call", () => {
-    expect(isMeteredJsonRpcBody(TOOLS_CALL_BODY)).toBe(true);
+  it("meters a tools/call naming each free tool", () => {
+    for (const name of FREE_TIER_TOOL_NAMES) {
+      expect(
+        isMeteredJsonRpcBody({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: {} },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("does not meter a tools/call for a hidden tool (returns 'tool not found' without spend)", () => {
+    for (const name of ["tako_agent", "get_credit_balance", "no_such_tool"]) {
+      expect(
+        isMeteredJsonRpcBody({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name, arguments: {} },
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does not meter a tools/call with missing or malformed params", () => {
+    expect(
+      isMeteredJsonRpcBody({ jsonrpc: "2.0", id: 1, method: "tools/call" }),
+    ).toBe(false);
+    expect(
+      isMeteredJsonRpcBody({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: 42 },
+      }),
+    ).toBe(false);
   });
 
   it("does not meter the handshake and listing methods", () => {
@@ -117,100 +201,286 @@ describe("isMeteredJsonRpcBody", () => {
   });
 });
 
+describe("freeTierRateLimitKey", () => {
+  it("uses the shared 'unknown' bucket when the header is absent", () => {
+    expect(freeTierRateLimitKey(null)).toBe("unknown");
+  });
+
+  it("keys IPv4 addresses verbatim", () => {
+    expect(freeTierRateLimitKey("203.0.113.7")).toBe("203.0.113.7");
+  });
+
+  it("keys IPv6 addresses by /64 prefix — one subscriber, one bucket", () => {
+    expect(freeTierRateLimitKey("2001:db8:1:2:3:4:5:6")).toBe("v6:2001:db8:1:2");
+    // `::` expansion: 2001:db8::1 is 2001:db8:0:0:0:0:0:1 → /64 = 2001:db8:0:0.
+    expect(freeTierRateLimitKey("2001:db8::1")).toBe("v6:2001:db8:0:0");
+    // Two hosts in the same /64 share a bucket…
+    expect(freeTierRateLimitKey("2001:db8:1:2:aaaa::1")).toBe(
+      freeTierRateLimitKey("2001:db8:1:2:bbbb::2"),
+    );
+    // …two different /64s do not.
+    expect(freeTierRateLimitKey("2001:db8:1:2::1")).not.toBe(
+      freeTierRateLimitKey("2001:db8:1:3::1"),
+    );
+  });
+});
+
 describe("checkFreeTierRateLimit", () => {
-  it("counts a tools/call against the CF-Connecting-IP key and allows under-limit", async () => {
-    const limiter = fakeLimiter(true);
-    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
-    expect(limiter.keys).toEqual(["203.0.113.7"]);
-  });
-
-  it("returns limited when the bucket is exhausted", async () => {
-    const limiter = fakeLimiter(false);
-    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("limited");
-  });
-
-  it("never calls the limiter for unmetered methods", async () => {
-    const limiter = fakeLimiter(false); // would report limited if consulted
+  it("hits the global ceiling for EVERY request, even unmetered methods", async () => {
+    const config = makeConfig();
     const req = mcpRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
-    expect(limiter.keys).toEqual([]);
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "allowed",
+    });
+    expect((config.globalLimiter as ReturnType<typeof fakeLimiter>).keys).toEqual([
+      "global",
+    ]);
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
+  });
+
+  it("returns global_limited when the ceiling is exhausted, before per-IP metering", async () => {
+    const config = makeConfig({ globalLimiter: fakeLimiter(false) });
+    const req = mcpRequest(TOOLS_CALL_BODY);
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "global_limited",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
+  });
+
+  it("counts a free-tool tools/call against the CF-Connecting-IP key and allows under-limit", async () => {
+    const config = makeConfig();
+    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "allowed",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([
+      "203.0.113.7",
+    ]);
+  });
+
+  it("returns limited with the request id when the per-IP bucket is exhausted", async () => {
+    const config = makeConfig({ limiter: fakeLimiter(false) });
+    const req = mcpRequest(
+      { ...TOOLS_CALL_BODY, id: "req-9" },
+      { "cf-connecting-ip": "203.0.113.7" },
+    );
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "limited",
+      requestId: "req-9",
+    });
+  });
+
+  it("degrades the request id to null when it is missing or malformed", async () => {
+    const config = makeConfig({ limiter: fakeLimiter(false) });
+    const { id: _dropped, ...noIdBody } = TOOLS_CALL_BODY;
+    const req = mcpRequest(noIdBody);
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "limited",
+      requestId: null,
+    });
+  });
+
+  it("never consults the per-IP limiter for a hidden-tool tools/call (still counts globally)", async () => {
+    const config = makeConfig({ limiter: fakeLimiter(false) }); // would report limited if consulted
+    const req = mcpRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "tako_agent", arguments: {} },
+    });
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "allowed",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
+    expect((config.globalLimiter as ReturnType<typeof fakeLimiter>).keys).toEqual([
+      "global",
+    ]);
+  });
+
+  it("keys IPv6 clients by /64 prefix", async () => {
+    const config = makeConfig();
+    const req = mcpRequest(TOOLS_CALL_BODY, {
+      "cf-connecting-ip": "2001:db8:1:2:3:4:5:6",
+    });
+    await checkFreeTierRateLimit(req, config);
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([
+      "v6:2001:db8:1:2",
+    ]);
   });
 
   it("falls back to the shared 'unknown' key without CF-Connecting-IP", async () => {
-    const limiter = fakeLimiter(true);
-    await checkFreeTierRateLimit(mcpRequest(TOOLS_CALL_BODY), limiter);
-    expect(limiter.keys).toEqual(["unknown"]);
+    const config = makeConfig();
+    await checkFreeTierRateLimit(mcpRequest(TOOLS_CALL_BODY), config);
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([
+      "unknown",
+    ]);
   });
 
   it("does not consume the request body (the transport still needs it)", async () => {
-    const limiter = fakeLimiter(true);
+    const config = makeConfig();
     const req = mcpRequest(TOOLS_CALL_BODY);
-    await checkFreeTierRateLimit(req, limiter);
+    await checkFreeTierRateLimit(req, config);
     // The original body must remain readable after the peek.
     await expect(req.json()).resolves.toMatchObject({ method: "tools/call" });
   });
 
-  it("allows (does not meter) an unparseable body — the SDK will reject it anyway", async () => {
-    const limiter = fakeLimiter(false);
+  it("allows (does not meter per-IP) an unparseable body — the SDK will reject it anyway", async () => {
+    const config = makeConfig({ limiter: fakeLimiter(false) });
     const req = new Request("https://example.com/mcp", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: "not json{",
     });
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
-    expect(limiter.keys).toEqual([]);
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "allowed",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
   });
 
-  it("rejects a batch array as 'batch' without calling the limiter, even when it contains a tools/call", async () => {
-    const limiter = fakeLimiter(true); // would allow if (wrongly) consulted
-    const req = mcpRequest([{ jsonrpc: "2.0", id: 1, method: "tools/list" }, TOOLS_CALL_BODY]);
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("batch");
-    expect(limiter.keys).toEqual([]);
+  it("rejects a batch array as 'batch' without per-IP metering, even when it contains a tools/call", async () => {
+    const config = makeConfig();
+    const req = mcpRequest([
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      TOOLS_CALL_BODY,
+    ]);
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "batch",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
   });
 
-  it("rejects a batch array as 'batch' without calling the limiter, even without a tools/call", async () => {
-    const limiter = fakeLimiter(true);
+  it("rejects a batch array as 'batch' even without a tools/call", async () => {
+    const config = makeConfig();
     const req = mcpRequest([{ jsonrpc: "2.0", id: 1, method: "tools/list" }]);
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("batch");
-    expect(limiter.keys).toEqual([]);
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "batch",
+    });
   });
 
-  it("fails open and logs when the limiter binding throws", async () => {
+  it("rejects a declared Content-Length over the cap before reading the body", async () => {
+    const config = makeConfig();
+    const req = mcpRequest(TOOLS_CALL_BODY, {
+      "content-length": String(MAX_FREE_TIER_BODY_BYTES + 1),
+    });
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "too_large",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
+  });
+
+  it("rejects an actually-oversized body via the bounded read (Content-Length can lie)", async () => {
+    const config = makeConfig();
+    // A real body over the cap; the header (if any) is not what stops it.
+    const bigQuery = "x".repeat(MAX_FREE_TIER_BODY_BYTES + 1024);
+    const req = new Request("https://example.com/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...TOOLS_CALL_BODY,
+        params: { name: "tako_answer", arguments: { query: bigQuery } },
+      }),
+    });
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "too_large",
+    });
+    expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
+  });
+
+  it("fails open and logs when the per-IP limiter binding throws", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const limiter: RateLimit = {
-      async limit() {
-        throw new Error("limiter unavailable");
-      },
-    };
-    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
-    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
-    expect(errSpy).toHaveBeenCalledOnce();
-    expect(String(errSpy.mock.calls[0]?.[0])).toContain("[free-tier]");
-    errSpy.mockRestore();
+    try {
+      const config = makeConfig({ limiter: throwingLimiter() });
+      const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
+      await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+        kind: "allowed",
+      });
+      expect(errSpy).toHaveBeenCalledOnce();
+      expect(String(errSpy.mock.calls[0]?.[0])).toContain("failing open");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("fails open and logs when the global limiter binding throws", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const config = makeConfig({ globalLimiter: throwingLimiter() });
+      const req = mcpRequest(TOOLS_CALL_BODY);
+      await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+        kind: "allowed",
+      });
+      expect(errSpy).toHaveBeenCalledOnce();
+      expect(String(errSpy.mock.calls[0]?.[0])).toContain("failing open");
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 });
 
 describe("freeTierLimitResponse", () => {
-  it("is a 429 JSON-RPC error with the upsell message and Retry-After", async () => {
-    const res = freeTierLimitResponse();
-    expect(res.status).toBe(429);
-    expect(res.headers.get("retry-after")).toBe("60");
-    expect(res.headers.get("content-type")).toBe(
-      "application/json; charset=utf-8",
-    );
+  it("with a request id: HTTP 200 JSON-RPC RESULT carrying the upsell as a tool error", async () => {
+    // Deliberately not a 429 — the SDK client throws on non-2xx POSTs at
+    // the transport layer, so a 429 body never reaches the model. As a
+    // tool result the host feeds the text straight to the model.
+    const res = freeTierLimitResponse(4);
+    expect(res.status).toBe(200);
     const body = (await res.json()) as {
       jsonrpc: string;
+      id: number;
+      result: { content: Array<{ type: string; text: string }>; isError: boolean };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBe(4);
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content).toEqual([
+      { type: "text", text: FREE_TIER_LIMIT_MESSAGE },
+    ]);
+    expect(FREE_TIER_LIMIT_MESSAGE).toContain("https://trytako.com/account/");
+  });
+
+  it("without a request id: degrades to the legacy 429 with Retry-After", async () => {
+    const res = freeTierLimitResponse(null);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("60");
+    const body = (await res.json()) as {
       id: null;
       error: { code: number; message: string; data: { kind: string } };
     };
-    expect(body.jsonrpc).toBe("2.0");
     expect(body.id).toBeNull();
     expect(body.error.code).toBe(-32000);
     expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
     expect(body.error.data.kind).toBe("rate_limited");
-    expect(body.error.message).toContain("https://trytako.com/account/");
+  });
+});
+
+describe("freeTierGlobalLimitResponse", () => {
+  it("is a 429 JSON-RPC error with the capacity message and Retry-After", async () => {
+    const res = freeTierGlobalLimitResponse();
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("60");
+    const body = (await res.json()) as {
+      id: null;
+      error: { code: number; message: string; data: { kind: string } };
+    };
+    expect(body.id).toBeNull();
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toBe(FREE_TIER_GLOBAL_LIMIT_MESSAGE);
+    expect(body.error.data.kind).toBe("global_rate_limited");
+  });
+});
+
+describe("freeTierTooLargeResponse", () => {
+  it("is a 413 JSON-RPC error naming the byte cap", async () => {
+    const res = freeTierTooLargeResponse();
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as {
+      id: null;
+      error: { code: number; message: string; data: { kind: string } };
+    };
+    expect(body.id).toBeNull();
+    expect(body.error.code).toBe(-32600);
+    expect(body.error.data.kind).toBe("payload_too_large");
+    expect(body.error.message).toContain(String(MAX_FREE_TIER_BODY_BYTES));
   });
 });
 
@@ -239,17 +509,51 @@ describe("freeTierBatchResponse", () => {
   });
 });
 
+describe("wrangler.jsonc ↔ message drift", () => {
+  // The limit numbers live in `unsafe.bindings` blocks (one per env) AND
+  // in the user-facing messages. This test is the sync mechanism the
+  // README promises: the upsell can never advertise a number the limiter
+  // does not enforce.
+  function bindingLimits(name: string): number[] {
+    const re = new RegExp(
+      `"name":\\s*"${name}"[\\s\\S]*?"limit":\\s*(\\d+)`,
+      "g",
+    );
+    return [...wranglerRaw.matchAll(re)].map((m) => Number(m[1]));
+  }
+
+  it("per-IP binding limits match the number in FREE_TIER_LIMIT_MESSAGE (all 3 envs)", () => {
+    const limits = bindingLimits("FREE_TIER_RATE_LIMITER");
+    expect(limits).toHaveLength(3);
+    const advertised = FREE_TIER_LIMIT_MESSAGE.match(/\((\d+) requests\/min\)/);
+    expect(advertised).not.toBeNull();
+    for (const limit of limits) {
+      expect(limit).toBe(Number(advertised![1]));
+    }
+  });
+
+  it("global binding limits agree across all 3 envs", () => {
+    const limits = bindingLimits("FREE_TIER_GLOBAL_RATE_LIMITER");
+    expect(limits).toHaveLength(3);
+    expect(new Set(limits).size).toBe(1);
+  });
+});
+
 describe("free tier end-to-end (worker.fetch with stub env)", () => {
   const JSON_HEADERS = {
     "content-type": "application/json",
     accept: "application/json, text/event-stream",
   };
 
-  function freeEnv(limiter: RateLimit): Env {
+  function freeEnv(
+    limiter: RateLimit,
+    globalLimiter: RateLimit = fakeLimiter(true),
+  ): Env {
     return {
       DJANGO_BASE_URL: "http://localhost:8000",
       FREE_TIER_API_KEY: "free-tier-secret-key",
       FREE_TIER_RATE_LIMITER: limiter,
+      FREE_TIER_GLOBAL_RATE_LIMITER: globalLimiter,
     } as Env;
   }
 
@@ -275,24 +579,35 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     },
   };
   const TOOLS_LIST_BODY = { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} };
+  const ANSWER_CALL_BODY = {
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "tako_answer", arguments: { query: "US GDP" } },
+  };
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("anonymous initialize succeeds without metering", async () => {
-    const limiter = fakeLimiter(false); // would 429 if (wrongly) consulted
-    const res = await worker.fetch(post(INITIALIZE_BODY), freeEnv(limiter));
+  it("anonymous initialize succeeds without per-IP metering (global counts it)", async () => {
+    const limiter = fakeLimiter(false); // would limit if (wrongly) consulted
+    const globalLimiter = fakeLimiter(true);
+    const res = await worker.fetch(
+      post(INITIALIZE_BODY),
+      freeEnv(limiter, globalLimiter),
+    );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       result: { serverInfo: { name: string } };
     };
     expect(body.result.serverInfo.name).toBe("tako-mcp");
     expect(limiter.keys).toEqual([]);
+    expect(globalLimiter.keys).toEqual(["global"]);
   });
 
-  it("anonymous tools/list shows exactly the three free tools, unmetered", async () => {
+  it("anonymous tools/list shows exactly the three free tools, unmetered per-IP", async () => {
     const limiter = fakeLimiter(false);
     const res = await worker.fetch(post(TOOLS_LIST_BODY), freeEnv(limiter));
     expect(res.status).toBe(200);
@@ -307,7 +622,7 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(limiter.keys).toEqual([]);
   });
 
-  it("anonymous tools/call forwards FREE_TIER_API_KEY to Django and meters the IP", async () => {
+  it("anonymous tools/call forwards the TRIMMED FREE_TIER_API_KEY to Django and meters the IP", async () => {
     const limiter = fakeLimiter(true);
     // tako_answer POSTs /api/v1/answer/ once; the handler's response
     // handling is irrelevant here — the assertion is the outgoing header.
@@ -317,17 +632,12 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
         headers: { "content-type": "application/json" },
       }),
     ]);
+    const env = freeEnv(limiter);
+    (env as { FREE_TIER_API_KEY?: string }).FREE_TIER_API_KEY =
+      "free-tier-secret-key\n";
     const res = await worker.fetch(
-      post(
-        {
-          jsonrpc: "2.0",
-          id: 3,
-          method: "tools/call",
-          params: { name: "tako_answer", arguments: { query: "US GDP" } },
-        },
-        { "cf-connecting-ip": "203.0.113.7" },
-      ),
-      freeEnv(limiter),
+      post(ANSWER_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" }),
+      env,
     );
     expect(res.status).toBe(200);
     expect(limiter.keys).toEqual(["203.0.113.7"]);
@@ -336,36 +646,54 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(outbound.headers.get("x-api-key")).toBe("free-tier-secret-key");
   });
 
-  it("an over-limit anonymous tools/call gets the 429 upsell", async () => {
+  it("an over-limit anonymous tools/call gets a 200 TOOL ERROR the model can read", async () => {
     const limiter = fakeLimiter(false);
     const res = await worker.fetch(
-      post(
-        {
-          jsonrpc: "2.0",
-          id: 4,
-          method: "tools/call",
-          params: { name: "tako_answer", arguments: { query: "US GDP" } },
-        },
-        { "cf-connecting-ip": "203.0.113.7" },
-      ),
+      post(ANSWER_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" }),
       freeEnv(limiter),
+    );
+    // Not a 429: the SDK client throws on non-2xx, so the upsell would
+    // never reach the model. A JSON-RPC result with isError does.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: number;
+      result: { content: Array<{ type: string; text: string }>; isError: boolean };
+    };
+    expect(body.id).toBe(ANSWER_CALL_BODY.id);
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).toBe(FREE_TIER_LIMIT_MESSAGE);
+  });
+
+  it("an anonymous request over the global ceiling gets the capacity 429", async () => {
+    const limiter = fakeLimiter(true);
+    const res = await worker.fetch(
+      post(TOOLS_LIST_BODY),
+      freeEnv(limiter, fakeLimiter(false)),
     );
     expect(res.status).toBe(429);
     const body = (await res.json()) as { error: { message: string } };
-    expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
+    expect(body.error.message).toBe(FREE_TIER_GLOBAL_LIMIT_MESSAGE);
+    expect(limiter.keys).toEqual([]);
   });
 
-  it("an anonymous batch request gets a 400, never hits the limiter or Django", async () => {
+  it("an oversized anonymous body gets a 413 without reaching Django", async () => {
+    const fetchMock = mockFetchSequence([]);
+    const res = await worker.fetch(
+      post(ANSWER_CALL_BODY, {
+        "content-length": String(MAX_FREE_TIER_BODY_BYTES + 1),
+      }),
+      freeEnv(fakeLimiter(true)),
+    );
+    expect(res.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("an anonymous batch request gets a 400, never hits the per-IP limiter or Django", async () => {
     const limiter = fakeLimiter(true); // would allow if (wrongly) consulted
     const fetchMock = mockFetchSequence([]);
     const res = await worker.fetch(
       post([
-        {
-          jsonrpc: "2.0",
-          id: 6,
-          method: "tools/call",
-          params: { name: "tako_answer", arguments: { query: "US GDP" } },
-        },
+        ANSWER_CALL_BODY,
         {
           jsonrpc: "2.0",
           id: 7,
@@ -380,6 +708,62 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(body.error.message).toBe(FREE_TIER_BATCH_MESSAGE);
     expect(limiter.keys).toEqual([]);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("an anonymous call to a hidden tool does not burn per-IP quota", async () => {
+    const limiter = fakeLimiter(false); // would 429 the call if consulted
+    const res = await worker.fetch(
+      post({
+        jsonrpc: "2.0",
+        id: 8,
+        method: "tools/call",
+        params: { name: "tako_agent", arguments: { query: "x" } },
+      }),
+      freeEnv(limiter),
+    );
+    // The SDK answers "tool not found" itself (the tool is unregistered
+    // on the free tier); the per-IP bucket is untouched.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown;
+    expect(JSON.stringify(body)).toMatch(/not found/i);
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("free-tier credit exhaustion (Django 402) surfaces as the upsell, not a billing error", async () => {
+    const limiter = fakeLimiter(true);
+    mockFetchSequence([
+      new Response(JSON.stringify({ error_type: "PAYMENT_REQUIRED" }), {
+        status: 402,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    const res = await worker.fetch(post(ANSWER_CALL_BODY), freeEnv(limiter));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).toBe(FREE_TIER_CREDITS_MESSAGE);
+  });
+
+  it("authenticated credit exhaustion keeps the real Django error (no upsell substitution)", async () => {
+    mockFetchSequence([
+      new Response(JSON.stringify({ error_type: "PAYMENT_REQUIRED" }), {
+        status: 402,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    const res = await worker.fetch(
+      post(ANSWER_CALL_BODY, { authorization: "Bearer real-user-token" }),
+      freeEnv(fakeLimiter(true)),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).not.toBe(FREE_TIER_CREDITS_MESSAGE);
+    expect(body.result.content[0]?.text).toContain("402");
   });
 
   it("a malformed Authorization header still 401s even with the free tier configured", async () => {
@@ -398,6 +782,7 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     const env = {
       DJANGO_BASE_URL: "http://localhost:8000",
       FREE_TIER_RATE_LIMITER: fakeLimiter(true),
+      FREE_TIER_GLOBAL_RATE_LIMITER: fakeLimiter(true),
     } as Env;
     const res = await worker.fetch(post(INITIALIZE_BODY), env);
     expect(res.status).toBe(401);
@@ -406,11 +791,22 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(body.error.data.kind).toBe("missing");
   });
 
-  it("authenticated requests bypass the limiter and keep the full toolset", async () => {
+  it("without the global limiter binding, anonymous requests 401 (fail-closed)", async () => {
+    const env = {
+      DJANGO_BASE_URL: "http://localhost:8000",
+      FREE_TIER_API_KEY: "free-tier-secret-key",
+      FREE_TIER_RATE_LIMITER: fakeLimiter(true),
+    } as Env;
+    const res = await worker.fetch(post(INITIALIZE_BODY), env);
+    expect(res.status).toBe(401);
+  });
+
+  it("authenticated requests bypass both limiters and keep the full toolset", async () => {
     const limiter = fakeLimiter(false); // would 429 / restrict if consulted
+    const globalLimiter = fakeLimiter(false);
     const res = await worker.fetch(
       post(TOOLS_LIST_BODY, { authorization: "Bearer real-user-token" }),
-      freeEnv(limiter),
+      freeEnv(limiter, globalLimiter),
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -423,15 +819,11 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
       "tako_search",
     ]);
     expect(limiter.keys).toEqual([]);
+    expect(globalLimiter.keys).toEqual([]);
   });
 
   it("a limiter runtime failure fails open — the anonymous call still succeeds", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    const limiter: RateLimit = {
-      async limit() {
-        throw new Error("limiter unavailable");
-      },
-    };
     mockFetchSequence([
       new Response(JSON.stringify({}), {
         status: 200,
@@ -439,13 +831,8 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
       }),
     ]);
     const res = await worker.fetch(
-      post({
-        jsonrpc: "2.0",
-        id: 5,
-        method: "tools/call",
-        params: { name: "tako_answer", arguments: { query: "US GDP" } },
-      }),
-      freeEnv(limiter),
+      post(ANSWER_CALL_BODY),
+      freeEnv(throwingLimiter(), throwingLimiter()),
     );
     expect(res.status).toBe(200);
   });

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Env, RateLimit } from "./env.js";
+import {
+  checkFreeTierRateLimit,
+  FREE_TIER_LIMIT_MESSAGE,
+  FREE_TIER_TOOL_NAMES,
+  freeTierLimitResponse,
+  isMeteredJsonRpcBody,
+  resolveFreeTierConfig,
+} from "./freetier.js";
+
+/** A fake limiter that records keys and returns a scripted success value. */
+function fakeLimiter(success: boolean): RateLimit & { keys: string[] } {
+  const keys: string[] = [];
+  return {
+    keys,
+    async limit({ key }: { key: string }) {
+      keys.push(key);
+      return { success };
+    },
+  };
+}
+
+function mcpRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("https://example.com/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const TOOLS_CALL_BODY = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "tools/call",
+  params: { name: "tako_answer", arguments: { query: "US GDP" } },
+};
+
+describe("FREE_TIER_TOOL_NAMES", () => {
+  it("is exactly the three approved free tools", () => {
+    expect([...FREE_TIER_TOOL_NAMES].sort()).toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_search",
+    ]);
+  });
+});
+
+describe("resolveFreeTierConfig", () => {
+  const limiter = fakeLimiter(true);
+
+  it("returns the config when both bindings are present", () => {
+    const env = {
+      DJANGO_BASE_URL: "http://localhost:8000",
+      FREE_TIER_API_KEY: "free-key",
+      FREE_TIER_RATE_LIMITER: limiter,
+    } as Env;
+    expect(resolveFreeTierConfig(env)).toEqual({
+      apiKey: "free-key",
+      limiter,
+    });
+  });
+
+  it("returns null when the API key is missing or empty (fail-closed)", () => {
+    expect(
+      resolveFreeTierConfig({
+        DJANGO_BASE_URL: "http://localhost:8000",
+        FREE_TIER_RATE_LIMITER: limiter,
+      } as Env),
+    ).toBeNull();
+    expect(
+      resolveFreeTierConfig({
+        DJANGO_BASE_URL: "http://localhost:8000",
+        FREE_TIER_API_KEY: "",
+        FREE_TIER_RATE_LIMITER: limiter,
+      } as Env),
+    ).toBeNull();
+  });
+
+  it("returns null when the limiter binding is missing (fail-closed)", () => {
+    expect(
+      resolveFreeTierConfig({
+        DJANGO_BASE_URL: "http://localhost:8000",
+        FREE_TIER_API_KEY: "free-key",
+      } as Env),
+    ).toBeNull();
+  });
+});
+
+describe("isMeteredJsonRpcBody", () => {
+  it("meters tools/call", () => {
+    expect(isMeteredJsonRpcBody(TOOLS_CALL_BODY)).toBe(true);
+  });
+
+  it("does not meter the handshake and listing methods", () => {
+    for (const method of [
+      "initialize",
+      "tools/list",
+      "prompts/list",
+      "resources/list",
+      "notifications/initialized",
+      "ping",
+    ]) {
+      expect(isMeteredJsonRpcBody({ jsonrpc: "2.0", id: 1, method })).toBe(false);
+    }
+  });
+
+  it("meters a batch iff it contains a tools/call", () => {
+    expect(
+      isMeteredJsonRpcBody([{ method: "tools/list" }, TOOLS_CALL_BODY]),
+    ).toBe(true);
+    expect(isMeteredJsonRpcBody([{ method: "tools/list" }])).toBe(false);
+  });
+
+  it("does not meter non-object garbage", () => {
+    expect(isMeteredJsonRpcBody(null)).toBe(false);
+    expect(isMeteredJsonRpcBody("tools/call")).toBe(false);
+    expect(isMeteredJsonRpcBody(42)).toBe(false);
+  });
+});
+
+describe("checkFreeTierRateLimit", () => {
+  it("counts a tools/call against the CF-Connecting-IP key and allows under-limit", async () => {
+    const limiter = fakeLimiter(true);
+    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
+    expect(limiter.keys).toEqual(["203.0.113.7"]);
+  });
+
+  it("returns limited when the bucket is exhausted", async () => {
+    const limiter = fakeLimiter(false);
+    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("limited");
+  });
+
+  it("never calls the limiter for unmetered methods", async () => {
+    const limiter = fakeLimiter(false); // would report limited if consulted
+    const req = mcpRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("falls back to the shared 'unknown' key without CF-Connecting-IP", async () => {
+    const limiter = fakeLimiter(true);
+    await checkFreeTierRateLimit(mcpRequest(TOOLS_CALL_BODY), limiter);
+    expect(limiter.keys).toEqual(["unknown"]);
+  });
+
+  it("does not consume the request body (the transport still needs it)", async () => {
+    const limiter = fakeLimiter(true);
+    const req = mcpRequest(TOOLS_CALL_BODY);
+    await checkFreeTierRateLimit(req, limiter);
+    // The original body must remain readable after the peek.
+    await expect(req.json()).resolves.toMatchObject({ method: "tools/call" });
+  });
+
+  it("allows (does not meter) an unparseable body — the SDK will reject it anyway", async () => {
+    const limiter = fakeLimiter(false);
+    const req = new Request("https://example.com/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json{",
+    });
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("fails open and logs when the limiter binding throws", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const limiter: RateLimit = {
+      async limit() {
+        throw new Error("limiter unavailable");
+      },
+    };
+    const req = mcpRequest(TOOLS_CALL_BODY, { "cf-connecting-ip": "203.0.113.7" });
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("allowed");
+    expect(errSpy).toHaveBeenCalledOnce();
+    expect(String(errSpy.mock.calls[0]?.[0])).toContain("[free-tier]");
+    errSpy.mockRestore();
+  });
+});
+
+describe("freeTierLimitResponse", () => {
+  it("is a 429 JSON-RPC error with the upsell message and Retry-After", async () => {
+    const res = freeTierLimitResponse();
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("60");
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    const body = (await res.json()) as {
+      jsonrpc: string;
+      id: null;
+      error: { code: number; message: string; data: { kind: string } };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBeNull();
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
+    expect(body.error.data.kind).toBe("rate_limited");
+    expect(body.error.message).toContain("https://trytako.com/account/");
+  });
+});

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Env, RateLimit } from "./env.js";
 import {
@@ -9,6 +9,8 @@ import {
   isMeteredJsonRpcBody,
   resolveFreeTierConfig,
 } from "./freetier.js";
+import worker from "./index.js";
+import { mockFetchSequence, requestFrom } from "./tools/__test_helpers.js";
 
 /** A fake limiter that records keys and returns a scripted success value. */
 function fakeLimiter(success: boolean): RateLimit & { keys: string[] } {
@@ -200,5 +202,190 @@ describe("freeTierLimitResponse", () => {
     expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
     expect(body.error.data.kind).toBe("rate_limited");
     expect(body.error.message).toContain("https://trytako.com/account/");
+  });
+});
+
+describe("free tier end-to-end (worker.fetch with stub env)", () => {
+  const JSON_HEADERS = {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+  };
+
+  function freeEnv(limiter: RateLimit): Env {
+    return {
+      DJANGO_BASE_URL: "http://localhost:8000",
+      FREE_TIER_API_KEY: "free-tier-secret-key",
+      FREE_TIER_RATE_LIMITER: limiter,
+    } as Env;
+  }
+
+  function post(
+    body: unknown,
+    headers: Record<string, string> = {},
+  ): Request {
+    return new Request("https://example.com/mcp", {
+      method: "POST",
+      headers: { ...JSON_HEADERS, ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const INITIALIZE_BODY = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "0.0.0" },
+    },
+  };
+  const TOOLS_LIST_BODY = { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("anonymous initialize succeeds without metering", async () => {
+    const limiter = fakeLimiter(false); // would 429 if (wrongly) consulted
+    const res = await worker.fetch(post(INITIALIZE_BODY), freeEnv(limiter));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { serverInfo: { name: string } };
+    };
+    expect(body.result.serverInfo.name).toBe("tako-mcp");
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("anonymous tools/list shows exactly the three free tools, unmetered", async () => {
+    const limiter = fakeLimiter(false);
+    const res = await worker.fetch(post(TOOLS_LIST_BODY), freeEnv(limiter));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { tools: Array<{ name: string }> };
+    };
+    expect(body.result.tools.map((t) => t.name).sort()).toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_search",
+    ]);
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("anonymous tools/call forwards FREE_TIER_API_KEY to Django and meters the IP", async () => {
+    const limiter = fakeLimiter(true);
+    // tako_answer POSTs /api/v1/answer/ once; the handler's response
+    // handling is irrelevant here — the assertion is the outgoing header.
+    const fetchMock = mockFetchSequence([
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    const res = await worker.fetch(
+      post(
+        {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: { name: "tako_answer", arguments: { query: "US GDP" } },
+        },
+        { "cf-connecting-ip": "203.0.113.7" },
+      ),
+      freeEnv(limiter),
+    );
+    expect(res.status).toBe(200);
+    expect(limiter.keys).toEqual(["203.0.113.7"]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const outbound = requestFrom(fetchMock.mock.calls[0]!);
+    expect(outbound.headers.get("x-api-key")).toBe("free-tier-secret-key");
+  });
+
+  it("an over-limit anonymous tools/call gets the 429 upsell", async () => {
+    const limiter = fakeLimiter(false);
+    const res = await worker.fetch(
+      post(
+        {
+          jsonrpc: "2.0",
+          id: 4,
+          method: "tools/call",
+          params: { name: "tako_answer", arguments: { query: "US GDP" } },
+        },
+        { "cf-connecting-ip": "203.0.113.7" },
+      ),
+      freeEnv(limiter),
+    );
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
+  });
+
+  it("a malformed Authorization header still 401s even with the free tier configured", async () => {
+    const limiter = fakeLimiter(true);
+    const res = await worker.fetch(
+      post(INITIALIZE_BODY, { authorization: "NotBearer xyz" }),
+      freeEnv(limiter),
+    );
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: { data: { kind: string } } };
+    expect(body.error.data.kind).toBe("malformed");
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("without FREE_TIER_API_KEY, anonymous requests 401 exactly as before (fail-closed)", async () => {
+    const env = {
+      DJANGO_BASE_URL: "http://localhost:8000",
+      FREE_TIER_RATE_LIMITER: fakeLimiter(true),
+    } as Env;
+    const res = await worker.fetch(post(INITIALIZE_BODY), env);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toContain("Bearer");
+    const body = (await res.json()) as { error: { data: { kind: string } } };
+    expect(body.error.data.kind).toBe("missing");
+  });
+
+  it("authenticated requests bypass the limiter and keep the full toolset", async () => {
+    const limiter = fakeLimiter(false); // would 429 / restrict if consulted
+    const res = await worker.fetch(
+      post(TOOLS_LIST_BODY, { authorization: "Bearer real-user-token" }),
+      freeEnv(limiter),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { tools: Array<{ name: string }> };
+    };
+    expect(body.result.tools.map((t) => t.name).sort()).toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_contents",
+      "tako_search",
+    ]);
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("a limiter runtime failure fails open — the anonymous call still succeeds", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const limiter: RateLimit = {
+      async limit() {
+        throw new Error("limiter unavailable");
+      },
+    };
+    mockFetchSequence([
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ]);
+    const res = await worker.fetch(
+      post({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "tako_answer", arguments: { query: "US GDP" } },
+      }),
+      freeEnv(limiter),
+    );
+    expect(res.status).toBe(200);
   });
 });

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Env, RateLimit } from "./env.js";
 import {
   checkFreeTierRateLimit,
+  FREE_TIER_BATCH_MESSAGE,
   FREE_TIER_LIMIT_MESSAGE,
   FREE_TIER_TOOL_NAMES,
+  freeTierBatchResponse,
   freeTierLimitResponse,
   isMeteredJsonRpcBody,
   resolveFreeTierConfig,
@@ -108,13 +110,6 @@ describe("isMeteredJsonRpcBody", () => {
     }
   });
 
-  it("meters a batch iff it contains a tools/call", () => {
-    expect(
-      isMeteredJsonRpcBody([{ method: "tools/list" }, TOOLS_CALL_BODY]),
-    ).toBe(true);
-    expect(isMeteredJsonRpcBody([{ method: "tools/list" }])).toBe(false);
-  });
-
   it("does not meter non-object garbage", () => {
     expect(isMeteredJsonRpcBody(null)).toBe(false);
     expect(isMeteredJsonRpcBody("tools/call")).toBe(false);
@@ -168,6 +163,20 @@ describe("checkFreeTierRateLimit", () => {
     expect(limiter.keys).toEqual([]);
   });
 
+  it("rejects a batch array as 'batch' without calling the limiter, even when it contains a tools/call", async () => {
+    const limiter = fakeLimiter(true); // would allow if (wrongly) consulted
+    const req = mcpRequest([{ jsonrpc: "2.0", id: 1, method: "tools/list" }, TOOLS_CALL_BODY]);
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("batch");
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("rejects a batch array as 'batch' without calling the limiter, even without a tools/call", async () => {
+    const limiter = fakeLimiter(true);
+    const req = mcpRequest([{ jsonrpc: "2.0", id: 1, method: "tools/list" }]);
+    await expect(checkFreeTierRateLimit(req, limiter)).resolves.toBe("batch");
+    expect(limiter.keys).toEqual([]);
+  });
+
   it("fails open and logs when the limiter binding throws", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const limiter: RateLimit = {
@@ -202,6 +211,31 @@ describe("freeTierLimitResponse", () => {
     expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
     expect(body.error.data.kind).toBe("rate_limited");
     expect(body.error.message).toContain("https://trytako.com/account/");
+  });
+});
+
+describe("freeTierBatchResponse", () => {
+  it("is a 400 JSON-RPC error with the verbatim batch message", async () => {
+    const res = freeTierBatchResponse();
+    expect(res.status).toBe(400);
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    const body = (await res.json()) as {
+      jsonrpc: string;
+      id: null;
+      error: { code: number; message: string; data: { kind: string } };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBeNull();
+    expect(body.error.code).toBe(-32600);
+    expect(body.error.data.kind).toBe("batch_not_supported");
+    expect(body.error.message).toBe(FREE_TIER_BATCH_MESSAGE);
+    expect(body.error.message).toBe(
+      "Batch requests are not supported on the free tier. Send one " +
+        "JSON-RPC request per POST, or get a free API key at " +
+        "https://trytako.com/account/ for full access.",
+    );
   });
 });
 
@@ -319,6 +353,33 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(res.status).toBe(429);
     const body = (await res.json()) as { error: { message: string } };
     expect(body.error.message).toBe(FREE_TIER_LIMIT_MESSAGE);
+  });
+
+  it("an anonymous batch request gets a 400, never hits the limiter or Django", async () => {
+    const limiter = fakeLimiter(true); // would allow if (wrongly) consulted
+    const fetchMock = mockFetchSequence([]);
+    const res = await worker.fetch(
+      post([
+        {
+          jsonrpc: "2.0",
+          id: 6,
+          method: "tools/call",
+          params: { name: "tako_answer", arguments: { query: "US GDP" } },
+        },
+        {
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: { name: "tako_search", arguments: { query: "US CPI" } },
+        },
+      ]),
+      freeEnv(limiter),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toBe(FREE_TIER_BATCH_MESSAGE);
+    expect(limiter.keys).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("a malformed Authorization header still 401s even with the free tier configured", async () => {

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -238,13 +238,38 @@ describe("checkFreeTierRateLimit", () => {
     expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
   });
 
-  it("returns global_limited when the ceiling is exhausted, before per-IP metering", async () => {
+  it("returns global_limited with the request id for a tools/call, before per-IP metering", async () => {
     const config = makeConfig({ globalLimiter: fakeLimiter(false) });
     const req = mcpRequest(TOOLS_CALL_BODY);
     await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
       kind: "global_limited",
+      requestId: TOOLS_CALL_BODY.id,
     });
     expect((config.limiter as ReturnType<typeof fakeLimiter>).keys).toEqual([]);
+  });
+
+  it("returns global_limited with a null id for non-tools/call methods", async () => {
+    const config = makeConfig({ globalLimiter: fakeLimiter(false) });
+    const req = mcpRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" });
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "global_limited",
+      requestId: null,
+    });
+  });
+
+  it("counts unparseable bodies against the per-colo ceiling (garbage floods still count)", async () => {
+    const config = makeConfig();
+    const req = new Request("https://example.com/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not json{",
+    });
+    await expect(checkFreeTierRateLimit(req, config)).resolves.toEqual({
+      kind: "allowed",
+    });
+    expect((config.globalLimiter as ReturnType<typeof fakeLimiter>).keys).toEqual([
+      "global",
+    ]);
   });
 
   it("counts a free-tool tools/call against the CF-Connecting-IP key and allows under-limit", async () => {
@@ -454,8 +479,22 @@ describe("freeTierLimitResponse", () => {
 });
 
 describe("freeTierGlobalLimitResponse", () => {
-  it("is a 429 JSON-RPC error with the capacity message and Retry-After", async () => {
-    const res = freeTierGlobalLimitResponse();
+  it("with a tools/call id: HTTP 200 tool-error result the model can read", async () => {
+    const res = freeTierGlobalLimitResponse("req-3");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      result: { content: Array<{ type: string; text: string }>; isError: boolean };
+    };
+    expect(body.id).toBe("req-3");
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content).toEqual([
+      { type: "text", text: FREE_TIER_GLOBAL_LIMIT_MESSAGE },
+    ]);
+  });
+
+  it("without an id: a 429 JSON-RPC error with the capacity message and Retry-After", async () => {
+    const res = freeTierGlobalLimitResponse(null);
     expect(res.status).toBe(429);
     expect(res.headers.get("retry-after")).toBe("60");
     const body = (await res.json()) as {
@@ -664,7 +703,7 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(body.result.content[0]?.text).toBe(FREE_TIER_LIMIT_MESSAGE);
   });
 
-  it("an anonymous request over the global ceiling gets the capacity 429", async () => {
+  it("a non-tools/call request over the per-colo ceiling gets the capacity 429", async () => {
     const limiter = fakeLimiter(true);
     const res = await worker.fetch(
       post(TOOLS_LIST_BODY),
@@ -673,6 +712,23 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(res.status).toBe(429);
     const body = (await res.json()) as { error: { message: string } };
     expect(body.error.message).toBe(FREE_TIER_GLOBAL_LIMIT_MESSAGE);
+    expect(limiter.keys).toEqual([]);
+  });
+
+  it("a tools/call over the per-colo ceiling gets a 200 TOOL ERROR the model can read", async () => {
+    const limiter = fakeLimiter(true);
+    const res = await worker.fetch(
+      post(ANSWER_CALL_BODY),
+      freeEnv(limiter, fakeLimiter(false)),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: number;
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.id).toBe(ANSWER_CALL_BODY.id);
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).toBe(FREE_TIER_GLOBAL_LIMIT_MESSAGE);
     expect(limiter.keys).toEqual([]);
   });
 
@@ -744,6 +800,25 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     };
     expect(body.result.isError).toBe(true);
     expect(body.result.content[0]?.text).toBe(FREE_TIER_CREDITS_MESSAGE);
+  });
+
+  it("a 4xx body merely CONTAINING 'PAYMENT_REQUIRED' text is not mistaken for credit exhaustion", async () => {
+    // Only status 402 signals credit exhaustion. A validation error that
+    // echoes caller-supplied text must keep the real error message.
+    const limiter = fakeLimiter(true);
+    mockFetchSequence([
+      new Response(
+        JSON.stringify({ detail: "invalid query: PAYMENT_REQUIRED" }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ),
+    ]);
+    const res = await worker.fetch(post(ANSWER_CALL_BODY), freeEnv(limiter));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).not.toBe(FREE_TIER_CREDITS_MESSAGE);
   });
 
   it("authenticated credit exhaustion keeps the real Django error (no upsell substitution)", async () => {

--- a/workers/src/freetier.ts
+++ b/workers/src/freetier.ts
@@ -1,15 +1,31 @@
 /**
  * Anonymous free tier for `/mcp`.
  *
- * When a request arrives with NO `Authorization` header and both free-tier
- * bindings are configured, the Worker serves it as a rate-limited anonymous
- * request instead of a 401: a shared free-tier Tako API key is forwarded to
- * Django, the visible toolset shrinks to `FREE_TIER_TOOL_NAMES`, and
- * `tools/call` requests are metered per client IP through Cloudflare's
- * rate-limit binding. JSON-RPC batch arrays are rejected outright (see
+ * When a request arrives with NO `Authorization` header and all three
+ * free-tier bindings are configured, the Worker serves it as a rate-limited
+ * anonymous request instead of a 401: a shared free-tier Tako API key is
+ * forwarded to Django, the visible toolset shrinks to
+ * `FREE_TIER_TOOL_NAMES`, and requests are limited by two buckets:
+ *
+ * - A GLOBAL ceiling (constant key, every anonymous request regardless of
+ *   method) — the actual spend/volume bound. Per-IP keying means nothing
+ *   for hosted MCP hosts (claude.ai, ChatGPT, Centaur) whose fetches all
+ *   egress from a handful of platform IPs, and an IPv6 /64 can mint
+ *   endless distinct keys — so the global bucket is the control that
+ *   bounds the shared account, and it also caps the otherwise-unmetered
+ *   handshake methods (`initialize`, `tools/list`), which need no
+ *   credential at all.
+ * - A PER-IP bucket (fairness layer) counting only `tools/call`s that
+ *   name one of the three free tools — the only requests that spend Tako
+ *   credits. Calls to hidden tools return "tool not found" without
+ *   burning the caller's per-IP quota (they still count globally).
+ *
+ * JSON-RPC batch arrays are rejected outright (see
  * `checkFreeTierRateLimit`) rather than metered — a batch would let one
- * limiter hit cover an arbitrary number of Django-spending calls. Design
- * doc:
+ * limiter hit cover an arbitrary number of Django-spending calls. Bodies
+ * over `MAX_FREE_TIER_BODY_BYTES` are rejected before being buffered:
+ * this parse is new pre-auth surface, so it must not read unbounded
+ * unauthenticated input. Design doc:
  * `docs/superpowers/specs/2026-07-26-anonymous-free-tier-design.md`.
  *
  * Fail modes, deliberately asymmetric:
@@ -18,7 +34,9 @@
  *   silently serve anonymous traffic.
  * - Limiter runtime failure → fail OPEN for that request. A Cloudflare
  *   limiter hiccup must not take the tier down; the free-tier account's own
- *   Django-side limits backstop total spend.
+ *   Django-side limits backstop total spend. Detection runbook is in
+ *   `workers/README.md` — the greppable signal is the "failing open" error
+ *   line below.
  */
 
 import type { Env, RateLimit } from "./env.js";
@@ -37,119 +55,322 @@ export const FREE_TIER_TOOL_NAMES: ReadonlySet<string> = new Set([
   "tako_answer",
 ]);
 
+/**
+ * Upper bound on an anonymous request body. The body peek below buffers a
+ * clone of unauthenticated input, so it must be bounded the same way
+ * `django.ts` bounds error-body reads. Real free-tier tool calls are a few
+ * KiB of JSON; 128 KiB is generous.
+ */
+export const MAX_FREE_TIER_BODY_BYTES = 128 * 1024;
+
 /** Resolved free-tier bindings — proof the env opted in. */
 export interface FreeTierConfig {
   /** Forwarded to Django as `X-API-Key` for anonymous requests. */
   apiKey: string;
-  /** Per-IP request limiter (see `checkFreeTierRateLimit`). */
+  /** Per-IP fairness limiter — free-tool `tools/call`s only. */
   limiter: RateLimit;
+  /** Global (constant-key) ceiling — every anonymous request. */
+  globalLimiter: RateLimit;
 }
 
 /**
- * Gate the free tier on configuration: BOTH the shared API key and the
- * rate-limit binding must be present, else `null` (fail-closed — callers
+ * Gate the free tier on configuration: the shared API key and BOTH
+ * rate-limit bindings must be present, else `null` (fail-closed — callers
  * return the same 401 the Worker served before the free tier existed).
- * The limiter is shape-checked (not just truthy) so a misconfigured
- * binding fails here, at the gate, instead of throwing mid-request.
+ * The limiters are shape-checked (not just truthy) so a misconfigured
+ * binding fails here, at the gate, instead of throwing mid-request. The
+ * key is trimmed: `wrangler secret put` fed from a pipe or file picks up
+ * a trailing newline, which would otherwise 401 every anonymous request
+ * downstream — indistinguishable from a wrong key.
  */
 export function resolveFreeTierConfig(env: Env): FreeTierConfig | null {
-  const apiKey = env.FREE_TIER_API_KEY;
+  const apiKey =
+    typeof env.FREE_TIER_API_KEY === "string"
+      ? env.FREE_TIER_API_KEY.trim()
+      : "";
   const limiter = env.FREE_TIER_RATE_LIMITER;
-  if (typeof apiKey !== "string" || apiKey.length === 0) return null;
+  const globalLimiter = env.FREE_TIER_GLOBAL_RATE_LIMITER;
+  if (apiKey.length === 0) return null;
   if (typeof limiter?.limit !== "function") return null;
-  return { apiKey, limiter };
+  if (typeof globalLimiter?.limit !== "function") return null;
+  return { apiKey, limiter, globalLimiter };
 }
 
 /**
- * Should this JSON-RPC body count against the free-tier limit?
+ * Should this JSON-RPC body count against the free-tier PER-IP limit?
  *
- * Only `tools/call` is metered — it is the only method that spends the
- * shared account's Tako credits. Handshake and discovery methods
- * (`initialize`, `tools/list`, notifications, pings) must stay unmetered
- * or clients would burn quota (or get 429s) just connecting. Array bodies
- * never reach here — `checkFreeTierRateLimit` rejects batches before the
- * metering decision — so no recursion into batch elements is needed.
- * Anything unparseable / non-object is unmetered: it can never reach
- * Django, and the SDK will reject it with a proper JSON-RPC error on its
- * own.
+ * Only a `tools/call` naming one of the three free tools is metered — the
+ * only request shape that spends the shared account's Tako credits.
+ * Handshake and discovery methods (`initialize`, `tools/list`,
+ * notifications, pings) must stay unmetered or clients would burn quota
+ * just connecting, and a `tools/call` for a hidden tool (`tako_agent`,
+ * `get_credit_balance`, …) returns "tool not found" without spending a
+ * credit, so a confused client retrying it must not burn its whole
+ * minute. Both stay bounded by the global ceiling, which counts every
+ * anonymous request before this decision is made. Array bodies never
+ * reach here — `checkFreeTierRateLimit` rejects batches before the
+ * metering decision. Anything unparseable / non-object is unmetered: it
+ * can never reach Django, and the SDK will reject it with a proper
+ * JSON-RPC error on its own.
  */
 export function isMeteredJsonRpcBody(body: unknown): boolean {
-  return (
-    typeof body === "object" &&
-    body !== null &&
-    (body as { method?: unknown }).method === "tools/call"
-  );
+  if (typeof body !== "object" || body === null) return false;
+  const { method, params } = body as { method?: unknown; params?: unknown };
+  if (method !== "tools/call") return false;
+  if (typeof params !== "object" || params === null) return false;
+  const name = (params as { name?: unknown }).name;
+  return typeof name === "string" && FREE_TIER_TOOL_NAMES.has(name);
+}
+
+/** A JSON-RPC request id — what `freeTierLimitResponse` echoes back. */
+export type JsonRpcRequestId = string | number | null;
+
+/** Outcome of the anonymous-path admission checks, in check order. */
+export type FreeTierMeterResult =
+  | { kind: "allowed" }
+  /** Global ceiling exhausted — every anonymous request counts here. */
+  | { kind: "global_limited" }
+  /** Body over `MAX_FREE_TIER_BODY_BYTES` (or unparseable length). */
+  | { kind: "too_large" }
+  /** JSON-RPC batch (array body) — rejected, never metered. */
+  | { kind: "batch" }
+  /**
+   * Per-IP bucket exhausted on a metered `tools/call`. Carries the
+   * request id (when the body was parseable) so the response can be a
+   * proper JSON-RPC *result* the client resolves — see
+   * `freeTierLimitResponse` for why a 429 would never reach the model.
+   */
+  | { kind: "limited"; requestId: JsonRpcRequestId };
+
+/**
+ * Derive the per-IP bucket key from `CF-Connecting-IP`. Cloudflare sets
+ * the header on every proxied request (and overwrites any client-supplied
+ * value), so the `"unknown"` shared bucket only occurs in local
+ * `wrangler dev`. IPv6 addresses are keyed by their /64 prefix — end
+ * users typically hold an entire /64, so keying the full address would
+ * hand one subscriber effectively unlimited distinct buckets.
+ */
+export function freeTierRateLimitKey(ip: string | null): string {
+  if (ip === null) return "unknown";
+  if (!ip.includes(":")) return ip;
+  // Expand `::` far enough to name the first four hextets (the /64).
+  const [head = "", tail = ""] = ip.split("::");
+  const headParts = head === "" ? [] : head.split(":");
+  if (!ip.includes("::")) return `v6:${headParts.slice(0, 4).join(":")}`;
+  const tailParts = tail === "" ? [] : tail.split(":");
+  const missing = Math.max(0, 8 - headParts.length - tailParts.length);
+  const full = [...headParts, ...Array<string>(missing).fill("0"), ...tailParts];
+  return `v6:${full.slice(0, 4).join(":")}`;
 }
 
 /**
- * Meter an anonymous request. Peeks at a CLONE of the request body (the
- * transport still needs the original stream), skips the limiter entirely
- * for unmetered methods, and keys the bucket on `CF-Connecting-IP` —
- * Cloudflare sets it on every proxied request; the `"unknown"` shared
- * bucket only occurs in local `wrangler dev`.
+ * Admission checks for an anonymous request, in order:
  *
- * A JSON-RPC batch (array body) is rejected outright as `"batch"`,
- * checked before the metering decision — the MCP SDK dispatches every
- * element of a batch individually, so a single limiter hit would cover an
- * arbitrary number of Django-spending calls. JSON-RPC batching was
- * removed from the MCP spec in 2025-06-18, so no legitimate modern client
- * sends one; this only runs on the anonymous path, so authenticated
- * requests are unaffected.
+ * 1. Global ceiling — one constant-key `limit()` per anonymous request,
+ *    before the body is even looked at. This is the spend/volume bound
+ *    (see module header) and the only limit on handshake methods.
+ * 2. Body size — a declared `Content-Length` over
+ *    `MAX_FREE_TIER_BODY_BYTES` is rejected before any read, and the
+ *    body peek itself is a BOUNDED read that aborts past the same cap
+ *    (`Content-Length` is client-supplied and can lie; the bounded read
+ *    is the enforcement, the header check just a cheap early exit).
+ * 3. Batch rejection — array bodies (see module header).
+ * 4. Per-IP metering — only for `tools/call`s naming a free tool, keyed
+ *    per `freeTierRateLimitKey`, on a CLONE of the body (the transport
+ *    still needs the original stream).
  *
- * Limiter failure fails OPEN (see module header for why).
+ * Limiter failure (either bucket) fails OPEN — see module header. The
+ * "failing open" error line is the runbook grep target.
  */
 export async function checkFreeTierRateLimit(
   request: Request,
-  limiter: RateLimit,
-): Promise<"allowed" | "limited" | "batch"> {
-  let body: unknown;
+  config: FreeTierConfig,
+): Promise<FreeTierMeterResult> {
   try {
-    body = await request.clone().json();
-  } catch {
-    return "allowed";
+    const { success } = await config.globalLimiter.limit({ key: "global" });
+    if (!success) {
+      console.log("[free-tier] global ceiling limited");
+      return { kind: "global_limited" };
+    }
+  } catch (err) {
+    console.error(
+      `[free-tier] global rate limiter error (failing open): ${String(err)}`,
+    );
   }
-  if (Array.isArray(body)) return "batch";
-  if (!isMeteredJsonRpcBody(body)) return "allowed";
 
-  const key = request.headers.get("cf-connecting-ip") ?? "unknown";
+  const contentLength = request.headers.get("content-length");
+  if (contentLength !== null) {
+    const declaredBytes = Number(contentLength);
+    if (!Number.isFinite(declaredBytes) || declaredBytes > MAX_FREE_TIER_BODY_BYTES) {
+      return { kind: "too_large" };
+    }
+  }
+
+  const peeked = await readBoundedJson(request);
+  if (peeked.kind === "too_large") return { kind: "too_large" };
+  if (peeked.kind === "unparseable") return { kind: "allowed" };
+  const body = peeked.body;
+  if (Array.isArray(body)) return { kind: "batch" };
+  if (!isMeteredJsonRpcBody(body)) return { kind: "allowed" };
+
+  const rawId = (body as { id?: unknown }).id;
+  const requestId: JsonRpcRequestId =
+    typeof rawId === "string" || typeof rawId === "number" ? rawId : null;
+  return hitPerIpLimiter(request, config.limiter, requestId);
+}
+
+/**
+ * Read a CLONE of the request body as JSON, aborting once the byte count
+ * passes `MAX_FREE_TIER_BODY_BYTES`. This is the actual size enforcement
+ * for the anonymous body peek — it never buffers more than the cap plus
+ * one chunk, regardless of what `Content-Length` claims. Unparseable
+ * (or absent) bodies are reported as such, not thrown: the SDK gives
+ * those a proper JSON-RPC error downstream.
+ */
+async function readBoundedJson(
+  request: Request,
+): Promise<
+  | { kind: "ok"; body: unknown }
+  | { kind: "too_large" }
+  | { kind: "unparseable" }
+> {
+  const clone = request.clone();
+  if (clone.body === null) return { kind: "unparseable" };
+  const reader = clone.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_FREE_TIER_BODY_BYTES) {
+      await reader.cancel();
+      return { kind: "too_large" };
+    }
+    chunks.push(value);
+  }
+  const joined = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return { kind: "ok", body: JSON.parse(new TextDecoder().decode(joined)) };
+  } catch {
+    return { kind: "unparseable" };
+  }
+}
+
+/** Per-IP bucket hit shared by the parsed and no-length paths. */
+async function hitPerIpLimiter(
+  request: Request,
+  limiter: RateLimit,
+  requestId: JsonRpcRequestId,
+): Promise<FreeTierMeterResult> {
+  const key = freeTierRateLimitKey(request.headers.get("cf-connecting-ip"));
   try {
     const { success } = await limiter.limit({ key });
     console.log(`[free-tier] ip=${key} ${success ? "allowed" : "limited"}`);
-    return success ? "allowed" : "limited";
+    return success ? { kind: "allowed" } : { kind: "limited", requestId };
   } catch (err) {
     console.error(
       `[free-tier] ip=${key} rate limiter error (failing open): ${String(err)}`,
     );
-    return "allowed";
+    return { kind: "allowed" };
   }
 }
 
 /**
- * The 429 body's `message`. States the limit number — keep in sync with
- * the `simple.limit` value on the `FREE_TIER_RATE_LIMITER` binding in
- * `wrangler.jsonc`. The URL is the upsell: a free API key lifts the
- * anonymous per-IP limit and unlocks the full toolset.
+ * The over-limit message. States the limit number — keep in sync with the
+ * `simple.limit` value on the `FREE_TIER_RATE_LIMITER` bindings in
+ * `wrangler.jsonc` (a test in `freetier.test.ts` asserts they match). The
+ * URL is the upsell: a free API key lifts the anonymous per-IP limit and
+ * unlocks the full toolset.
  */
 export const FREE_TIER_LIMIT_MESSAGE =
-  "Free tier limit reached (10 requests/min). Get a free API key at " +
-  "https://trytako.com/account/ for higher limits.";
+  "Free tier limit reached (10 requests/min). Try again in a minute, or " +
+  "get a free API key at https://trytako.com/account/ for higher limits.";
 
 /**
- * HTTP 429 for an over-limit anonymous request. JSON-RPC envelope with
- * `id: null` (the limiter runs before the SDK parses the request id),
- * `code: -32000` (implementation-defined server-error range; distinct
- * from `-32001`, which auth failures use), and a `Retry-After` matching
- * the limiter window.
+ * Response for an over-limit metered `tools/call`.
+ *
+ * With a known request id this is deliberately HTTP 200 carrying a
+ * JSON-RPC *result* with `isError: true` — the same shape Django tool
+ * errors use — NOT a 429. On any non-2xx POST the MCP SDK client throws a
+ * transport-level `StreamableHTTPError` and the pending `tools/call`
+ * rejects, so an upsell delivered via 429 never reaches the model as
+ * readable text. As a tool result, the host feeds the message straight
+ * back to the model, which can relay it to the user.
+ *
+ * Without an id (a metered body whose `id` is absent or malformed) a
+ * matching result cannot be built, so this degrades to the legacy 429
+ * (`code: -32000`, distinct from `-32001` auth failures) with a
+ * `Retry-After` matching the limiter window.
  */
-export function freeTierLimitResponse(): Response {
+export function freeTierLimitResponse(requestId: JsonRpcRequestId): Response {
+  if (requestId === null) {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32000,
+          message: FREE_TIER_LIMIT_MESSAGE,
+          data: { kind: "rate_limited" },
+        },
+      }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Retry-After": "60",
+        },
+      },
+    );
+  }
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: requestId,
+      result: {
+        content: [{ type: "text", text: FREE_TIER_LIMIT_MESSAGE }],
+        isError: true,
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    },
+  );
+}
+
+/**
+ * The global-ceiling message. Keep the number in sync with the
+ * `FREE_TIER_GLOBAL_RATE_LIMITER` bindings in `wrangler.jsonc` (asserted
+ * by the same drift test as `FREE_TIER_LIMIT_MESSAGE`).
+ */
+export const FREE_TIER_GLOBAL_LIMIT_MESSAGE =
+  "The Tako free tier is at capacity right now. Try again shortly, or " +
+  "get a free API key at https://trytako.com/account/ for dedicated access.";
+
+/**
+ * HTTP 429 for a request over the GLOBAL anonymous ceiling. This fires
+ * before the body is read, so no request id is available and the tripping
+ * request may not even be a `tools/call` — a plain 429 (which the SDK
+ * client surfaces as a transport error) is the honest answer here, unlike
+ * the per-IP case above. It should be rare: the ceiling is sized well
+ * above expected legitimate volume.
+ */
+export function freeTierGlobalLimitResponse(): Response {
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
       id: null,
       error: {
         code: -32000,
-        message: FREE_TIER_LIMIT_MESSAGE,
-        data: { kind: "rate_limited" },
+        message: FREE_TIER_GLOBAL_LIMIT_MESSAGE,
+        data: { kind: "global_rate_limited" },
       },
     }),
     {
@@ -158,6 +379,29 @@ export function freeTierLimitResponse(): Response {
         "Content-Type": "application/json; charset=utf-8",
         "Retry-After": "60",
       },
+    },
+  );
+}
+
+/**
+ * HTTP 413 for an anonymous body over `MAX_FREE_TIER_BODY_BYTES` (or with
+ * an unparseable `Content-Length`). Rejected before any buffering — see
+ * step 2 in `checkFreeTierRateLimit`.
+ */
+export function freeTierTooLargeResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32600,
+        message: `Request body exceeds the free-tier limit of ${MAX_FREE_TIER_BODY_BYTES} bytes.`,
+        data: { kind: "payload_too_large" },
+      },
+    }),
+    {
+      status: 413,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
     },
   );
 }
@@ -197,4 +441,36 @@ export function freeTierBatchResponse(): Response {
       },
     },
   );
+}
+
+/**
+ * Model-visible message when the SHARED free-tier account runs out of
+ * Tako credits — the steady-state failure the Django-side cap exists to
+ * produce (it is the fail-open spend backstop). Without this mapping the
+ * anonymous user would see Django's raw billing error spliced into the
+ * tool result by `djangoErrorToToolResult`, which reads as a bug rather
+ * than an upsell.
+ */
+export const FREE_TIER_CREDITS_MESSAGE =
+  "The Tako free tier is temporarily out of shared capacity. Get a free " +
+  "API key at https://trytako.com/account/ to keep going with your own " +
+  "account.";
+
+/**
+ * Tool result substituted for a Django payment/credit error on the free
+ * tier. Same envelope `djangoErrorToToolResult` produces (`isError: true`,
+ * text content, machine-readable `_meta["tako/error"]`), with the billing
+ * detail replaced by upsell copy. Callers (see `registerTool`'s catch in
+ * `mcp.ts`) decide *when* this applies — this module only owns the shape.
+ */
+export function freeTierCreditsToolResult(): {
+  content: Array<{ type: "text"; text: string }>;
+  _meta: Record<string, unknown>;
+  isError: true;
+} {
+  return {
+    content: [{ type: "text", text: FREE_TIER_CREDITS_MESSAGE }],
+    _meta: { "tako/error": { kind: "free_tier_credits_exhausted" } },
+    isError: true,
+  };
 }

--- a/workers/src/freetier.ts
+++ b/workers/src/freetier.ts
@@ -7,18 +7,25 @@
  * forwarded to Django, the visible toolset shrinks to
  * `FREE_TIER_TOOL_NAMES`, and requests are limited by two buckets:
  *
- * - A GLOBAL ceiling (constant key, every anonymous request regardless of
- *   method) — the actual spend/volume bound. Per-IP keying means nothing
- *   for hosted MCP hosts (claude.ai, ChatGPT, Centaur) whose fetches all
- *   egress from a handful of platform IPs, and an IPv6 /64 can mint
- *   endless distinct keys — so the global bucket is the control that
- *   bounds the shared account, and it also caps the otherwise-unmetered
- *   handshake methods (`initialize`, `tools/list`), which need no
- *   credential at all.
+ * - A constant-key bucket hit by every anonymous request regardless of
+ *   method — PER-COLO BURST SHAPING, not a true global ceiling:
+ *   Cloudflare's ratelimit binding counts per colo with no global mode,
+ *   so the enforced number is `limit × (colos reached)`, and hosted MCP
+ *   hosts (claude.ai, ChatGPT, Centaur) egressing from many regions
+ *   maximize that fan-out. It still bounds per-colo floods — including
+ *   the otherwise-unmetered handshake methods, which need no credential
+ *   at all. The genuinely GLOBAL ceiling is Django's Redis-backed
+ *   per-user throttles on the free-tier account (search and answer at
+ *   720/min per user, graph at 180/min + 10,000/day per user — see
+ *   `app/backend/api/throttling/policy.py` in the monorepo), which every
+ *   anonymous request lands on because they all authenticate as the one
+ *   `FREE_TIER_API_KEY` user.
  * - A PER-IP bucket (fairness layer) counting only `tools/call`s that
  *   name one of the three free tools — the only requests that spend Tako
  *   credits. Calls to hidden tools return "tool not found" without
- *   burning the caller's per-IP quota (they still count globally).
+ *   burning the caller's per-IP quota (they still count per-colo).
+ *   Per-IP keying alone means little for hosted hosts (shared egress
+ *   IPs), which is why the platform-wide bound lives in Django.
  *
  * JSON-RPC batch arrays are rejected outright (see
  * `checkFreeTierRateLimit`) rather than metered — a batch would let one
@@ -128,8 +135,12 @@ export type JsonRpcRequestId = string | number | null;
 /** Outcome of the anonymous-path admission checks, in check order. */
 export type FreeTierMeterResult =
   | { kind: "allowed" }
-  /** Global ceiling exhausted — every anonymous request counts here. */
-  | { kind: "global_limited" }
+  /**
+   * Per-colo ceiling exhausted — every anonymous request counts here.
+   * `requestId` is set when the body is a `tools/call` request (any tool
+   * name) so the response can be a readable tool result; null otherwise.
+   */
+  | { kind: "global_limited"; requestId: JsonRpcRequestId }
   /** Body over `MAX_FREE_TIER_BODY_BYTES` (or unparseable length). */
   | { kind: "too_large" }
   /** JSON-RPC batch (array body) — rejected, never metered. */
@@ -166,14 +177,16 @@ export function freeTierRateLimitKey(ip: string | null): string {
 /**
  * Admission checks for an anonymous request, in order:
  *
- * 1. Global ceiling — one constant-key `limit()` per anonymous request,
- *    before the body is even looked at. This is the spend/volume bound
- *    (see module header) and the only limit on handshake methods.
- * 2. Body size — a declared `Content-Length` over
+ * 1. Body size — a declared `Content-Length` over
  *    `MAX_FREE_TIER_BODY_BYTES` is rejected before any read, and the
  *    body peek itself is a BOUNDED read that aborts past the same cap
  *    (`Content-Length` is client-supplied and can lie; the bounded read
  *    is the enforcement, the header check just a cheap early exit).
+ * 2. Per-colo ceiling — one constant-key `limit()` per anonymous request
+ *    (parse failures included, so garbage floods still count). The peek
+ *    runs FIRST so that a ceiling-limited `tools/call` can carry its
+ *    request id and answer as a readable tool result instead of a 429
+ *    the SDK client swallows as a transport error.
  * 3. Batch rejection — array bodies (see module header).
  * 4. Per-IP metering — only for `tools/call`s naming a free tool, keyed
  *    per `freeTierRateLimitKey`, on a CLONE of the body (the transport
@@ -186,18 +199,6 @@ export async function checkFreeTierRateLimit(
   request: Request,
   config: FreeTierConfig,
 ): Promise<FreeTierMeterResult> {
-  try {
-    const { success } = await config.globalLimiter.limit({ key: "global" });
-    if (!success) {
-      console.log("[free-tier] global ceiling limited");
-      return { kind: "global_limited" };
-    }
-  } catch (err) {
-    console.error(
-      `[free-tier] global rate limiter error (failing open): ${String(err)}`,
-    );
-  }
-
   const contentLength = request.headers.get("content-length");
   if (contentLength !== null) {
     const declaredBytes = Number(contentLength);
@@ -208,8 +209,25 @@ export async function checkFreeTierRateLimit(
 
   const peeked = await readBoundedJson(request);
   if (peeked.kind === "too_large") return { kind: "too_large" };
+  const body = peeked.kind === "ok" ? peeked.body : undefined;
+
+  // A response with a matching id can only be built for a `tools/call`
+  // (the tool-error result shape is not a valid reply to other methods).
+  const toolsCallId = jsonRpcToolsCallId(body);
+
+  try {
+    const { success } = await config.globalLimiter.limit({ key: "global" });
+    if (!success) {
+      console.log("[free-tier] per-colo ceiling limited");
+      return { kind: "global_limited", requestId: toolsCallId };
+    }
+  } catch (err) {
+    console.error(
+      `[free-tier] global rate limiter error (failing open): ${String(err)}`,
+    );
+  }
+
   if (peeked.kind === "unparseable") return { kind: "allowed" };
-  const body = peeked.body;
   if (Array.isArray(body)) return { kind: "batch" };
   if (!isMeteredJsonRpcBody(body)) return { kind: "allowed" };
 
@@ -217,6 +235,20 @@ export async function checkFreeTierRateLimit(
   const requestId: JsonRpcRequestId =
     typeof rawId === "string" || typeof rawId === "number" ? rawId : null;
   return hitPerIpLimiter(request, config.limiter, requestId);
+}
+
+/**
+ * The request id, iff `body` is a single JSON-RPC `tools/call` request
+ * (any tool name) with a well-formed id — the only shape whose over-limit
+ * response can echo an id inside a tool-error result.
+ */
+function jsonRpcToolsCallId(body: unknown): JsonRpcRequestId {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return null;
+  }
+  const { method, id } = body as { method?: unknown; id?: unknown };
+  if (method !== "tools/call") return null;
+  return typeof id === "string" || typeof id === "number" ? id : null;
 }
 
 /**
@@ -346,39 +378,59 @@ export function freeTierLimitResponse(requestId: JsonRpcRequestId): Response {
 }
 
 /**
- * The global-ceiling message. Keep the number in sync with the
- * `FREE_TIER_GLOBAL_RATE_LIMITER` bindings in `wrangler.jsonc` (asserted
- * by the same drift test as `FREE_TIER_LIMIT_MESSAGE`).
+ * The per-colo-ceiling message. Deliberately numberless: the binding's
+ * `limit` is enforced per Cloudflare colo, so the effective platform-wide
+ * number varies with colo fan-out and any stated figure would be wrong.
+ * (The drift test only asserts the three env bindings agree with each
+ * other; there is no message number to sync.)
  */
 export const FREE_TIER_GLOBAL_LIMIT_MESSAGE =
   "The Tako free tier is at capacity right now. Try again shortly, or " +
   "get a free API key at https://trytako.com/account/ for dedicated access.";
 
 /**
- * HTTP 429 for a request over the GLOBAL anonymous ceiling. This fires
- * before the body is read, so no request id is available and the tripping
- * request may not even be a `tools/call` — a plain 429 (which the SDK
- * client surfaces as a transport error) is the honest answer here, unlike
- * the per-IP case above. It should be rare: the ceiling is sized well
- * above expected legitimate volume.
+ * Response for a request over the per-colo anonymous ceiling. Same
+ * readability rule as `freeTierLimitResponse`: when the tripping request
+ * is a `tools/call` with a known id, answer HTTP 200 with a JSON-RPC
+ * tool-error result the model can read; otherwise (handshake methods,
+ * unparseable bodies, batches) a plain 429 with `Retry-After` is the only
+ * shape available.
  */
-export function freeTierGlobalLimitResponse(): Response {
+export function freeTierGlobalLimitResponse(
+  requestId: JsonRpcRequestId,
+): Response {
+  if (requestId === null) {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32000,
+          message: FREE_TIER_GLOBAL_LIMIT_MESSAGE,
+          data: { kind: "global_rate_limited" },
+        },
+      }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Retry-After": "60",
+        },
+      },
+    );
+  }
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
-      id: null,
-      error: {
-        code: -32000,
-        message: FREE_TIER_GLOBAL_LIMIT_MESSAGE,
-        data: { kind: "global_rate_limited" },
+      id: requestId,
+      result: {
+        content: [{ type: "text", text: FREE_TIER_GLOBAL_LIMIT_MESSAGE }],
+        isError: true,
       },
     }),
     {
-      status: 429,
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "Retry-After": "60",
-      },
+      status: 200,
+      headers: { "Content-Type": "application/json; charset=utf-8" },
     },
   );
 }

--- a/workers/src/freetier.ts
+++ b/workers/src/freetier.ts
@@ -6,7 +6,10 @@
  * request instead of a 401: a shared free-tier Tako API key is forwarded to
  * Django, the visible toolset shrinks to `FREE_TIER_TOOL_NAMES`, and
  * `tools/call` requests are metered per client IP through Cloudflare's
- * rate-limit binding. Design doc:
+ * rate-limit binding. JSON-RPC batch arrays are rejected outright (see
+ * `checkFreeTierRateLimit`) rather than metered — a batch would let one
+ * limiter hit cover an arbitrary number of Django-spending calls. Design
+ * doc:
  * `docs/superpowers/specs/2026-07-26-anonymous-free-tier-design.md`.
  *
  * Fail modes, deliberately asymmetric:
@@ -63,13 +66,14 @@ export function resolveFreeTierConfig(env: Env): FreeTierConfig | null {
  * Only `tools/call` is metered — it is the only method that spends the
  * shared account's Tako credits. Handshake and discovery methods
  * (`initialize`, `tools/list`, notifications, pings) must stay unmetered
- * or clients would burn quota (or get 429s) just connecting. Batch arrays
- * are metered iff any element is a `tools/call`. Anything unparseable /
- * non-object is unmetered: it can never reach Django, and the SDK will
- * reject it with a proper JSON-RPC error on its own.
+ * or clients would burn quota (or get 429s) just connecting. Array bodies
+ * never reach here — `checkFreeTierRateLimit` rejects batches before the
+ * metering decision — so no recursion into batch elements is needed.
+ * Anything unparseable / non-object is unmetered: it can never reach
+ * Django, and the SDK will reject it with a proper JSON-RPC error on its
+ * own.
  */
 export function isMeteredJsonRpcBody(body: unknown): boolean {
-  if (Array.isArray(body)) return body.some(isMeteredJsonRpcBody);
   return (
     typeof body === "object" &&
     body !== null &&
@@ -84,18 +88,27 @@ export function isMeteredJsonRpcBody(body: unknown): boolean {
  * Cloudflare sets it on every proxied request; the `"unknown"` shared
  * bucket only occurs in local `wrangler dev`.
  *
+ * A JSON-RPC batch (array body) is rejected outright as `"batch"`,
+ * checked before the metering decision — the MCP SDK dispatches every
+ * element of a batch individually, so a single limiter hit would cover an
+ * arbitrary number of Django-spending calls. JSON-RPC batching was
+ * removed from the MCP spec in 2025-06-18, so no legitimate modern client
+ * sends one; this only runs on the anonymous path, so authenticated
+ * requests are unaffected.
+ *
  * Limiter failure fails OPEN (see module header for why).
  */
 export async function checkFreeTierRateLimit(
   request: Request,
   limiter: RateLimit,
-): Promise<"allowed" | "limited"> {
+): Promise<"allowed" | "limited" | "batch"> {
   let body: unknown;
   try {
     body = await request.clone().json();
   } catch {
     return "allowed";
   }
+  if (Array.isArray(body)) return "batch";
   if (!isMeteredJsonRpcBody(body)) return "allowed";
 
   const key = request.headers.get("cf-connecting-ip") ?? "unknown";
@@ -144,6 +157,43 @@ export function freeTierLimitResponse(): Response {
       headers: {
         "Content-Type": "application/json; charset=utf-8",
         "Retry-After": "60",
+      },
+    },
+  );
+}
+
+/**
+ * The batch-rejection body's `message`. States the constraint plainly and
+ * points at the same upsell as `FREE_TIER_LIMIT_MESSAGE` — a free API key
+ * also lifts the batch restriction, since it puts the request on the
+ * authenticated path where this check never runs.
+ */
+export const FREE_TIER_BATCH_MESSAGE =
+  "Batch requests are not supported on the free tier. Send one JSON-RPC " +
+  "request per POST, or get a free API key at https://trytako.com/account/ " +
+  "for full access.";
+
+/**
+ * HTTP 400 for an anonymous JSON-RPC batch (array body). `id: null` (a
+ * batch has no single request id, and this runs before the SDK would parse
+ * one), `code: -32600` (JSON-RPC "Invalid Request" — batching is no longer
+ * a valid request shape per the 2025-06-18 MCP spec).
+ */
+export function freeTierBatchResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32600,
+        message: FREE_TIER_BATCH_MESSAGE,
+        data: { kind: "batch_not_supported" },
+      },
+    }),
+    {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
       },
     },
   );

--- a/workers/src/freetier.ts
+++ b/workers/src/freetier.ts
@@ -1,0 +1,150 @@
+/**
+ * Anonymous free tier for `/mcp`.
+ *
+ * When a request arrives with NO `Authorization` header and both free-tier
+ * bindings are configured, the Worker serves it as a rate-limited anonymous
+ * request instead of a 401: a shared free-tier Tako API key is forwarded to
+ * Django, the visible toolset shrinks to `FREE_TIER_TOOL_NAMES`, and
+ * `tools/call` requests are metered per client IP through Cloudflare's
+ * rate-limit binding. Design doc:
+ * `docs/superpowers/specs/2026-07-26-anonymous-free-tier-design.md`.
+ *
+ * Fail modes, deliberately asymmetric:
+ * - Configuration missing → fail CLOSED (`resolveFreeTierConfig` returns
+ *   null, callers keep today's 401). An env that never opted in must not
+ *   silently serve anonymous traffic.
+ * - Limiter runtime failure → fail OPEN for that request. A Cloudflare
+ *   limiter hiccup must not take the tier down; the free-tier account's own
+ *   Django-side limits backstop total spend.
+ */
+
+import type { Env, RateLimit } from "./env.js";
+
+/** Which surface a connection gets — see `createMcpServer`'s tier gate. */
+export type Tier = "free" | "authenticated";
+
+/**
+ * The complete anonymous tool surface. Everything else is hidden (not
+ * listed, not callable) rather than listed-but-erroring — tools that
+ * error on call waste agent turns.
+ */
+export const FREE_TIER_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "tako_available_data",
+  "tako_search",
+  "tako_answer",
+]);
+
+/** Resolved free-tier bindings — proof the env opted in. */
+export interface FreeTierConfig {
+  /** Forwarded to Django as `X-API-Key` for anonymous requests. */
+  apiKey: string;
+  /** Per-IP request limiter (see `checkFreeTierRateLimit`). */
+  limiter: RateLimit;
+}
+
+/**
+ * Gate the free tier on configuration: BOTH the shared API key and the
+ * rate-limit binding must be present, else `null` (fail-closed — callers
+ * return the same 401 the Worker served before the free tier existed).
+ * The limiter is shape-checked (not just truthy) so a misconfigured
+ * binding fails here, at the gate, instead of throwing mid-request.
+ */
+export function resolveFreeTierConfig(env: Env): FreeTierConfig | null {
+  const apiKey = env.FREE_TIER_API_KEY;
+  const limiter = env.FREE_TIER_RATE_LIMITER;
+  if (typeof apiKey !== "string" || apiKey.length === 0) return null;
+  if (typeof limiter?.limit !== "function") return null;
+  return { apiKey, limiter };
+}
+
+/**
+ * Should this JSON-RPC body count against the free-tier limit?
+ *
+ * Only `tools/call` is metered — it is the only method that spends the
+ * shared account's Tako credits. Handshake and discovery methods
+ * (`initialize`, `tools/list`, notifications, pings) must stay unmetered
+ * or clients would burn quota (or get 429s) just connecting. Batch arrays
+ * are metered iff any element is a `tools/call`. Anything unparseable /
+ * non-object is unmetered: it can never reach Django, and the SDK will
+ * reject it with a proper JSON-RPC error on its own.
+ */
+export function isMeteredJsonRpcBody(body: unknown): boolean {
+  if (Array.isArray(body)) return body.some(isMeteredJsonRpcBody);
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    (body as { method?: unknown }).method === "tools/call"
+  );
+}
+
+/**
+ * Meter an anonymous request. Peeks at a CLONE of the request body (the
+ * transport still needs the original stream), skips the limiter entirely
+ * for unmetered methods, and keys the bucket on `CF-Connecting-IP` —
+ * Cloudflare sets it on every proxied request; the `"unknown"` shared
+ * bucket only occurs in local `wrangler dev`.
+ *
+ * Limiter failure fails OPEN (see module header for why).
+ */
+export async function checkFreeTierRateLimit(
+  request: Request,
+  limiter: RateLimit,
+): Promise<"allowed" | "limited"> {
+  let body: unknown;
+  try {
+    body = await request.clone().json();
+  } catch {
+    return "allowed";
+  }
+  if (!isMeteredJsonRpcBody(body)) return "allowed";
+
+  const key = request.headers.get("cf-connecting-ip") ?? "unknown";
+  try {
+    const { success } = await limiter.limit({ key });
+    console.log(`[free-tier] ip=${key} ${success ? "allowed" : "limited"}`);
+    return success ? "allowed" : "limited";
+  } catch (err) {
+    console.error(
+      `[free-tier] ip=${key} rate limiter error (failing open): ${String(err)}`,
+    );
+    return "allowed";
+  }
+}
+
+/**
+ * The 429 body's `message`. States the limit number — keep in sync with
+ * the `simple.limit` value on the `FREE_TIER_RATE_LIMITER` binding in
+ * `wrangler.jsonc`. The URL is the upsell: a free API key lifts the
+ * anonymous per-IP limit and unlocks the full toolset.
+ */
+export const FREE_TIER_LIMIT_MESSAGE =
+  "Free tier limit reached (10 requests/min). Get a free API key at " +
+  "https://trytako.com/account/ for higher limits.";
+
+/**
+ * HTTP 429 for an over-limit anonymous request. JSON-RPC envelope with
+ * `id: null` (the limiter runs before the SDK parses the request id),
+ * `code: -32000` (implementation-defined server-error range; distinct
+ * from `-32001`, which auth failures use), and a `Retry-After` matching
+ * the limiter window.
+ */
+export function freeTierLimitResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32000,
+        message: FREE_TIER_LIMIT_MESSAGE,
+        data: { kind: "rate_limited" },
+      },
+    }),
+    {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Retry-After": "60",
+      },
+    },
+  );
+}

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -479,3 +479,72 @@ describe("server instructions", () => {
     }
   });
 });
+
+describe("free-tier tool surface", () => {
+  const ctx: ToolContext = {
+    token: "free-tier-key",
+    env: { DJANGO_BASE_URL: "http://localhost:8000" } as Env,
+    sendProgress: noopSendProgress,
+    client: "unknown",
+  };
+
+  /** List tool names over an in-memory transport for the given options. */
+  async function listToolNames(
+    options: Parameters<typeof createMcpServer>[1],
+  ): Promise<string[]> {
+    const server = createMcpServer(ctx, options);
+    const mcpClient = new Client(
+      { name: "tier-test", version: "0.0.0" },
+      { jsonSchemaValidator: new CfWorkerJsonSchemaValidator() },
+    );
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await mcpClient.connect(clientTransport);
+    try {
+      const { tools } = await mcpClient.listTools();
+      return tools.map((t) => t.name).sort();
+    } finally {
+      await mcpClient.close();
+      await server.close();
+    }
+  }
+
+  it("tier 'free' registers exactly the three free tools", async () => {
+    await expect(listToolNames({ tier: "free" })).resolves.toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_search",
+    ]);
+  });
+
+  it("tier 'free' wins over ?tools= opt-ins — the anonymous surface cannot widen", async () => {
+    await expect(
+      listToolNames({
+        tier: "free",
+        enabledOptionalToolNames: new Set([
+          "tako_agent",
+          "tako_visualize",
+          "get_credit_balance",
+        ]),
+      }),
+    ).resolves.toEqual(["tako_answer", "tako_available_data", "tako_search"]);
+  });
+
+  it("tier 'free' on ChatGPT clients also drops the default-on visualize tool", async () => {
+    // CHATGPT_DEFAULT_ON_TOOL_NAMES keeps tako_visualize on ChatGPT's
+    // default surface — but not for anonymous connections.
+    await expect(
+      listToolNames({ tier: "free", client: "chatgpt" }),
+    ).resolves.toEqual(["tako_answer", "tako_available_data", "tako_search"]);
+  });
+
+  it("omitting tier keeps the existing default (authenticated) surface", async () => {
+    await expect(listToolNames({})).resolves.toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_contents",
+      "tako_search",
+    ]);
+  });
+});

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -29,6 +29,7 @@ import {
   extractErrorDetail,
 } from "./django.js";
 import type { Env } from "./env.js";
+import { FREE_TIER_TOOL_NAMES, type Tier } from "./freetier.js";
 import { tryResolveOAuthAccessToken } from "./oauth/access.js";
 import {
   OPTIONAL_TOOL_NAMES,
@@ -146,6 +147,13 @@ export function createMcpServer(
      * in (the default surface), which is what tests and non-HTTP callers want.
      */
     enabledOptionalToolNames?: Set<string>;
+    /**
+     * Connection tier. `"free"` (anonymous, no Authorization header)
+     * restricts the registered toolset to `FREE_TIER_TOOL_NAMES`.
+     * Omitted → `"authenticated"`, the full surface — what every
+     * existing caller and test gets.
+     */
+    tier?: Tier;
   } = {},
 ): McpServer {
   // Hosts (Claude.ai connector cards, ChatGPT app directory, etc.) pick
@@ -267,12 +275,20 @@ export function createMcpServer(
   // enable it via `?tools=visualize`.
   const CHATGPT_DEFAULT_ON_TOOL_NAMES = new Set(["tako_visualize"]);
   const client = options.client ?? "unknown";
+  const tier = options.tier ?? "authenticated";
   // Opt-in tools enabled for this request via `?tools=` (see `_optional.ts`).
   // Empty by default → the default surface excludes every optional tool.
   const enabledOptionalToolNames =
     options.enabledOptionalToolNames ?? new Set<string>();
 
   for (const tool of TOOL_REGISTRY) {
+    // Free-tier surface: anonymous connections see ONLY the three free
+    // tools. Applied before every other gate so no client-specific rule
+    // (`?tools=` opt-ins, CHATGPT_DEFAULT_ON_TOOL_NAMES) can widen the
+    // anonymous surface.
+    if (tier === "free" && !FREE_TIER_TOOL_NAMES.has(tool.name)) {
+      continue;
+    }
     // Opt-in gate: optional tools (see `OPTIONAL_TOOL_ALIASES` in
     // `_optional.ts`) are excluded from the default surface and registered
     // only when enabled via the `tools` query param — except tools ChatGPT

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -29,7 +29,14 @@ import {
   extractErrorDetail,
 } from "./django.js";
 import type { Env } from "./env.js";
-import { FREE_TIER_TOOL_NAMES, type Tier } from "./freetier.js";
+import {
+  checkFreeTierRateLimit,
+  FREE_TIER_TOOL_NAMES,
+  type FreeTierConfig,
+  freeTierLimitResponse,
+  resolveFreeTierConfig,
+  type Tier,
+} from "./freetier.js";
 import { tryResolveOAuthAccessToken } from "./oauth/access.js";
 import {
   OPTIONAL_TOOL_NAMES,
@@ -987,36 +994,60 @@ export async function handleMcpRequest(
   request: Request,
   env: Env,
 ): Promise<Response> {
-  // Gate the whole endpoint behind Bearer auth. If the header is missing /
-  // malformed / empty, return a uniform 401 before invoking the SDK.
-  let bearer: string;
+  // Gate the endpoint behind Bearer auth — with one carve-out. A request
+  // whose Authorization header is fully ABSENT (kind="missing") is served
+  // as the anonymous free tier when the env has opted in (both free-tier
+  // bindings configured, see `resolveFreeTierConfig`). A malformed or
+  // empty header is a client *trying* to authenticate — that stays a loud
+  // 401 and is never silently downgraded to the free tier.
+  let bearer: string | null = null;
+  let freeTier: FreeTierConfig | null = null;
   try {
     bearer = extractBearer(request);
   } catch (err) {
-    if (err instanceof BearerAuthError) {
+    if (!(err instanceof BearerAuthError)) throw err;
+    freeTier = err.kind === "missing" ? resolveFreeTierConfig(env) : null;
+    if (freeTier === null) {
       return bearerAuthResponse(request, err);
     }
-    throw err;
   }
 
-  // Two-mode bearer handling:
-  // - OAuth access JWT issued by /token: verify signature, decrypt the
-  //   per-user Tako API token from the `enc_tako_token` claim, forward
-  //   that token downstream as `X-API-Key`. Each user authenticates as
-  //   themselves to Django.
-  // - Raw Tako API token (the existing Claude Code path): non-JWT shape,
-  //   `tryResolveOAuthAccessToken` returns null, we forward the bearer
-  //   verbatim. Backwards-compatible with every Claude Code install in
-  //   the wild.
   const origin = new URL(request.url).origin;
-  const oauth = await tryResolveOAuthAccessToken(bearer, env, origin);
-  if (oauth.kind === "reject") {
-    // The bearer IS a Worker-issued JWT but failed a binding check
-    // (wrong audience/issuer/scope/type). Return a clean 401 rather than
-    // forwarding it to Django as a raw API key.
-    return oauthChallengeResponse(request, oauth.error, oauth.errorDescription);
+  let token: string;
+  let tier: Tier;
+  if (bearer === null && freeTier !== null) {
+    // Anonymous free tier: meter tools/call per client IP BEFORE any SDK
+    // work, then act as the shared free-tier account downstream.
+    if ((await checkFreeTierRateLimit(request, freeTier.limiter)) === "limited") {
+      return freeTierLimitResponse();
+    }
+    token = freeTier.apiKey;
+    tier = "free";
+  } else if (bearer !== null) {
+    // Two-mode bearer handling:
+    // - OAuth access JWT issued by /token: verify signature, decrypt the
+    //   per-user Tako API token from the `enc_tako_token` claim, forward
+    //   that token downstream as `X-API-Key`. Each user authenticates as
+    //   themselves to Django.
+    // - Raw Tako API token (the existing Claude Code path): non-JWT shape,
+    //   `tryResolveOAuthAccessToken` returns null, we forward the bearer
+    //   verbatim. Backwards-compatible with every Claude Code install in
+    //   the wild.
+    const oauth = await tryResolveOAuthAccessToken(bearer, env, origin);
+    if (oauth.kind === "reject") {
+      // The bearer IS a Worker-issued JWT but failed a binding check
+      // (wrong audience/issuer/scope/type). Return a clean 401 rather than
+      // forwarding it to Django as a raw API key.
+      return oauthChallengeResponse(request, oauth.error, oauth.errorDescription);
+    }
+    token = oauth.kind === "ok" ? oauth.takoToken : bearer;
+    tier = "authenticated";
+  } else {
+    // Unreachable: `bearer === null` implies the catch above ran, and it
+    // either set `freeTier` or returned. Kept as a hard failure so a
+    // future refactor can't silently serve an unauthenticated request.
+    throw new Error("unreachable: no bearer and no free-tier config");
   }
-  const token = oauth.kind === "ok" ? oauth.takoToken : bearer;
 
   // Base ctx — `sendProgress` here is a placeholder overridden per
   // tool call inside `registerTool`'s SDK callback (where the
@@ -1062,6 +1093,7 @@ export async function handleMcpRequest(
       iconsBaseUrl: requestOrigin,
       client,
       enabledOptionalToolNames,
+      tier,
     });
     // Omitting `sessionIdGenerator` puts the transport in stateless mode — no
     // `Mcp-Session-Id` header is issued or validated. This matches the Worker

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -33,6 +33,7 @@ import {
   checkFreeTierRateLimit,
   FREE_TIER_TOOL_NAMES,
   type FreeTierConfig,
+  freeTierBatchResponse,
   freeTierLimitResponse,
   resolveFreeTierConfig,
   type Tier,
@@ -1017,9 +1018,15 @@ export async function handleMcpRequest(
   let tier: Tier;
   if (bearer === null && freeTier !== null) {
     // Anonymous free tier: meter tools/call per client IP BEFORE any SDK
-    // work, then act as the shared free-tier account downstream.
-    if ((await checkFreeTierRateLimit(request, freeTier.limiter)) === "limited") {
+    // work, then act as the shared free-tier account downstream. Batch
+    // (array) bodies are rejected outright rather than metered — see
+    // `checkFreeTierRateLimit`.
+    const meterResult = await checkFreeTierRateLimit(request, freeTier.limiter);
+    if (meterResult === "limited") {
       return freeTierLimitResponse();
+    }
+    if (meterResult === "batch") {
+      return freeTierBatchResponse();
     }
     token = freeTier.apiKey;
     tier = "free";

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -34,7 +34,10 @@ import {
   FREE_TIER_TOOL_NAMES,
   type FreeTierConfig,
   freeTierBatchResponse,
+  freeTierCreditsToolResult,
+  freeTierGlobalLimitResponse,
   freeTierLimitResponse,
+  freeTierTooLargeResponse,
   resolveFreeTierConfig,
   type Tier,
 } from "./freetier.js";
@@ -730,6 +733,18 @@ function registerTool(
         // Non-Django throws re-throw to the SDK, which wraps them in a
         // generic tool error (last-resort path for handler bugs).
         if (err instanceof DjangoError) {
+          // Free tier: the shared account exhausting its Tako credits is
+          // the tier's expected steady-state failure (the Django-side cap
+          // is the fail-open spend backstop). Surface it as upsell copy,
+          // not the raw billing error — which would read as a bug to an
+          // anonymous user who has no account to top up.
+          if (
+            callCtx.tier === "free" &&
+            err instanceof DjangoHttpError &&
+            (err.status === 402 || err.body.includes("PAYMENT_REQUIRED"))
+          ) {
+            return freeTierCreditsToolResult();
+          }
           return djangoErrorToToolResult(err);
         }
         throw err;
@@ -982,10 +997,13 @@ function djangoErrorKind(err: DjangoError): string {
  * subsequent calls independently; re-negotiation is cheap).
  *
  * Auth gate: `extractBearer` runs BEFORE the SDK sees the request. A
- * missing / malformed / empty `Authorization` header short-circuits here
- * with a uniform JSON-RPC 401 response — the SDK never processes
- * unauthenticated traffic. `initialize` requires auth too; MCP clients are
- * expected to be configured with a Tako API token before they connect.
+ * malformed or empty `Authorization` header short-circuits here with a
+ * uniform JSON-RPC 401 response. A fully ABSENT header is served as the
+ * anonymous free tier — restricted toolset, rate-limited, on the shared
+ * `FREE_TIER_API_KEY` account — but ONLY in environments where all three
+ * free-tier bindings are configured (see `resolveFreeTierConfig`);
+ * everywhere else the missing-header case 401s exactly as it always did,
+ * and `initialize` requires auth.
  *
  * `enableJsonResponse: true` makes the transport return a single JSON-RPC
  * response body instead of an SSE stream, which keeps the wire format simple
@@ -1017,16 +1035,22 @@ export async function handleMcpRequest(
   let token: string;
   let tier: Tier;
   if (bearer === null && freeTier !== null) {
-    // Anonymous free tier: meter tools/call per client IP BEFORE any SDK
-    // work, then act as the shared free-tier account downstream. Batch
-    // (array) bodies are rejected outright rather than metered — see
-    // `checkFreeTierRateLimit`.
-    const meterResult = await checkFreeTierRateLimit(request, freeTier.limiter);
-    if (meterResult === "limited") {
-      return freeTierLimitResponse();
-    }
-    if (meterResult === "batch") {
-      return freeTierBatchResponse();
+    // Anonymous free tier: admission checks BEFORE any SDK work (global
+    // ceiling → body-size bound → batch rejection → per-IP metering of
+    // free-tool calls), then act as the shared free-tier account
+    // downstream. See `checkFreeTierRateLimit` for the ordering rationale.
+    const meterResult = await checkFreeTierRateLimit(request, freeTier);
+    switch (meterResult.kind) {
+      case "global_limited":
+        return freeTierGlobalLimitResponse();
+      case "too_large":
+        return freeTierTooLargeResponse();
+      case "batch":
+        return freeTierBatchResponse();
+      case "limited":
+        return freeTierLimitResponse(meterResult.requestId);
+      case "allowed":
+        break;
     }
     token = freeTier.apiKey;
     tier = "free";
@@ -1069,6 +1093,7 @@ export async function handleMcpRequest(
       /* no-op outside tool-call scope */
     },
     client: "unknown",
+    tier,
   };
 
   try {

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -737,11 +737,14 @@ function registerTool(
           // the tier's expected steady-state failure (the Django-side cap
           // is the fail-open spend backstop). Surface it as upsell copy,
           // not the raw billing error — which would read as a bug to an
-          // anonymous user who has no account to top up.
+          // anonymous user who has no account to top up. Status 402 is
+          // the complete signal (Django's PaymentRequiredError always
+          // serves 402); matching on body text would let any 4xx that
+          // echoes caller-supplied input masquerade as credit exhaustion.
           if (
             callCtx.tier === "free" &&
             err instanceof DjangoHttpError &&
-            (err.status === 402 || err.body.includes("PAYMENT_REQUIRED"))
+            err.status === 402
           ) {
             return freeTierCreditsToolResult();
           }
@@ -1042,7 +1045,7 @@ export async function handleMcpRequest(
     const meterResult = await checkFreeTierRateLimit(request, freeTier);
     switch (meterResult.kind) {
       case "global_limited":
-        return freeTierGlobalLimitResponse();
+        return freeTierGlobalLimitResponse(meterResult.requestId);
       case "too_large":
         return freeTierTooLargeResponse();
       case "batch":

--- a/workers/src/raw-imports.d.ts
+++ b/workers/src/raw-imports.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Vite `?raw` imports — used by `freetier.test.ts` to read
+ * `wrangler.jsonc` as text for the limit-drift assertion (JSONC has
+ * comments, so it can't be imported as JSON).
+ */
+declare module "*.jsonc?raw" {
+  const text: string;
+  export default text;
+}

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -17,6 +17,7 @@
 import type { z } from "zod";
 
 import type { Env } from "../env.js";
+import type { Tier } from "../freetier.js";
 
 /**
  * Calling-client kind detected from the request's User-Agent. Used by
@@ -82,6 +83,15 @@ export interface ToolContext {
    * specific calls even though it generally supports progress.
    */
   client: McpClientKind;
+  /**
+   * Connection tier — `"free"` for anonymous (no `Authorization` header)
+   * requests served on the shared free-tier account, `"authenticated"`
+   * otherwise. Optional; absent means `"authenticated"` (the default for
+   * tests and non-HTTP callers). Currently consumed only by the Django
+   * error mapping in `mcp.ts`, which swaps raw billing errors for
+   * free-tier upsell copy when the SHARED account runs out of credits.
+   */
+  tier?: Tier;
 }
 
 /**

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -32,11 +32,17 @@
     // tokens below.
     "OPENAI_APPS_CHALLENGE_TOKEN": "dev-stub-not-a-real-challenge-token"
   },
-  // Free-tier rate limiter (10 metered requests / 60 s / IP). Cloudflare's
-  // rate-limiting API is configured via `unsafe.bindings`. Keep the
-  // `limit` value in sync with FREE_TIER_LIMIT_MESSAGE in
-  // `src/freetier.ts` — the upsell message states the number.
-  // NB: the binding alone does NOT enable the free tier; the
+  // Free-tier rate limiters. Cloudflare's rate-limiting API is configured
+  // via `unsafe.bindings`; two buckets:
+  //  - FREE_TIER_RATE_LIMITER: per-IP fairness bucket (10 free-tool
+  //    tools/call per 60 s). Keep `limit` in sync with
+  //    FREE_TIER_LIMIT_MESSAGE in `src/freetier.ts` — a drift test in
+  //    `src/freetier.test.ts` asserts the message matches this value.
+  //  - FREE_TIER_GLOBAL_RATE_LIMITER: constant-key global ceiling
+  //    (1000 anonymous requests / 60 s across ALL callers) — the actual
+  //    spend/volume bound; per-IP means little for hosted MCP hosts
+  //    egressing from a few platform IPs.
+  // NB: the bindings alone do NOT enable the free tier; the
   // FREE_TIER_API_KEY secret must also be set (fail-closed).
   "unsafe": {
     "bindings": [
@@ -45,6 +51,12 @@
         "type": "ratelimit",
         "namespace_id": "1000",
         "simple": { "limit": 10, "period": 60 }
+      },
+      {
+        "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1010",
+        "simple": { "limit": 1000, "period": 60 }
       }
     ]
   },
@@ -72,6 +84,12 @@
             "type": "ratelimit",
             "namespace_id": "1001",
             "simple": { "limit": 10, "period": 60 }
+          },
+          {
+            "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1011",
+            "simple": { "limit": 1000, "period": 60 }
           }
         ]
       },
@@ -114,6 +132,12 @@
             "type": "ratelimit",
             "namespace_id": "1002",
             "simple": { "limit": 10, "period": 60 }
+          },
+          {
+            "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1012",
+            "simple": { "limit": 1000, "period": 60 }
           }
         ]
       },

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -32,6 +32,22 @@
     // tokens below.
     "OPENAI_APPS_CHALLENGE_TOKEN": "dev-stub-not-a-real-challenge-token"
   },
+  // Free-tier rate limiter (10 metered requests / 60 s / IP). Cloudflare's
+  // rate-limiting API is configured via `unsafe.bindings`. Keep the
+  // `limit` value in sync with FREE_TIER_LIMIT_MESSAGE in
+  // `src/freetier.ts` — the upsell message states the number.
+  // NB: the binding alone does NOT enable the free tier; the
+  // FREE_TIER_API_KEY secret must also be set (fail-closed).
+  "unsafe": {
+    "bindings": [
+      {
+        "name": "FREE_TIER_RATE_LIMITER",
+        "type": "ratelimit",
+        "namespace_id": "1000",
+        "simple": { "limit": 10, "period": 60 }
+      }
+    ]
+  },
   "env": {
     "staging": {
       "name": "tako-mcp-staging",
@@ -42,6 +58,22 @@
         // `mcp.staging.tako.com`. Served as plain text from
         // `/.well-known/openai-apps-challenge`.
         "OPENAI_APPS_CHALLENGE_TOKEN": "yvdAP5oZPvNXuisifiatKihXGqCnPqg64InQXJ0yB5U"
+      },
+      // Free-tier rate limiter (10 metered requests / 60 s / IP). Cloudflare's
+      // rate-limiting API is configured via `unsafe.bindings`. Keep the
+      // `limit` value in sync with FREE_TIER_LIMIT_MESSAGE in
+      // `src/freetier.ts` — the upsell message states the number.
+      // NB: the binding alone does NOT enable the free tier; the
+      // FREE_TIER_API_KEY secret must also be set (fail-closed).
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "FREE_TIER_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1001",
+            "simple": { "limit": 10, "period": 60 }
+          }
+        ]
       },
       // `custom_domain: true` provisions a Cloudflare Custom Domain (TLS
       // auto-issued, CNAME auto-managed) on the deploying account's
@@ -68,6 +100,22 @@
         // value, update here and redeploy. Not a secret — the URL is
         // public by design.
         "OPENAI_APPS_CHALLENGE_TOKEN": "uXTBcUGnISWBPU2YXEn7IPIDh2ANMxLa1rkFvv3Z0c0"
+      },
+      // Free-tier rate limiter (10 metered requests / 60 s / IP). Cloudflare's
+      // rate-limiting API is configured via `unsafe.bindings`. Keep the
+      // `limit` value in sync with FREE_TIER_LIMIT_MESSAGE in
+      // `src/freetier.ts` — the upsell message states the number.
+      // NB: the binding alone does NOT enable the free tier; the
+      // FREE_TIER_API_KEY secret must also be set (fail-closed).
+      "unsafe": {
+        "bindings": [
+          {
+            "name": "FREE_TIER_RATE_LIMITER",
+            "type": "ratelimit",
+            "namespace_id": "1002",
+            "simple": { "limit": 10, "period": 60 }
+          }
+        ]
       },
       "routes": [
         { "pattern": "mcp.tako.com", "custom_domain": true }

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -38,10 +38,11 @@
   //    tools/call per 60 s). Keep `limit` in sync with
   //    FREE_TIER_LIMIT_MESSAGE in `src/freetier.ts` — a drift test in
   //    `src/freetier.test.ts` asserts the message matches this value.
-  //  - FREE_TIER_GLOBAL_RATE_LIMITER: constant-key global ceiling
-  //    (1000 anonymous requests / 60 s across ALL callers) — the actual
-  //    spend/volume bound; per-IP means little for hosted MCP hosts
-  //    egressing from a few platform IPs.
+  //  - FREE_TIER_GLOBAL_RATE_LIMITER: constant-key bucket counting every
+  //    anonymous request (1000 / 60 s). PER-COLO burst shaping, not a
+  //    true global ceiling — the binding counts per colo, so the enforced
+  //    number is limit x colos reached. The genuine platform-wide bound
+  //    is Django's per-user throttling on the free-tier account.
   // NB: the bindings alone do NOT enable the free tier; the
   // FREE_TIER_API_KEY secret must also be set (fail-closed).
   "unsafe": {


### PR DESCRIPTION
## Summary

Serves unauthenticated `/mcp` requests (no `Authorization` header) as an **anonymous free tier** instead of a 401 — the no-OAuth fallback for hosts that can't run a sign-in flow (e.g. the upcoming Centaur integration), and a zero-friction first-run path for any MCP client.

- **Fail-closed activation:** requires BOTH a `FREE_TIER_API_KEY` secret (a dedicated free-tier Tako account's key, forwarded to Django as `X-API-Key`) and the `FREE_TIER_RATE_LIMITER` binding. With either missing, behavior is byte-identical to today (401). Each env opts in independently; nothing is enabled until the secret is set.
- **Rate limiting:** 10 `tools/call`/min per client IP via Cloudflare's rate-limit binding (`unsafe.bindings`, per-env namespaces). Handshake methods (`initialize`, `tools/list`, notifications) are never metered. Over-limit → HTTP 429 with a JSON-RPC error carrying an upsell message. Limiter runtime failure fails **open** (Django-side account limits are the spend backstop); missing config fails **closed**.
- **Restricted toolset:** anonymous connections see exactly 3 tools — `tako_available_data`, `tako_search`, `tako_answer` — hidden (not registered), not erroring. The gate runs before every other registration rule, so `?tools=` opt-ins and ChatGPT default-on tools cannot widen the anonymous surface.
- **Auth semantics preserved:** a *malformed/empty* `Authorization` header still 401s (a client trying to authenticate is never silently downgraded); raw-token and OAuth JWT paths are unchanged.
- **Batch hardening (from adversarial review):** anonymous JSON-RPC batch arrays are rejected with 400 (`-32600`, `batch_not_supported`) — the SDK dispatches every batch element, so metering a batch as one hit would have let one request spend unbounded credits. Batching was removed from the MCP spec in 2025-06-18, so no modern client is affected.

New module: `workers/src/freetier.ts` (config gate, metering decision, limiter call, 429/400 responses). Wiring in `mcp.ts` (`handleMcpRequest` anonymous branch + `createMcpServer` `tier` option). Operator docs in `workers/README.md`, including a warning that enabling the free tier changes onboarding for OAuth-capable hosts (no 401 → no automatic sign-in prompt).

Design doc: `docs/superpowers/specs/2026-07-26-anonymous-free-tier-design.md` (local, gitignored).

## Test plan

- [x] 31 new tests (unit + end-to-end through `worker.fetch`): fail-closed 401, malformed-auth 401, 3-tool surface, `X-API-Key` forwarding, per-IP metering, 429 shape/message, batch rejection with zero Django spend, limiter fail-open, authenticated bypass
- [x] Full suite: 428/428 passing, `tsc --noEmit` clean
- [x] Adversarial whole-branch review (batch-bypass finding fixed + re-reviewed)
- [ ] Staging: set `wrangler secret put FREE_TIER_API_KEY --env staging` and verify anonymous connect from a real MCP client (3 tools listed, 11th call/min → 429)
- [ ] Confirm the free-tier Tako account's Django-side limits are set (spend backstop for fail-open)
- [ ] Decide production enablement (see README operator warning re: OAuth-host onboarding)