### PR TITLE
fix(free-tier): declare rate limiters under ratelimits, not unsafe.bindings

### DIFF
--- a/workers/README.md
+++ b/workers/README.md
@@ -26,12 +26,19 @@ requests 401 exactly as before):
 | Binding | Kind | Purpose |
 |---|---|---|
 | `FREE_TIER_API_KEY` | secret | Tako API key of the dedicated free-tier account, forwarded to Django as `X-API-Key` (trimmed, so a piped `wrangler secret put` newline can't break it) |
-| `FREE_TIER_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | per-IP fairness bucket: 10 free-tool `tools/call`s / 60 s |
-| `FREE_TIER_GLOBAL_RATE_LIMITER` | `unsafe.bindings` ratelimit in `wrangler.jsonc` | per-colo burst shaping: 1000 anonymous requests / 60 s / colo, all callers |
+| `FREE_TIER_RATE_LIMITER` | `ratelimits` entry in `wrangler.jsonc` | per-IP fairness bucket: 10 free-tool `tools/call`s / 60 s |
+| `FREE_TIER_GLOBAL_RATE_LIMITER` | `ratelimits` entry in `wrangler.jsonc` | per-colo burst shaping: 120 anonymous requests / 60 s / colo, all callers |
+
+Declare both under the first-class `ratelimits` key. **Never under
+`unsafe.bindings`** — that path is a raw passthrough: the API accepts it,
+`wrangler versions view` renders the limits correctly, and `limit()`
+resolves without throwing, but it never counts, so every call returns
+`{success: true}`. No unit test catches it (the suite injects fake
+limiters); the only proof is a live burst against a deployed Worker.
 
 Neither Worker bucket is the platform-wide spend bound. Cloudflare's
 ratelimit binding counts per colo (no global mode), so the constant-key
-bucket enforces `1000/min × colos reached` — it exists to shape per-colo
+bucket enforces `120/min × colos reached` — it exists to shape per-colo
 floods, including the otherwise-unmetered handshake methods. Per-IP
 keying means little for hosted MCP hosts (claude.ai, ChatGPT, and
 similar egress from a handful of platform IPs); it's a fairness layer.
@@ -147,9 +154,12 @@ To change the limits later: the per-IP limit lives in the three
 `FREE_TIER_LIMIT_MESSAGE` in `src/freetier.ts` (a drift test in
 `src/freetier.test.ts` fails if the message and bindings disagree); the
 global ceiling lives in the three `FREE_TIER_GLOBAL_RATE_LIMITER`
-blocks. Edit, then redeploy. Counting is per-Cloudflare-colo and
-approximate (an IP whose traffic hits two colos can see roughly 2× the
-limit) — acceptable for abuse protection, not billing.
+blocks. Edit, then redeploy — then confirm against the DEPLOYED Worker
+with a burst of more than `limit` metered calls inside one period. The
+unit suite injects fake limiters, so it passes whether or not the real
+binding counts. Counting is per-Cloudflare-colo and approximate (an IP
+whose traffic hits two colos can see roughly 2× the limit) — acceptable
+for abuse protection, not billing.
 
 **Operator warning:** OAuth-capable hosts (claude.ai and similar) decide
 whether to run their OAuth sign-in flow based on getting a 401 from the

--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -9,7 +9,8 @@
 
 /**
  * Structural type of Cloudflare's Workers rate-limiting binding
- * (`unsafe.bindings` entries with `type: "ratelimit"` in `wrangler.jsonc`).
+ * (`ratelimits` entries in `wrangler.jsonc` — NOT `unsafe.bindings`, which
+ * produces a binding that satisfies this interface but never counts).
  * Declared locally instead of relying on `@cloudflare/workers-types` so the
  * shape is pinned to exactly what we call and tests can supply fakes.
  * `limit()` counts one hit against `key`'s bucket and reports whether the
@@ -114,9 +115,9 @@ export interface Env {
   FREE_TIER_API_KEY?: string;
   /**
    * Cloudflare rate-limit binding metering anonymous free-tier usage,
-   * keyed per client IP. Declared under `unsafe.bindings` in
-   * `wrangler.jsonc` (10 requests / 60 s). Optional in the same
-   * fail-closed sense as `FREE_TIER_API_KEY`.
+   * keyed per client IP. Declared under `ratelimits` in `wrangler.jsonc`
+   * (10 requests / 60 s). Optional in the same fail-closed sense as
+   * `FREE_TIER_API_KEY`.
    */
   FREE_TIER_RATE_LIMITER?: RateLimit;
   /**
@@ -125,10 +126,10 @@ export interface Env {
    * a true global ceiling — the binding counts per colo with no global
    * mode, so the enforced number is `limit × colos reached`; the genuine
    * platform-wide bound is Django's per-user throttling on the free-tier
-   * account (see `freetier.ts` module header). Declared under
-   * `unsafe.bindings` in `wrangler.jsonc` (1000 requests / 60 s / colo).
-   * Optional in the same fail-closed sense as the other two free-tier
-   * bindings — all three must be present for the free tier to activate.
+   * account (see `freetier.ts` module header). Declared under `ratelimits`
+   * in `wrangler.jsonc` (120 requests / 60 s / colo). Optional in the same
+   * fail-closed sense as the other two free-tier bindings — all three must
+   * be present for the free tier to activate.
    */
   FREE_TIER_GLOBAL_RATE_LIMITER?: RateLimit;
 }

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -549,7 +549,7 @@ describe("freeTierBatchResponse", () => {
 });
 
 describe("wrangler.jsonc ↔ message drift", () => {
-  // The limit numbers live in `unsafe.bindings` blocks (one per env) AND
+  // The limit numbers live in `ratelimits` blocks (one per env) AND
   // in the user-facing messages. This test is the sync mechanism the
   // README promises: the upsell can never advertise a number the limiter
   // does not enforce.

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -32,35 +32,36 @@
     // tokens below.
     "OPENAI_APPS_CHALLENGE_TOKEN": "dev-stub-not-a-real-challenge-token"
   },
-  // Free-tier rate limiters. Cloudflare's rate-limiting API is configured
-  // via `unsafe.bindings`; two buckets:
+  // Free-tier rate limiters — declared with the first-class `ratelimits`
+  // key, NOT `unsafe.bindings`. `unsafe.bindings` is a raw passthrough to
+  // the API: it is accepted, it renders correctly in `wrangler versions
+  // view`, and `limit()` resolves without throwing — but it never counts,
+  // so every call comes back `{success: true}`. No unit test can catch
+  // that (the suite injects fake limiters), so the only proof is a live
+  // burst against a deployed Worker. Two buckets:
   //  - FREE_TIER_RATE_LIMITER: per-IP fairness bucket (10 free-tool
   //    tools/call per 60 s). Keep `limit` in sync with
   //    FREE_TIER_LIMIT_MESSAGE in `src/freetier.ts` — a drift test in
   //    `src/freetier.test.ts` asserts the message matches this value.
   //  - FREE_TIER_GLOBAL_RATE_LIMITER: constant-key bucket counting every
-  //    anonymous request (1000 / 60 s). PER-COLO burst shaping, not a
+  //    anonymous request (120 / 60 s). PER-COLO burst shaping, not a
   //    true global ceiling — the binding counts per colo, so the enforced
   //    number is limit x colos reached. The genuine platform-wide bound
   //    is Django's per-user throttling on the free-tier account.
   // NB: the bindings alone do NOT enable the free tier; the
   // FREE_TIER_API_KEY secret must also be set (fail-closed).
-  "unsafe": {
-    "bindings": [
-      {
-        "name": "FREE_TIER_RATE_LIMITER",
-        "type": "ratelimit",
-        "namespace_id": "1000",
-        "simple": { "limit": 10, "period": 60 }
-      },
-      {
-        "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
-        "type": "ratelimit",
-        "namespace_id": "1010",
-        "simple": { "limit": 1000, "period": 60 }
-      }
-    ]
-  },
+  "ratelimits": [
+    {
+      "name": "FREE_TIER_RATE_LIMITER",
+      "namespace_id": "1000",
+      "simple": { "limit": 10, "period": 60 }
+    },
+    {
+      "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
+      "namespace_id": "1010",
+      "simple": { "limit": 120, "period": 60 }
+    }
+  ],
   "env": {
     "staging": {
       "name": "tako-mcp-staging",
@@ -72,28 +73,26 @@
         // `/.well-known/openai-apps-challenge`.
         "OPENAI_APPS_CHALLENGE_TOKEN": "yvdAP5oZPvNXuisifiatKihXGqCnPqg64InQXJ0yB5U"
       },
-      // Free-tier rate limiter (10 metered requests / 60 s / IP). Cloudflare's
-      // rate-limiting API is configured via `unsafe.bindings`. Keep the
-      // `limit` value in sync with FREE_TIER_LIMIT_MESSAGE in
-      // `src/freetier.ts` — the upsell message states the number.
-      // NB: the binding alone does NOT enable the free tier; the
+      // Free-tier rate limiters (per-IP 10 metered requests / 60 s;
+      // per-colo ceiling 120 anonymous requests / 60 s). Declared with the
+      // first-class `ratelimits` key — see the top-level block for why
+      // `unsafe.bindings` silently never counts. Keep the per-IP `limit`
+      // in sync with FREE_TIER_LIMIT_MESSAGE in `src/freetier.ts` — the
+      // upsell message states the number.
+      // NB: the bindings alone do NOT enable the free tier; the
       // FREE_TIER_API_KEY secret must also be set (fail-closed).
-      "unsafe": {
-        "bindings": [
-          {
-            "name": "FREE_TIER_RATE_LIMITER",
-            "type": "ratelimit",
-            "namespace_id": "1001",
-            "simple": { "limit": 10, "period": 60 }
-          },
-          {
-            "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
-            "type": "ratelimit",
-            "namespace_id": "1011",
-            "simple": { "limit": 1000, "period": 60 }
-          }
-        ]
-      },
+      "ratelimits": [
+        {
+          "name": "FREE_TIER_RATE_LIMITER",
+          "namespace_id": "1001",
+          "simple": { "limit": 10, "period": 60 }
+        },
+        {
+          "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
+          "namespace_id": "1011",
+          "simple": { "limit": 120, "period": 60 }
+        }
+      ],
       // `custom_domain: true` provisions a Cloudflare Custom Domain (TLS
       // auto-issued, CNAME auto-managed) on the deploying account's
       // `tako.com` zone. Requires the deployer to have Workers Routes:Edit
@@ -120,28 +119,26 @@
         // public by design.
         "OPENAI_APPS_CHALLENGE_TOKEN": "uXTBcUGnISWBPU2YXEn7IPIDh2ANMxLa1rkFvv3Z0c0"
       },
-      // Free-tier rate limiter (10 metered requests / 60 s / IP). Cloudflare's
-      // rate-limiting API is configured via `unsafe.bindings`. Keep the
-      // `limit` value in sync with FREE_TIER_LIMIT_MESSAGE in
-      // `src/freetier.ts` — the upsell message states the number.
-      // NB: the binding alone does NOT enable the free tier; the
+      // Free-tier rate limiters (per-IP 10 metered requests / 60 s;
+      // per-colo ceiling 120 anonymous requests / 60 s). Declared with the
+      // first-class `ratelimits` key — see the top-level block for why
+      // `unsafe.bindings` silently never counts. Keep the per-IP `limit`
+      // in sync with FREE_TIER_LIMIT_MESSAGE in `src/freetier.ts` — the
+      // upsell message states the number.
+      // NB: the bindings alone do NOT enable the free tier; the
       // FREE_TIER_API_KEY secret must also be set (fail-closed).
-      "unsafe": {
-        "bindings": [
-          {
-            "name": "FREE_TIER_RATE_LIMITER",
-            "type": "ratelimit",
-            "namespace_id": "1002",
-            "simple": { "limit": 10, "period": 60 }
-          },
-          {
-            "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
-            "type": "ratelimit",
-            "namespace_id": "1012",
-            "simple": { "limit": 1000, "period": 60 }
-          }
-        ]
-      },
+      "ratelimits": [
+        {
+          "name": "FREE_TIER_RATE_LIMITER",
+          "namespace_id": "1002",
+          "simple": { "limit": 10, "period": 60 }
+        },
+        {
+          "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
+          "namespace_id": "1012",
+          "simple": { "limit": 120, "period": 60 }
+        }
+      ],
       "routes": [
         { "pattern": "mcp.tako.com", "custom_domain": true }
       ],


### PR DESCRIPTION
## Summary

**The anonymous free-tier per-IP rate limit does not enforce.** Found while running #171's own staging verification step.

Measured against deployed staging (secret set, bindings present):

- **15** metered anonymous `tools/call` requests in **2 seconds** against a `10 requests/60s` bucket — **all admitted**
- Across the session: **49** requests, **49 × `[free-tier] ip=<key> allowed`**, **0 × `limited`**, **0 × `failing open`**
- `wrangler versions view` reported the binding correctly the whole time: `env.FREE_TIER_RATE_LIMITER (10 requests/60s)  Rate Limit`

### Cause

#171 declared both limiters under `unsafe.bindings` with `type: "ratelimit"`. That key is a raw passthrough to the Cloudflare API — the deploy is accepted, the binding renders with the right numbers, and `limit()` resolves without throwing. It just never counts, so every call returns `{success: true}`. A silent no-op.

Cloudflare documents a first-class `ratelimits` key, and wrangler 4.87 carries schema support for it on both `RawConfig` and `RawEnvironment` (`simple.period` enum `[10, 60]`).

### Change

Move all three blocks — top-level (`tako-mcp-dev`), `env.staging`, `env.production` — from `unsafe.bindings` to `ratelimits`, dropping the now-redundant `type` field:

```jsonc
// before                                    // after
"unsafe": {                                  "ratelimits": [
  "bindings": [                                { "name": "FREE_TIER_RATE_LIMITER",
    { "name": "FREE_TIER_RATE_LIMITER",          "namespace_id": "1001",
      "type": "ratelimit",                       "simple": { "limit": 10, "period": 60 } },
      "namespace_id": "1001",                  ...
      "simple": { ... } },                   ]
```

`namespace_id` values are unchanged (1000/1010 dev, 1001/1011 staging, 1002/1012 prod), so the same namespaces are reused — the old ones never accumulated state.

**Also lowers the per-colo ceiling from 1000 to 120 requests/60s** per request from @robertabbott. Worth stating plainly in case it matters downstream: the binding has **no per-worker granularity** — 120 is enforced per Cloudflare colo, so the effective platform-wide number is `120 × colos reached`. It is also 2 qps, not 3. If a true global qps bound is wanted, the Worker binding cannot express it; that lives in Django's per-user throttling on the free-tier account (or a Durable Object).

### Scope / blast radius

No source change. `resolveFreeTierConfig` resolves bindings **by name**, which is unchanged, and `limit({key})` is the same runtime API.

The metered branch in `handleMcpRequest` is reachable only when the `Authorization` header is **fully absent**:

```js
if (bearer === null && freeTier !== null) {      // ← only limiter call site
    const meterResult = await checkFreeTierRateLimit(request, freeTier);
} else if (bearer !== null) {                     // raw API key or OAuth JWT
    tier = "authenticated";
}
```

So a paid user's own API key or OAuth token never touches either bucket — including the constant-key global one. A malformed or empty header still 401s and is never downgraded to the free tier.

Side effect: the `▲ WARNING "unsafe" fields are experimental` line that printed on every wrangler invocation in this repo is gone.

## Test plan

- [x] `npm run typecheck` — exit 0
- [x] `npm test` — 456 passed (workers project). The `test/widget` project fails locally on node 22.3.0 with a `require()` of ES Module error in jsdom's `html-encoding-sniffer`; **confirmed pre-existing on clean main** with the same node, and CI runs node 22.23.x where `main` passes.
- [x] `wrangler deploy --dry-run --env staging` and `--env production` — both resolve `FREE_TIER_RATE_LIMITER (10 requests/60s)` and `FREE_TIER_GLOBAL_RATE_LIMITER (120 requests/60s)` as `Rate Limit`, no `unsafe` warning
- [ ] **Live burst against deployed staging** — 15 sequential metered calls, expecting 1–10 admitted and 11+ returning `Free tier limit reached (10 requests/min)`. This is the only check that can actually catch the bug, and it cannot run pre-merge.

**No unit test can cover this class of defect** — the suite injects fake limiters and passes whether or not the real binding counts. That is why #171 shipped green with an inert limiter. The README now states the verification requirement at the point where limits get changed.

## Lines changed

- logic: 0
- config: 119 (`wrangler.jsonc`, 3 blocks + comments)
- docs: 39 (`README.md` 22, `env.ts` comments 17)
- tests: 1 (comment only)

## Note

Staging currently serves the anonymous free tier with **no working per-IP cap** (left up deliberately). Bounded by the free-tier account's $24.41 balance and Django's 720/min per-user throttle. **Production should not be enabled until this is merged, deployed, and the live burst passes** — its config had the identical defect.

Production deploy is still manual: release-triggered deploys fail on a missing Workers Routes:Edit permission on the `tako.com` zone (7 consecutive failures since v0.8.2). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)