### PR TITLE
fix(widget): probe iframe capability instead of sniffing window.openai

### DIFF
--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -486,19 +486,21 @@ function registerTool(
   //         interactive iframe (`frameDomains` populated, `embed_url`
   //         loaded live inside the sandbox).
   //       - Claude clients ALSO keep the widget, but render it via the
-  //         image branch, not an iframe: the server declares
+  //         image branch first: the server declares
   //         `csp.frameDomains` identically for every client (see
   //         `buildChartAppUiResource` — it always sets `frameDomains:
   //         [webBase]`), but claude.ai's host-side sandbox currently
   //         restricts third-party iframes regardless of what's
-  //         declared there, pending Claude's own MCP Apps security
-  //         review, so the iframe never loads on claude.ai. The
-  //         bundle's client-side JS feature-detects `window.openai` at
-  //         runtime (see `shouldUseInteractiveIframe` in
-  //         `_chart_widget.ts`) and falls back to painting the
-  //         server-fetched `_meta.image_data_url` PNG (see the
-  //         `extraMeta` comment below) instead of embedding
-  //         `embed_url` in an `<iframe>`.
+  //         declared there (anthropics/claude-ai-mcp#40, pending
+  //         Claude's own MCP Apps security review), so the iframe
+  //         never loads on claude.ai today. The bundle's client-side
+  //         JS paints the server-fetched `_meta.image_data_url` PNG
+  //         (see the `extraMeta` comment below) as the baseline, then
+  //         probes the `embed_url` iframe in the background and swaps
+  //         it in only if the host's CSP actually lets it load (see
+  //         `probeInteractiveIframe` in `_chart_widget.ts`) — so
+  //         Claude upgrades to the interactive chart automatically
+  //         once Anthropic fixes #40, without a Tako redeploy.
   //       - Unknown clients still suppress the widget — the long tail
   //         of MCP hosts (Cursor, Windsurf, Gemini CLI, LibreChat, …)
   //         almost never implements the MCP Apps spec, so shipping

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -359,6 +359,27 @@ const WIDGET_HTML = `<!doctype html>
   // embed page, not arbitrary cross-frame senders.
   var embedOrigin = null;
 
+  // Pin the embed/probe iframe to an explicit pixel height. Hosts vary in
+  // which of the three they read (inline \`style.height\`, the
+  // \`min-height\` floor, and the \`height\` attribute), so set all three
+  // together. One helper so the next height gotcha is a one-line fix
+  // instead of the four separate inlined call sites this replaces.
+  function setFrameHeight(n) {
+    frame.style.height = n + "px";
+    frame.style.minHeight = n + "px";
+    frame.setAttribute("height", String(n));
+  }
+
+  // Record the embed iframe's origin so the \`tako-embed-height\` resize
+  // handler will honor messages from it. Only arm this once the embed is
+  // the VISIBLE surface (an immediate iframe render, or a probe that has
+  // upgraded) — arming it while a probe frame is still hidden behind the
+  // PNG would let a background embed resize the widget under a chart the
+  // user is looking at.
+  function armEmbedOrigin(url) {
+    try { embedOrigin = new URL(url).origin; } catch (e) { embedOrigin = null; }
+  }
+
   // Pick the rendering mode by CAPABILITY, not host identity.
   //
   // ChatGPT's Apps SDK runtime exposes \`window.openai\`; its outer
@@ -394,6 +415,11 @@ const WIDGET_HTML = `<!doctype html>
   // tool-result delivery racing the flag can't double-assign
   // \`frame.src\`.
   var probeStarted = false;
+  // Flips true once the probe has swapped the interactive iframe in over
+  // the PNG. The image \`load\`/\`error\` handlers check it and no-op after
+  // an upgrade so a stray duplicate image event can't re-reveal the PNG
+  // on top of the live iframe.
+  var probeUpgraded = false;
 
   // Try to load \`url\` in the (still hidden) chart iframe and swap it
   // in over the already-rendered PNG if it genuinely loads.
@@ -417,6 +443,15 @@ const WIDGET_HTML = `<!doctype html>
     probeStarted = true;
     var settled = false;
     var timer = null;
+    // Flips true the instant we navigate the probe frame to \`url\`, and
+    // back to false before \`fail()\` sends it to about:blank. \`onLoad\`
+    // gates on this rather than \`frame.src === url\`: \`frame.src\` reads
+    // back the browser-NORMALIZED URL (\`https://tako.com:443\` collapses
+    // to \`https://tako.com\`, the host lowercases), so a raw-string
+    // compare against \`url\` can silently never match — stranding every
+    // render on the 8 s timeout on any host whose \`embed_url\` origin
+    // isn't already normalized.
+    var probeNavigated = false;
     function cleanup() {
       settled = true;
       if (timer !== null) clearTimeout(timer);
@@ -427,24 +462,28 @@ const WIDGET_HTML = `<!doctype html>
       if (settled) return;
       cleanup();
       embedOrigin = null;
+      probeNavigated = false;
       frame.src = "about:blank";
       log("iframe probe failed, staying on image", { reason: reason });
     }
     function succeed() {
       if (settled) return;
       cleanup();
+      probeUpgraded = true;
       // Swap at the image's CURRENT rendered height, not the tool's
       // requested height: claude.ai sizes its outer container once
       // (anthropics/claude-ai-mcp#69) from the PNG's footprint, so
-      // growing the frame past it would clip. A same-height swap is
-      // seamless; the \`tako-embed-height\` handshake below can still
-      // resize later on hosts that honor size-changed.
+      // growing the frame past it would clip. The probe only starts
+      // AFTER the image has loaded (see the image \`load\` handler), so
+      // \`getBoundingClientRect().height\` here is the real laid-out
+      // height — not 0 falling through to \`fallbackHeight\`.
       var rectH = image.getBoundingClientRect().height;
       var offsetH = image.offsetHeight;
       var h = Math.round(rectH || offsetH || 0) || fallbackHeight;
-      frame.style.height = h + "px";
-      frame.style.minHeight = h + "px";
-      frame.setAttribute("height", String(h));
+      setFrameHeight(h);
+      // Arm the embed-height handshake only NOW: the embed has become the
+      // visible surface, so honoring its resize messages is finally safe.
+      armEmbedOrigin(url);
       imageLink.classList.add("hidden");
       placeholder.classList.add("hidden");
       frame.classList.remove("hidden");
@@ -459,14 +498,27 @@ const WIDGET_HTML = `<!doctype html>
       }
     }
     function onLoad() {
-      // \`fail()\` navigates the frame to about:blank, which fires its
-      // own \`load\` — only count a load of the probe URL itself.
-      if (frame.src === url) succeed();
+      // \`fail()\` navigates the frame to about:blank, which fires its own
+      // \`load\`; \`probeNavigated\` is false by then so we don't count it.
+      //
+      // KNOWN GAP (bare-load success signal): \`load\` fires for ANY
+      // document the embed endpoint returns — including a Tako 404/5xx
+      // error page. On a host whose CSP allows \`frame-src\`, an embed-page
+      // outage would swap the known-good PNG for an error page. Accepted
+      // for now: the only positive signal from the cross-origin embed is
+      // the \`tako-embed-height\` message, which the Tako web app does not
+      // emit yet (see the handler comment near the bottom). Once it does,
+      // gate \`succeed()\` on that message instead of the bare \`load\`.
+      if (probeNavigated) succeed();
     }
     document.addEventListener("securitypolicyviolation", onViolation);
     frame.addEventListener("load", onLoad);
-    try { embedOrigin = new URL(url).origin; } catch (e) { embedOrigin = null; }
+    // Deliberately do NOT arm \`embedOrigin\` here — the probe frame is
+    // still hidden behind the PNG, so honoring its \`tako-embed-height\`
+    // messages would resize the widget under a chart the user is looking
+    // at. \`succeed()\` arms it after the swap.
     frame.src = url;
+    probeNavigated = true;
     timer = setTimeout(function () { fail("timeout"); }, 8000);
     log("iframe probe started", { src: url });
   }
@@ -586,10 +638,8 @@ const WIDGET_HTML = `<!doctype html>
 
     if (useIframe) {
       if (frame.src !== url) frame.src = url;
-      try { embedOrigin = new URL(url).origin; } catch (e) { embedOrigin = null; }
-      frame.style.height = h + "px";
-      frame.style.minHeight = h + "px";
-      frame.setAttribute("height", String(h));
+      armEmbedOrigin(url);
+      setFrameHeight(h);
       frame.classList.remove("hidden");
     } else if (validImage) {
       // Per anthropics/claude-ai-mcp#69 workaround:
@@ -623,6 +673,10 @@ const WIDGET_HTML = `<!doctype html>
       }
 
       image.addEventListener("load", function () {
+        // No-op after an upgrade: if the probe already swapped the
+        // interactive iframe in, a stray duplicate \`load\` must not
+        // re-reveal the PNG on top of it.
+        if (probeUpgraded) return;
         imageLink.classList.remove("hidden");
         placeholder.classList.add("hidden");
         // Defer measurement one frame so layout settles after the
@@ -646,6 +700,17 @@ const WIDGET_HTML = `<!doctype html>
             log("img resized after load", { height: renderedH });
           }
         });
