### PR TITLE
fix(ci): include raw-imports.d.ts in the test tsconfig project

### DIFF
--- a/workers/tsconfig.test.json
+++ b/workers/tsconfig.test.json
@@ -1,5 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.test.ts"],
+  // `src/raw-imports.d.ts` is named explicitly: the glob matches only
+  // `*.test.ts`, so the ambient `*.jsonc?raw` module declaration that
+  // `freetier.test.ts` depends on would otherwise be outside this program.
+  // The root `tsconfig.json` picks it up via `src/**/*.ts`, which is why
+  // a bare `tsc --noEmit` passes while this project fails.
+  "include": ["src/**/*.test.ts", "src/raw-imports.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

Unblocks the staging deploy of the anonymous free tier (#171).

`npm run typecheck` runs three tsc passes. The root `tsconfig.json` includes `src/**/*.ts`, so it picks up `src/raw-imports.d.ts` and the ambient `*.jsonc?raw` module declaration added in #171. `tsconfig.test.json` includes only `src/**/*.test.ts`, so that declaration is outside its program:

```
src/freetier.test.ts(3,25): error TS2307: Cannot find module '../wrangler.jsonc?raw' or its corresponding type declarations.
```

A bare `tsc --noEmit` passes, which is why this was reported clean on #171. It was not: `typecheck-and-test` failed on that PR, and after merge the `workers-deploy` run to staging died at the same step. **Staging is currently running pre-#171 code**, so setting `FREE_TIER_API_KEY` there is a no-op today — the two `unsafe.bindings` rate limiters ship in the Worker bundle, and that bundle never uploaded.

Fix: name `src/raw-imports.d.ts` explicitly in the test project's `include`.

## Verification

- `npm run typecheck` — exit 0 (all three passes; fails on `main` at f76276e)
- `npm test` — 458 passed, 26 files
- Repro confirmed on a clean checkout of `main` before the change

## Lines changed

- logic: 0
- tests: 0
- config: 4 (+1 net, 3 comment)
- docs: 0

## Note for the reviewer

Unrelated to this change, but found while tracing the failure: **every release-triggered production deploy has failed since v0.8.2 (2026-07-11)** — 7 in a row. The `CLOUDFLARE_API_TOKEN` CI secret lacks Workers Routes:Edit on the `tako.com` zone, which `routes: [{ custom_domain: true }]` requires:

```
✘ [ERROR] A request to the Cloudflare API (/zones/533c…4670/workers/routes) failed.
  Authentication error [code: 10000]
```

Worth fixing separately before anyone relies on the release path to ship the free tier to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)