### PR TITLE
fix(mcp): answer 405 on GET/DELETE /mcp, and add one-click install deeplinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ https://mcp.tako.com/mcp
 - **OAuth** (Claude Code plugin, Claude.ai, Claude Desktop, ChatGPT) — a browser sign-in with your Tako account; a per-host API key is minted for you automatically.
 - **Bearer token** (config-file clients: Cursor, Windsurf, VS Code, …) — **[get your API key](https://tako.com/console/api-keys)** and paste it into the header.
 
+### One-click install
+
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tako&config=eyJ1cmwiOiJodHRwczovL21jcC50YWtvLmNvbS9tY3AifQ==)
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Tako-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D)
+[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Tako-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D&quality=insiders)
+
+Claude Code installs with one command — the plugin brings the MCP connection plus Tako's bundled [research skills](#agent-skills):
+
+```bash
+claude plugin marketplace add TakoData/tako-mcp && claude plugin install tako@tako
+```
+
+Each of these lands on the free tier immediately. Authenticate later to unlock the full toolset — see your client's section below.
+
 Pick your client below.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://mcp.tako.com/mcp
 
 ### One-click install
 
-[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=tako&config=eyJ1cmwiOiJodHRwczovL21jcC50YWtvLmNvbS9tY3AifQ==)
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=tako&config=eyJ1cmwiOiJodHRwczovL21jcC50YWtvLmNvbS9tY3AifQ==)
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Tako-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D)
 [![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Tako-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=tako&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmcp.tako.com%2Fmcp%22%7D&quality=insiders)
 

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -23,6 +23,50 @@ describe("worker routing", () => {
     expect(res.status).toBe(404);
   });
 
+  // Regression: Cursor tombstoned the transport against production.
+  //
+  // Streamable HTTP reserves 404-on-a-session-request to mean "this session
+  // is gone, re-initialize", and requires 405 from a server that does not
+  // offer the optional server->client SSE stream. We run stateless (no
+  // Mcp-Session-Id is ever issued) so we genuinely do not offer that
+  // stream — but GET /mcp used to fall through to the catch-all 404, so
+  // Cursor read it as session death, re-initialized, retried, and after
+  // 5 consecutive session-404s disabled the transport permanently:
+  //
+  //   Failed to open SSE stream
+  //   Tombstoning streamable HTTP transport after 5 consecutive
+  //   session HTTP 404 responses; automatic retry disabled
+  //
+  // 405 tells the client "this method is not available here" without
+  // implying the session died, which is what Context7 and AWS's remote
+  // servers return and why they connect cleanly in Cursor.
+  describe("unsupported methods on /mcp return 405, never 404", () => {
+    for (const method of ["GET", "DELETE"] as const) {
+      it(`${method} /mcp returns 405 with Allow: POST`, async () => {
+        const res = await SELF.fetch("https://example.com/mcp", {
+          method,
+          headers: { accept: "text/event-stream" },
+        });
+        expect(res.status).toBe(405);
+        expect(res.headers.get("allow")).toBe("POST");
+      });
+    }
+
+    it("GET /mcp does not 404 even when a stale Mcp-Session-Id is sent", async () => {
+      // A client that had previously been handed a session id (or invented
+      // one) must still not be told the session expired.
+      const res = await SELF.fetch("https://example.com/mcp", {
+        method: "GET",
+        headers: {
+          accept: "text/event-stream",
+          "mcp-session-id": "stale-session-from-a-previous-connection",
+        },
+      });
+      expect(res.status).not.toBe(404);
+      expect(res.status).toBe(405);
+    });
+  });
+
   it("GET /.well-known/openai-apps-challenge returns the configured token as plain text", async () => {
     // OpenAI's connector-directory domain-verification flow GETs this
     // URL during submission and matches the response body verbatim

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -45,12 +45,40 @@ export default {
       return handleIconRequest(url.pathname);
     }
 
-    // GET /mcp (SSE resubscription), DELETE /mcp (session terminate), and
-    // OPTIONS /mcp (browser CORS preflight) are intentionally unrouted:
-    // stateless JSON-response mode does not use GET/DELETE, and current
-    // MCP clients (Claude Desktop, CLI) do not issue preflights. Revisit
-    // when Phase 2 introduces streaming tools or browser-based clients —
-    // see the `transport.close()` TODO in `mcp.ts`.
+    // GET /mcp (server->client SSE stream) and DELETE /mcp (session
+    // terminate) are genuinely not offered: we run stateless JSON-response
+    // mode and never issue an `Mcp-Session-Id`, so there is no session to
+    // resubscribe to or tear down.
+    //
+    // They must still answer 405, not fall through to the catch-all 404.
+    // Streamable HTTP gives those two codes different meanings: 405 means
+    // "this method is not available here" (the spec's prescribed reply from
+    // a server that does not offer the optional SSE stream), while 404 on a
+    // session-bearing request means "your session is gone, re-initialize".
+    //
+    // Cursor obeys that distinction. Against the 404 it re-initialized,
+    // re-issued the GET, and after 5 consecutive session-404s disabled the
+    // transport for good:
+    //
+    //   Failed to open SSE stream
+    //   Tombstoning streamable HTTP transport after 5 consecutive session
+    //   HTTP 404 responses; automatic retry disabled
+    //
+    // Claude Desktop and Claude Code never hit this because they do not
+    // open the GET stream, which is why it went unnoticed. Context7 and
+    // AWS's remote servers both return 405 here and connect cleanly.
+    if (
+      (request.method === "GET" || request.method === "DELETE") &&
+      url.pathname === "/mcp"
+    ) {
+      return new Response("method not allowed", {
+        status: 405,
+        headers: {
+          allow: "POST",
+          "content-type": "text/plain; charset=utf-8",
+        },
+      });
+    }
 
     // OpenAI connector-directory domain verification. During the
     // submission flow OpenAI hits this URL and expects to read back


### PR DESCRIPTION
Cursor could not connect to `mcp.tako.com`. Found by clicking a one-click install deeplink, so this PR carries both the fix and the deeplinks it unblocks.

## The bug

```
Successfully connected to streamableHttp server
Failed to open SSE stream
Detected session termination, re-initializing connection before retry
Tombstoning streamable HTTP transport after 5 consecutive session HTTP 404 responses;
automatic retry disabled
```

## Root cause

`initialize` succeeds over POST. Cursor then issues `GET /mcp` to open the server→client SSE stream. Only `POST /mcp` was routed (`index.ts:27`), so the GET fell through to the catch-all 404.

Streamable HTTP gives those two codes **different meanings**:

| Code | Meaning |
|---|---|
| **405** | This method is not available here — the prescribed reply from a server that does not offer the optional SSE stream |
| **404** on a session-bearing request | Your session is gone; re-initialize |

We run stateless and never issue an `Mcp-Session-Id`, so we genuinely do not offer that stream. But we answered with the code meaning *session died*, so Cursor re-initialized, re-issued the GET, got 404 again, and after 5 rounds disabled the transport permanently.

The comment at `index.ts:48` deliberately left GET/DELETE unrouted on the assumption that "current MCP clients (Claude Desktop, CLI) do not issue preflights." True for the Claude clients — they never open the GET stream, which is why this went unnoticed — but not for Cursor.

## Evidence

Reproduced against production:

```
POST   /mcp  initialize  -> 200, application/json, NO mcp-session-id
GET    /mcp  (SSE)       -> 404 "not found"   <-- the bug
DELETE /mcp              -> 404 "not found"
```

Two remote servers that connect cleanly in Cursor, for comparison:

```
GET https://mcp.context7.com/mcp          -> 405 Method Not Allowed
GET https://knowledge-mcp.global.api.aws  -> 405
```

## What's in here

**1. The fix** — route `GET` and `DELETE /mcp` to 405 with `Allow: POST`. `POST /mcp` untouched. No session support added; 405 is the honest answer for a stateless server.

**2. One-click install deeplinks** in the README — Cursor, VS Code, VS Code Insiders, plus the Claude Code plugin one-liner. All point at `https://mcp.tako.com/mcp` and land on the anonymous free tier, so click-to-first-answer has no signup in the middle. Config shapes verified against what Upstash Context7, `awslabs/mcp`, and Perplexity actually ship (`{"url":...}` for Cursor, `{"type":"http","url":...}` for VS Code); both round-tripped, badges return `200 image/svg+xml`.

These ship together because the deeplinks send Cursor users straight into the handshake this PR fixes.

## Tests

3 new cases in `index.test.ts`, including one asserting GET does not 404 **even with a stale `Mcp-Session-Id`** — the precise trigger for Cursor's session-death path. Verified failing before the fix:

```
AssertionError: expected 404 to be 405
AssertionError: expected 404 not to be 404
```

- 633/633 worker tests pass
- All four typecheck projects clean (`tsc`, `tsconfig.test.json`, `scripts/`, `test/widget/`)

## Test plan

Merging does not fix production — the worker has to be deployed. Until then the README badges point at a server Cursor still cannot hold a connection to.

- [ ] Deploy to staging, point Cursor at it, confirm the tool list loads and a query returns
- [ ] After prod deploy: `curl -i -X GET https://mcp.tako.com/mcp` returns `405` with `Allow: POST`
- [ ] Click the Cursor badge end to end (remove any existing Tako entry first — the tombstone disables retry for that transport)
- [ ] Click the VS Code badge
- [ ] Add GET/DELETE probes to the smoke suite; a POST-only check passes while Cursor is fully broken