+        // Capability probe, sequenced AFTER the PNG baseline has loaded.
+        // Starting it here rather than at render() time guarantees the
+        // image is laid out before the probe can \`succeed()\`, so the swap
+        // measures the image's real rendered height (not 0 falling through
+        // to the requested height), and this \`load\` handler has already
+        // run so it can't re-reveal the PNG over the swapped-in iframe.
+        // The PNG is the guaranteed baseline; if this host's CSP lets the
+        // embed iframe load (it doesn't on claude.ai until
+        // anthropics/claude-ai-mcp#40 is fixed), the probe upgrades to the
+        // interactive chart once it does.
+        if (validEmbed) probeInteractiveIframe(url, h);
       });
       // CSP / network error fallback. The most common trigger is
       // claude.ai's outer-document CSP (\`img-src 'self' blob: data:\`)
@@ -674,6 +739,11 @@ const WIDGET_HTML = `<!doctype html>
           placeholder.textContent = "Couldn't load chart.";
         }
         log("img errored, showing click-through fallback");
+        // Even with no visible PNG, still probe: a host that blocks
+        // cross-origin \`img-src\` but allows \`frame-src\` can upgrade to
+        // the interactive embed. \`probeStarted\` dedupes against the load
+        // path — only one of load/error fires per image.
+        if (validEmbed) probeInteractiveIframe(url, h);
       });
       // Mark rendered BEFORE assigning src so the \`if (rendered) return\`
       // guard at the top of \`render()\` blocks any re-entry from a
@@ -681,15 +751,9 @@ const WIDGET_HTML = `<!doctype html>
       // synchronously (data: URIs can do that in some browsers).
       rendered = true;
       // Triggers the load event above. Set last so the listener is
