### PR TITLE
fix(render): render freshness and free-tier relevance on cards

### DIFF
--- a/workers/src/tools/_render_markdown.test.ts
+++ b/workers/src/tools/_render_markdown.test.ts
@@ -176,6 +176,37 @@ describe("renderSearchMarkdown", () => {
     expect(md).toContain("semantic_description: Tesla quarterly revenue series");
   });
 
+  it("renders the as-of date from data_freshness in its object form (the shape prod sends)", () => {
+    const c = card({ data_freshness: { data_as_of: "2026-03-31" } } as Partial<TakoCard>);
+    const md = renderSearchMarkdown(searchOutput({ cards: [c] }));
+    expect(md).toContain("freshness: 2026-03-31");
+  });
+
+  it("still renders data_freshness when it arrives as a bare string", () => {
+    const c = card({ data_freshness: "2026-03-31" } as Partial<TakoCard>);
+    const md = renderSearchMarkdown(searchOutput({ cards: [c] }));
+    expect(md).toContain("freshness: 2026-03-31");
+  });
+
+  it("falls back to the coarse relevance string when relevance_score is absent (free tier)", () => {
+    const c = card({ relevance: "High" } as Partial<TakoCard>);
+    const md = renderSearchMarkdown(searchOutput({ cards: [c] }));
+    expect(md).toContain("relevance: High");
+  });
+
+  it("prefers the entitled numeric relevance_score over the coarse string", () => {
+    const c = card({ relevance_score: 0.87, relevance: "High" } as Partial<TakoCard>);
+    const md = renderSearchMarkdown(searchOutput({ cards: [c] }));
+    expect(md).toContain("relevance: 0.87");
+    expect(md).not.toContain("relevance: High");
+  });
+
+  it("omits freshness and relevance entirely when neither is present", () => {
+    const md = renderSearchMarkdown(searchOutput({ cards: [card()] }));
+    expect(md).not.toContain("freshness:");
+    expect(md).not.toContain("relevance:");
+  });
+
   it("omits semantic_description when it duplicates the description", () => {
     const c = card({
       semantic_description: "Quarterly revenue for Tesla, Inc.",

--- a/workers/src/tools/_render_markdown.ts
+++ b/workers/src/tools/_render_markdown.ts
@@ -206,6 +206,36 @@ function namesOf(items: unknown, nameKey: string): string[] {
 
 type LooseDefinition = { term?: unknown; metric_name?: unknown; name?: unknown; definition?: unknown };
 
+/**
+ * A card's as-of date. The backend ships this as an OBJECT
+ * (`{"data_as_of": "2026-03-31"}`) on search cards, so a bare
+ * `typeof === "string"` test drops it on every real card. The date is the
+ * only reliable way to tell a reported actual from a forward projection (a
+ * future date) and a fresh series from a stale vintage, so losing it costs
+ * the model a correctness check the title alone cannot replace. Accept the
+ * string form too — other endpoints send one.
+ */
+function freshnessOf(value: unknown): string | undefined {
+  if (typeof value === "string" && value !== "") return value;
+  if (value !== null && typeof value === "object") {
+    const asOf = (value as { data_as_of?: unknown }).data_as_of;
+    if (typeof asOf === "string" && asOf !== "") return asOf;
+  }
+  return undefined;
+}
+
+/**
+ * Retrieval relevance. `relevance_score` is the entitlement-gated numeric
+ * field; unentitled responses carry the coarse `relevance` string ("High" /
+ * "Medium" / "Low") instead. Render whichever is present so the fact never
+ * silently vanishes for free-tier callers.
+ */
+function relevanceOf(rec: Record<string, unknown>): string | undefined {
+  if (typeof rec.relevance_score === "number") return String(rec.relevance_score);
+  if (typeof rec.relevance === "string" && rec.relevance !== "") return rec.relevance;
+  return undefined;
+}
+
 function renderCard(card: TakoCard, idx: number): string {
   const rec = card as Record<string, unknown>;
   const lines: string[] = [];
@@ -227,11 +257,13 @@ function renderCard(card: TakoCard, idx: number): string {
 
   const facts: string[] = [];
   facts.push(`exportable: ${card.exportable === true ? "yes" : "no"}`);
-  if (typeof rec.relevance_score === "number") facts.push(`relevance: ${rec.relevance_score}`);
+  const relevance = relevanceOf(rec);
+  if (relevance !== undefined) facts.push(`relevance: ${relevance}`);
   if (typeof rec.card_type === "string" && rec.card_type !== "") {
     facts.push(`type: ${rec.card_type}`);
   }
-  if (typeof rec.data_freshness === "string") facts.push(`freshness: ${rec.data_freshness}`);
+  const freshness = freshnessOf(rec.data_freshness);
+  if (freshness !== undefined) facts.push(`freshness: ${freshness}`);
   const nodes = card.nodes ?? [];
   if (nodes.length > 0) {
     facts.push(`nodes: ${nodes.map((n) => `\`${n.id}\` (${n.name})`).join(", ")}`);

--- a/workers/src/tools/_search_results.ts
+++ b/workers/src/tools/_search_results.ts
@@ -560,11 +560,13 @@ const searchedWeb = (s: SearchedSources): boolean => s.includes("web");
  * not being covered, and every retry is a priced call the model burns on a
  * loop that never converges.
  *
- * The wording is mirrored (as a "HARD STOP on retries" bullet) in the three
- * bundled skills' SKILL.md files under skills/ and their embedded copies in
- * README.md — keep the recovery recipe (free tako_available_data check →
- * at most ONE pinned retry → stop) consistent across all copies when
- * editing any of them.
+ * This protocol is mirrored in the three bundled skills' SKILL.md files
+ * under skills/ and their embedded copies in README.md, each as the
+ * "Empty result (zero cards)" bullet. What must stay consistent is the
+ * RECIPE — free tako_available_data check → at most ONE pinned retry →
+ * stop and answer from the web results — not the phrasing; pin an
+ * invariant here rather than a quoted sentence, so a reworded skill does
+ * not silently make this comment a lie. Update all four copies together.
  */
 function buildZeroResultGuidance(
   hasWebResults: boolean,


### PR DESCRIPTION
Two retrieval facts were silently dropped from **every real card** in the markdown response this branch introduces — and that markdown is what the model reads.

## `freshness` never rendered

`renderCard` guarded on `typeof rec.data_freshness === "string"`, but the backend sends an object:

```json
"data_freshness": { "data_as_of": "2026-03-31" }
```

Verified against a captured production card. The as-of date is the only reliable way to tell a reported actual from a forward projection and a fresh series from a stale vintage — the title is not a usable signal (a plainly-titled "Toyota Revenues (Normalized) (Annual)" card carries a 2026-12-31 as-of), and stale vintages routinely outrank current ones in macro results (the FRED "Inflation Rate" card that ranks #1 for `"US CPI inflation"` ends in Jan 2024). Now accepts the object form and still handles the bare string other endpoints send.

## `relevance` never rendered for unentitled callers

The guard only accepted the entitlement-gated numeric `relevance_score`. Free-tier responses instead carry the coarse `relevance` string (`"High"`/`"Medium"`/`"Low"`), which was discarded — so the fact vanished entirely for anonymous users. Prefers the numeric score when present, falls back to the string.

## Also

Re-points the zero-result mirror comment in `_search_results.ts` at the recovery *recipe* rather than a quoted sentence. It previously said the wording was mirrored "as a `HARD STOP on retries` bullet" in the bundled skills; rewording those skills made the comment a lie without anything failing. Pinning the invariant instead of the phrasing keeps it honest.

## Testing

Five regression tests added. Verified they are not vacuous: reverting the renderer change fails exactly the two bug-catching tests (object-form freshness, relevance-string fallback) while the other three pass either way. Full suite green — 4/4 typecheck passes, 585 worker + 8 widget tests, `schemas:check` and `registry:check` clean.

Targets this branch rather than main because `_render_markdown.ts` does not exist on main. Companion skills PR is #184.