### PR TITLE
docs: add one-click install deeplinks for Cursor and VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ https://mcp.tako.com/mcp
 - **OAuth** (Claude Code plugin, Claude.ai, Claude Desktop, ChatGPT) — a browser sign-in with your Tako account; a per-host API key is minted for you automatically.
 - **Bearer token** (config-file clients: Cursor, Windsurf, VS Code, …) — **[get your API key](https://tako.com/console/api-keys)** and paste it into the header.
 
+### One-click install
+
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tako&config=eyJ1cmwiOiJodHRwczovL21jcC50YWtvLmNvbS9tY3AifQ==)
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Tako-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Tako-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D&quality=insiders)
+
+Claude Code installs with one command — the plugin brings the MCP connection plus Tako's bundled [research skills](#agent-skills):
+
+```bash
+claude plugin marketplace add TakoData/tako-mcp && claude plugin install tako@tako
+```
+
+Each of these lands on the free tier immediately. Authenticate later to unlock the full toolset — see your client's section below.
+
 Pick your client below.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://mcp.tako.com/mcp
 
 ### One-click install
 
-[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tako&config=eyJ1cmwiOiJodHRwczovL21jcC50YWtvLmNvbS9tY3AifQ==)
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=tako&config=eyJ1cmwiOiJodHRwczovL21jcC50YWtvLmNvbS9tY3AifQ==)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Tako-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Tako-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D&quality=insiders)
 


### PR DESCRIPTION
## What

Adds a **One-click install** section to the README install block:

- **Cursor** deeplink badge → `https://cursor.com/en/install-mcp?name=tako&config=<base64>`
- **VS Code** and **VS Code Insiders** deeplink badges → `https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=<urlencoded>`
- **Claude Code** as a single copy-paste plugin command

All three point at the hosted `https://mcp.tako.com/mcp` endpoint, so each one lands on the anonymous free tier — a new user reaches first value without minting a token.

## Why

The MCP distribution audit assumed these already existed. They did not — the README had zero install deeplinks. Registries and directories surface these badges, and install friction is where MCP servers lose users.

## Verification

- Cursor config is base64 of `{"url":"https://mcp.tako.com/mcp"}`, VS Code config is urlencoded `{"type":"http","url":"https://mcp.tako.com/mcp"}` — both round-tripped in Python.
- Formats copied from authoritative examples: Tavily's README (Cursor) and `github/github-mcp-server` (VS Code).
- Badge images return `200 image/svg+xml`; both deeplinks return `308`/`302` redirects into the client.
- Confirmed the embedded endpoint initializes anonymously: `initialize` → `serverInfo.version 0.15.1`, no token.

## Test plan

- [ ] Click the Cursor badge on a machine with Cursor installed — confirm it prefills a `tako` remote server and connects on the free tier
- [ ] Click the VS Code badge — same check
- [ ] Confirm badges render on the GitHub README (light and dark)

Docs-only; no code paths touched.