-      // attached first.
+      // attached first. The capability probe is kicked off from inside the
+      // load/error handlers (above) so it's sequenced after the image.
       image.src = imageSrc;
-      // Capability probe: the PNG above is the guaranteed baseline; if
-      // this host's CSP lets the embed iframe load (it doesn't on
-      // claude.ai until anthropics/claude-ai-mcp#40 is fixed), swap in
-      // the interactive chart once it does.
-      if (validEmbed) {
-        probeInteractiveIframe(url, h);
-      }
       // Skip the synchronous hide-placeholder / show-anchor / notifyHeight
       // tail below — image.load handles those atomically once the
       // content has actually rendered.
@@ -702,10 +766,8 @@ const WIDGET_HTML = `<!doctype html>
       // they'd otherwise have seen; best case some host without
       // \`window.openai\` actually allows the iframe.
       if (frame.src !== url) frame.src = url;
-      try { embedOrigin = new URL(url).origin; } catch (e) { embedOrigin = null; }
-      frame.style.height = h + "px";
-      frame.style.minHeight = h + "px";
-      frame.setAttribute("height", String(h));
+      armEmbedOrigin(url);
+      setFrameHeight(h);
       frame.classList.remove("hidden");
     } else {
       // Nothing usable; leave the placeholder visible.
@@ -921,9 +983,7 @@ const WIDGET_HTML = `<!doctype html>
       var h = msg.height;
       if (typeof h !== "number" || !isFinite(h) || h <= 0 || h > 4000) return;
       var n = Math.round(h);
-      frame.style.height = n + "px";
-      frame.style.minHeight = n + "px";
-      frame.setAttribute("height", String(n));
+      setFrameHeight(n);
       notifyHeight(n);
       log("resized via embed handshake", { height: n });
     }

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -359,26 +359,116 @@ const WIDGET_HTML = `<!doctype html>
   // embed page, not arbitrary cross-frame senders.
   var embedOrigin = null;
 
-  // Pick the rendering mode based on host. ChatGPT's Apps SDK runtime
-  // exposes \`window.openai\`; its outer sandbox CSP honors our
-  // \`frameDomains\` declaration and lets the cross-origin
-  // \`<iframe src=https://staging.trytako.com/embed/...>\` load fully
-  // interactive. Other hosts (claude.ai for custom connectors most
-  // notably) enforce a stricter \`frame-src 'self' blob: data:\` outer
-  // CSP that ignores frameDomains entirely, so the iframe ends up
-  // showing Chrome's "This content is blocked" placeholder. For those
-  // hosts we drop back to the static PNG via \`image_url\` — the
-  // \`img-src\` directive is far more commonly permissive than
-  // \`frame-src\`, and a non-interactive chart is strictly better than
-  // a "blocked" error tile. Confirmed via DevTools (2026-04-29) on
-  // claude.ai web: the same widget bundle, same handshake completion,
-  // with iframe blocked vs static \`<img>\` allowed.
-  function shouldUseInteractiveIframe() {
+  // Pick the rendering mode by CAPABILITY, not host identity.
+  //
+  // ChatGPT's Apps SDK runtime exposes \`window.openai\`; its outer
+  // sandbox CSP honors our \`frameDomains\` declaration and lets the
+  // cross-origin \`<iframe src=https://staging.trytako.com/embed/...>\`
+  // load fully interactive — commit to the iframe immediately there.
+  //
+  // Every other host renders the static PNG first (the baseline that
+  // always works) and then PROBES the embed iframe in the background
+  // via \`probeInteractiveIframe\`, swapping it in only if the embed
+  // actually loads. Rationale: claude.ai today enforces a hardcoded
+  // \`frame-src 'self' blob: data:\` outer CSP that ignores declared
+  // \`csp.frameDomains\` (anthropics/claude-ai-mcp#40 — spec violation,
+  // acknowledged, pending their MCP Apps security review), so the
+  // iframe shows Chrome's "This content is blocked" placeholder
+  // (confirmed via DevTools 2026-04-29 on claude.ai web). But that's a
+  // host bug with a pending fix: keying the branch on "is this
+  // ChatGPT" would keep Claude on the static PNG even after Anthropic
+  // ships it. Probing means the interactive path lights up on any
+  // host the moment its CSP allows it, with no Tako redeploy — and the
+  // CSP violation event fires ~immediately on blocking hosts, so
+  // today's PNG experience is unchanged.
+  function hasOpenAiRuntime() {
     try {
       return typeof window.openai !== "undefined";
     } catch (e) {
       return false;
     }
+  }
+
+  // One probe per widget lifetime. \`render()\` is one-shot via the
+  // \`rendered\` flag, but guard independently so a duplicate
+  // tool-result delivery racing the flag can't double-assign
+  // \`frame.src\`.
+  var probeStarted = false;
+
+  // Try to load \`url\` in the (still hidden) chart iframe and swap it
+  // in over the already-rendered PNG if it genuinely loads.
+  //
+  // Success signal: the iframe \`load\` event. A cross-origin frame's
+  // content is unreadable, but \`load\` only fires when a document
+  // actually loaded — CSP-blocked loads never make the request, so
+  // they never fire it.
+  //
+  // Failure signals, either of:
+  //  - \`securitypolicyviolation\` for \`frame-src\` on this document —
+  //    the definitive "host sandbox blocked it" signal.
+  //  - No \`load\` within the timeout — covers hosts that suppress
+  //    violation events and plain network stalls.
+  //
+  // On failure the widget stays on the PNG it already painted; the
+  // probe frame is unloaded so nothing can later surface a blocked
+  // tile.
+  function probeInteractiveIframe(url, fallbackHeight) {
+    if (probeStarted) return;
+    probeStarted = true;
+    var settled = false;
+    var timer = null;
+    function cleanup() {
+      settled = true;
+      if (timer !== null) clearTimeout(timer);
+      document.removeEventListener("securitypolicyviolation", onViolation);
+      frame.removeEventListener("load", onLoad);
+    }
+    function fail(reason) {
+      if (settled) return;
+      cleanup();
+      embedOrigin = null;
+      frame.src = "about:blank";
+      log("iframe probe failed, staying on image", { reason: reason });
+    }
+    function succeed() {
+      if (settled) return;
+      cleanup();
+      // Swap at the image's CURRENT rendered height, not the tool's
+      // requested height: claude.ai sizes its outer container once
+      // (anthropics/claude-ai-mcp#69) from the PNG's footprint, so
+      // growing the frame past it would clip. A same-height swap is
+      // seamless; the \`tako-embed-height\` handshake below can still
+      // resize later on hosts that honor size-changed.
+      var rectH = image.getBoundingClientRect().height;
+      var offsetH = image.offsetHeight;
+      var h = Math.round(rectH || offsetH || 0) || fallbackHeight;
+      frame.style.height = h + "px";
+      frame.style.minHeight = h + "px";
+      frame.setAttribute("height", String(h));
+      imageLink.classList.add("hidden");
+      placeholder.classList.add("hidden");
+      frame.classList.remove("hidden");
+      notifyHeight(h);
+      log("iframe probe succeeded, upgraded to interactive", { height: h });
+    }
+    function onViolation(event) {
+      var directive =
+        event && (event.effectiveDirective || event.violatedDirective);
+      if (typeof directive === "string" && directive.indexOf("frame-src") === 0) {
+        fail("csp:" + directive);
+      }
+    }
+    function onLoad() {
+      // \`fail()\` navigates the frame to about:blank, which fires its
+      // own \`load\` — only count a load of the probe URL itself.
+      if (frame.src === url) succeed();
+    }
+    document.addEventListener("securitypolicyviolation", onViolation);
+    frame.addEventListener("load", onLoad);
+    try { embedOrigin = new URL(url).origin; } catch (e) { embedOrigin = null; }
+    frame.src = url;
+    timer = setTimeout(function () { fail("timeout"); }, 8000);
+    log("iframe probe started", { src: url });
   }
 
   function log(label, payload) {
@@ -492,7 +582,7 @@ const WIDGET_HTML = `<!doctype html>
       typeof structuredContent.height === "number" && structuredContent.height > 0
         ? structuredContent.height
         : 600;
-    var useIframe = shouldUseInteractiveIframe() && validEmbed;
+    var useIframe = hasOpenAiRuntime() && validEmbed;
 
     if (useIframe) {
       if (frame.src !== url) frame.src = url;
@@ -593,6 +683,13 @@ const WIDGET_HTML = `<!doctype html>
       // Triggers the load event above. Set last so the listener is
       // attached first.
       image.src = imageSrc;
+      // Capability probe: the PNG above is the guaranteed baseline; if
+      // this host's CSP lets the embed iframe load (it doesn't on
+      // claude.ai until anthropics/claude-ai-mcp#40 is fixed), swap in
+      // the interactive chart once it does.
+      if (validEmbed) {
+        probeInteractiveIframe(url, h);
+      }
       // Skip the synchronous hide-placeholder / show-anchor / notifyHeight
       // tail below — image.load handles those atomically once the
       // content has actually rendered.

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -244,8 +244,8 @@ const tako_search = {
     );
   },
   async extraMeta(output, ctx) {
-    // Skip the fetch on ChatGPT: its widget bundle takes the iframe
-    // path (`window.openai` defined → `shouldUseInteractiveIframe()`
+    // Skip the fetch on ChatGPT: its widget bundle takes the committed
+    // iframe path (`window.openai` defined → `hasOpenAiRuntime()`
     // true in `_chart_widget.ts`), which renders `embed_url` directly
     // and never reads `image_data_url` from `_meta`. Without this
     // gate we pay the full chart-render latency

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -149,6 +149,24 @@ function widgetFrame(m: Mounted): HTMLIFrameElement {
   ) as HTMLIFrameElement;
 }
 
+/**
+ * Deliver a `tako-embed-height` resize message as if the embed iframe
+ * posted it. The widget's handler gates on `event.origin` matching the
+ * armed embed origin, so set it to the embed URL's origin.
+ */
+function deliverEmbedHeight(m: Mounted, height: number): void {
+  const WidgetMessageEvent = (
+    m.widgetWin as unknown as { MessageEvent: typeof MessageEvent }
+  ).MessageEvent;
+  m.widgetWin.dispatchEvent(
+    new WidgetMessageEvent("message", {
+      data: { type: "tako-embed-height", height },
+      origin: "https://staging.trytako.com",
+      source: m.widgetWin as unknown as MessageEventSource,
+    }),
+  );
+}
+
 /** Fire the probe iframe's `load` event as if the embed page loaded. */
 function fireFrameLoad(m: Mounted): void {
   const WidgetEvent = (m.widgetWin as unknown as { Event: typeof Event })
@@ -325,10 +343,62 @@ describe("interactive iframe capability probe (executed)", () => {
   it("upgrades to the interactive iframe when the probe loads", () => {
     const m = mountWidget(staticWidgetHtml());
     deliver(m, CHART_RESULT, m.wrapperWin);
+    // The probe only arms once the PNG baseline has loaded, so the swap
+    // measures the image's real rendered height rather than the requested
+    // fallback.
+    fireImageLoad(m);
     fireFrameLoad(m);
     // Iframe swapped in over the PNG.
     expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
     expect(widgetLink(m).classList.contains("hidden")).toBe(true);
+  });
+
+  it("does not arm the probe until the PNG baseline has loaded", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    // No probe in flight yet: the frame has no src and a stray `load`
+    // (there is no listener bound) can't swap a not-yet-measured iframe
+    // over the PNG.
+    expect(widgetFrame(m).getAttribute("src")).toBeNull();
+    fireFrameLoad(m);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(true);
+    // Image loads → probe arms and starts loading the embed, hidden.
+    fireImageLoad(m);
+    expect(widgetFrame(m).getAttribute("src")).toBe(EMBED_URL);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(false);
+  });
+
+  it("does not re-reveal the PNG when a duplicate image load fires after upgrade", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    fireImageLoad(m);
+    fireFrameLoad(m); // upgrade to the interactive iframe
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(true);
+    // A stray second image load must not un-hide the PNG on top of the
+    // live iframe.
+    fireImageLoad(m);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(true);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
+  });
+
+  it("ignores embed-height messages while the probe is hidden, honors them after upgrade", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    fireImageLoad(m); // probe armed, embed loading hidden behind the PNG
+    const frame = widgetFrame(m);
+    frame.removeAttribute("height");
+    // During the probe window `embedOrigin` is unarmed, so a resize
+    // message from the (hidden) embed must not size the widget under the
+    // visible PNG.
+    deliverEmbedHeight(m, 1234);
+    expect(frame.getAttribute("height")).toBeNull();
+    // After the swap, `embedOrigin` is armed and the same message resizes.
+    fireFrameLoad(m);
+    deliverEmbedHeight(m, 1234);
+    expect(frame.getAttribute("height")).toBe("1234");
   });
 
   it("stays on the image when the host CSP blocks the probe", () => {

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -143,6 +143,43 @@ function widgetLink(m: Mounted): HTMLAnchorElement {
   ) as HTMLAnchorElement;
 }
 
+function widgetFrame(m: Mounted): HTMLIFrameElement {
+  return m.widgetWin.document.getElementById(
+    "tako-embed",
+  ) as HTMLIFrameElement;
+}
+
+/** Fire the probe iframe's `load` event as if the embed page loaded. */
+function fireFrameLoad(m: Mounted): void {
+  const WidgetEvent = (m.widgetWin as unknown as { Event: typeof Event })
+    .Event;
+  widgetFrame(m).dispatchEvent(new WidgetEvent("load"));
+}
+
+/**
+ * Fire the chart image's `load` event — jsdom doesn't decode `data:`
+ * URIs, so the widget's img.load listener (which unhides the link)
+ * never fires on its own.
+ */
+function fireImageLoad(m: Mounted): void {
+  const WidgetEvent = (m.widgetWin as unknown as { Event: typeof Event })
+    .Event;
+  widgetImg(m).dispatchEvent(new WidgetEvent("load"));
+}
+
+/** Fire a `frame-src` CSP violation as if the host sandbox blocked the probe. */
+function fireFrameSrcViolation(m: Mounted): void {
+  const WidgetEvent = (m.widgetWin as unknown as { Event: typeof Event })
+    .Event;
+  const event = new WidgetEvent("securitypolicyviolation");
+  Object.assign(event, {
+    effectiveDirective: "frame-src",
+    violatedDirective: "frame-src",
+    blockedURI: EMBED_URL,
+  });
+  m.widgetWin.document.dispatchEvent(event);
+}
+
 function staticWidgetHtml(): string {
   return buildChartAppUiResourceFromOutputPubId(ENV).html;
 }
@@ -260,6 +297,74 @@ describe("static widget bundle (executed)", () => {
         "ui/notifications/size-changed",
     ) as Array<{ params: { height: number } }>;
     expect(sizeChanges.at(-1)?.params.height).toBe(0);
+  });
+});
+
+describe("interactive iframe capability probe (executed)", () => {
+  const CHART_RESULT = toolResult(
+    { embed_url: EMBED_URL, image_url: IMAGE_URL },
+    {
+      image_data_url: DATA_URL,
+      image_natural_width: 800,
+      image_natural_height: 600,
+    },
+  );
+
+  it("probes the embed iframe in the background while showing the image", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    fireImageLoad(m);
+    // Image is the visible baseline...
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(false);
+    // ...while the probe iframe loads the embed hidden.
+    expect(widgetFrame(m).getAttribute("src")).toBe(EMBED_URL);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+  });
+
+  it("upgrades to the interactive iframe when the probe loads", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    fireFrameLoad(m);
+    // Iframe swapped in over the PNG.
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(true);
+  });
+
+  it("stays on the image when the host CSP blocks the probe", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    fireImageLoad(m);
+    fireFrameSrcViolation(m);
+    // Probe cancelled: frame unloaded and still hidden, image untouched.
+    expect(widgetFrame(m).getAttribute("src")).toBe("about:blank");
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(false);
+    // A late load (e.g. the about:blank unload settling) must not swap.
+    fireFrameLoad(m);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+    expect(widgetLink(m).classList.contains("hidden")).toBe(false);
+  });
+
+  it("commits to the iframe immediately when window.openai is present", () => {
+    const m = mountWidget(staticWidgetHtml());
+    (m.widgetWin as unknown as { openai: object }).openai = {};
+    deliver(m, CHART_RESULT, m.wrapperWin);
+    // ChatGPT path: no PNG detour, no probe — straight to the iframe.
+    expect(widgetFrame(m).getAttribute("src")).toBe(EMBED_URL);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
+    expect(widgetImg(m).getAttribute("src")).toBeNull();
+  });
+
+  it("does not probe when there is no embed_url", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult({ image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+    expect(widgetFrame(m).getAttribute("src")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

The static chart widget decided interactive-iframe vs static-PNG by **host identity**: `window.openai` defined → iframe (ChatGPT), otherwise PNG. That permanently pins Claude to the static image. claude.ai's sandbox currently hardcodes `frame-src 'self' blob: data:` and ignores declared `csp.frameDomains` ([anthropics/claude-ai-mcp#40](https://github.com/anthropics/claude-ai-mcp/issues/40), open, pending their MCP Apps security review) — but once Anthropic ships that fix, the host sniff would *still* route Claude to the PNG until we redeployed.

This PR replaces the sniff with **capability detection**:

- **ChatGPT** (`window.openai` present): commits to the interactive iframe immediately — behavior unchanged.
- **Every other host** (claude.ai, VS Code, Goose, …): paints the PNG first (today's guaranteed baseline), then probes the embed iframe hidden in the background:
  - **Success** = iframe `load` event → swap the iframe in over the PNG, at the PNG's rendered height (claude.ai sizes its outer container once per [anthropics/claude-ai-mcp#69](https://github.com/anthropics/claude-ai-mcp/issues/69); a taller swap would clip).
  - **Failure** = `frame-src` `securitypolicyviolation` (fires ~instantly on blocking hosts, so today's Claude UX is unchanged) or 8 s timeout → stay on the PNG and unload the probe frame so a blocked-content tile can never surface.

Net effect: the interactive chart lights up on any host the moment its CSP allows it — **no Tako redeploy, no widget-URI change** (Claude desktop caches widget URIs beyond connector lifecycle, so the URI must stay stable).

Also updates the now-stale comments in `mcp.ts` / `tako_search.ts` that described the old host-sniff behavior.

## Test plan

- [x] 5 new jsdom-executed widget tests (`test/widget/widget-dom.test.ts`): probe starts hidden behind the image; upgrade on load; stay-on-image on CSP violation (and a late `load` cannot swap after settling); ChatGPT path skips the probe; no probe without `embed_url`
- [x] Full suite: 533 + 13 tests pass, all 4 typecheck projects pass
- [ ] Staging smoke: chart renders unchanged on claude.ai (PNG baseline, probe fails fast via CSP violation)
- [ ] Staging smoke: chart still interactive on ChatGPT (committed iframe path untouched)