### PR TITLE
fix(guidance): scope the anti-retry rule to the data axis, not the whole call

### DIFF
--- a/workers/src/tools/_search_results.test.ts
+++ b/workers/src/tools/_search_results.test.ts
@@ -359,13 +359,32 @@ describe("buildSearchOutput — zero-card guidance", () => {
     expect(out.guidance).toMatch(/tako_available_data/);
   });
 
-  it("still fires on zero cards WITH web_results — steering to the web fallback, not a re-search", () => {
+  it("still fires on zero cards WITH web_results — steering to the web fallback", () => {
     // The common default-source miss: no data card, some web hits. This is
     // exactly the "reword and retry for a chart" loop case, so guidance must
     // not be silently skipped here.
     const out = buildSearchOutput([], [{ title: "t", url: "https://x.com" }], "req-3", null, ENV, ["data", "web"]);
-    expect(out.guidance).toMatch(/do not re-search/i);
     expect(out.guidance).toMatch(/web_results/);
+    // The verdict is scoped to the graph, not to the whole call.
+    expect(out.guidance).toMatch(/DATA GRAPH only/);
+  });
+
+  // THE MISFIRE. This branch used to say "do NOT re-search with rephrasings"
+  // flat out, which is right for hunting a data card and wrong for every
+  // question whose answer is on the web: a docs or reference lookup is won by
+  // re-searching per entity or per provider, and the guidance was telling the
+  // model to stop after one call. The ban must name the DATA axis and the
+  // carve-out must be explicit — a model reading this cannot be left to infer
+  // that web refinement is still allowed.
+  it("does not ban web re-searching when zero cards come back with web results", () => {
+    const out = buildSearchOutput([], [{ title: "t", url: "https://x.com" }], "req-3b", null, ENV, ["data", "web"]);
+    const g = out.guidance ?? "";
+    expect(g).toContain("Re-searching is NOT banned here");
+    // Names the fan-out that wins these questions.
+    expect(g).toMatch(/SEVERAL narrow queries/);
+    expect(g).toMatch(/one per entity, provider or site/);
+    // Any surviving blanket ban would read as one of these.
+    expect(g).not.toMatch(/do NOT re-search with rephrasings/i);
   });
 
   it("tailors the both-empty protocol for a data-only search (web fallback allowed on the single retry)", () => {
@@ -374,10 +393,19 @@ describe("buildSearchOutput — zero-card guidance", () => {
     expect(out.guidance).toMatch(/"web"/);
   });
 
-  it("gives a web-only search web-shaped guidance instead of node-pinning advice", () => {
+  // A web-only search that came back empty has NO data verdict to report (the
+  // data source was never queried) and exactly one lever available: the query.
+  // This branch used to ban that lever — "do NOT retry this query or
+  // rephrasings of it" — which left the model with nothing to do at all.
+  it("tells a web-only search to refine, and claims nothing about graph coverage", () => {
     const out = buildSearchOutput([], [], "req-5", null, ENV, ["web"]);
-    expect(out.guidance).toMatch(/do not retry/i);
-    expect(out.guidance).not.toMatch(/node_id/);
+    const g = out.guidance ?? "";
+    expect(g).not.toMatch(/node_id/);
+    expect(g).toMatch(/Refine and re-search/i);
+    expect(g).toMatch(/NOT a coverage verdict/i);
+    expect(g).not.toMatch(/do NOT retry/i);
+    // Still not an invitation to loop forever.
+    expect(g).toMatch(/Stop only once/i);
   });
 
   it("treats the legacy \"tako\" source alias as data", () => {

--- a/workers/src/tools/_search_results.ts
+++ b/workers/src/tools/_search_results.ts
@@ -650,6 +650,59 @@ export const searchedData = (s: SearchedSources): boolean =>
 const searchedWeb = (s: SearchedSources): boolean => s.includes("web");
 
 /**
+ * The WEB axis carve-out — the other half of the anti-retry rule.
+ *
+ * "Do not rephrase and retry" was measured on DATA queries, where rewording
+ * almost never flips a miss into a hit and every attempt is priced. It was
+ * then written as advice about the whole call, which made it misfire on
+ * questions the data graph was never going to answer: a zero-card
+ * `tako_search` told the model "the data graph does not cover this — do NOT
+ * re-search with rephrasings" even when the question was a docs or reference
+ * lookup whose answer is entirely on the web, and where re-searching per
+ * entity or per provider is precisely the strategy that works. Measured
+ * against the field, a competing web-search MCP wins those questions with
+ * 5-6 targeted calls per question; our own guidance was telling the model to
+ * stop after one.
+ *
+ * So the ban is scoped to what it was measured on. Rephrasing to hunt for a
+ * CARD does not converge. Refining a WEB query does, and fanning out narrow
+ * queries beats one broad one — the same rule the tool descriptions already
+ * give for the data side ("one entity + one metric per query"), applied to
+ * the web side.
+ *
+ * `sources: ["web"]` on those follow-ups is not a guess: a response carrying
+ * web results and zero cards has just DEMONSTRATED the graph does not hold
+ * this, which is the exact precondition `sources`' own description sets for
+ * narrowing ("only for content a data graph cannot hold").
+ *
+ * Exported so `tako_answer`'s data-gap guidance carries the identical
+ * carve-out. Two tools whose recovery advice disagrees teach the model that
+ * one of them is wrong.
+ */
+export const REFINE_WEB_FREELY =
+  'Re-searching is NOT banned here — what does not converge is rephrasing to hunt for a data CARD. If what you actually need is web content (docs, reference pages, news, qualitative claims), refine and re-search freely: prefer SEVERAL narrow queries (one per entity, provider or site) over one broad one, and pass sources:["web"] on them, since this response has already shown the graph does not hold it.';
+
+/**
+ * The same carve-out for `tako_answer`, where the move is DECOMPOSITION rather
+ * than refinement.
+ *
+ * `tako_answer` synthesizes one answer per call, so a question spanning several
+ * entities or providers ("how does each of these APIs handle X") gets one
+ * blended answer built from whatever the single retrieval happened to surface.
+ * Re-asking the same broad question is the loop that does not converge; asking
+ * it once per entity is not a retry at all, it is the shape the tool wants —
+ * the same "one entity per query" rule its own description gives for the data
+ * side.
+ *
+ * Stated as guidance rather than implemented as internal fan-out on purpose:
+ * splitting a question server-side would multiply a priced call without the
+ * caller asking, and the model is the only party that knows which entities the
+ * question actually covers.
+ */
+export const DECOMPOSE_WEB_ASK =
+  "If the answer lives on the web rather than in the data graph, do not re-ask this same question: DECOMPOSE it. One narrow question per entity, provider or site, asked in parallel, beats one broad question — that is not a retry, it is the shape this tool answers best, and it is how a multi-part web question gets a complete answer instead of a blended one.";
+
+/**
  * Recovery protocol for a zero-CARD search. Rewording the same query almost
  * never flips a miss into a hit — misses come from query SHAPE (compound
  * query, brand instead of domain, unresolved entity) or from the data simply
@@ -663,6 +716,14 @@ const searchedWeb = (s: SearchedSources): boolean => s.includes("web");
  * stop and answer from the web results — not the phrasing; pin an
  * invariant here rather than a quoted sentence, so a reworded skill does
  * not silently make this comment a lie. Update all four copies together.
+ *
+ * {@link REFINE_WEB_FREELY} is deliberately NOT mirrored into those three:
+ * they are data-domain skills (equity research, macro indicators, site
+ * traffic) whose questions are metric lookups by construction, so the
+ * data-axis recipe is the whole story there. The carve-out matters for the
+ * TOOL guidance, which serves arbitrary questions — including ones with no
+ * data answer at all. Absence from the skills is the intended state, not
+ * drift.
  */
 function buildZeroResultGuidance(
   hasWebResults: boolean,
@@ -670,20 +731,27 @@ function buildZeroResultGuidance(
 ): string {
   if (hasWebResults) {
     return [
-      "This search returned web results but no data cards. That usually means the data graph does not cover this query, not that the wording was unlucky, so do NOT re-search with rephrasings.",
+      "This search returned web results but no data cards. That is a verdict about the DATA GRAPH only: it does not cover this query, and rewording will not change that.",
       "Answer from the web_results (tako_contents on the most relevant url fetches its full page text).",
       `If you specifically need a chart or dataset, run tako_available_data (free) once; re-search only if it confirms coverage, and then ${PINNED_RETRY}.`,
+      REFINE_WEB_FREELY,
     ].join(" ");
   }
   if (!searchedData(sources)) {
+    // Web-only search, nothing back. There is no data verdict to report here —
+    // the data source was never queried — and a bare "do not retry" was simply
+    // wrong: on a web-only query, the QUERY is the only lever there is, so
+    // refining it is the whole recovery. This branch used to ban the one move
+    // available.
     return [
-      "No results — do NOT retry this query or rephrasings of it; every search is priced, and the live web returned nothing here.",
-      "If a data metric is what you are after, check tako_available_data (free) for coverage and run ONE data-source search;",
-      "otherwise stop calling Tako for this question and answer from other tools.",
+      "No results from the web for this query. The data source was not searched, so this is NOT a coverage verdict about Tako's graph — it means the query itself came back empty.",
+      "Refine and re-search: narrow to one entity, provider or site per query rather than one broad query, or name the specific doc/page you expect to find.",
+      "If a data metric is what you are actually after, check tako_available_data (free) for coverage and run ONE data-source search.",
+      "Stop only once a couple of genuinely different framings have come back empty.",
     ].join(" ");
   }
   return [
-    "No results — do NOT retry this query or rephrasings of it; every search is priced, and empty means the query shape is off or the data is not covered, not that the wording was unlucky.",
+    "No results — do NOT retry this query or rephrasings of it hoping a data card appears; every search is priced, and empty means the query shape is off or the data is not covered, not that the wording was unlucky.",
     "Recover in order: (1) call tako_available_data (free) with the entity to learn the exact metric names + node_ids Tako actually has;",
     `(2) if it confirms coverage, spend your ONE remaining search on that exact name and ${PINNED_RETRY}` +
       (searchedWeb(sources)

--- a/workers/src/tools/tako_answer.test.ts
+++ b/workers/src/tools/tako_answer.test.ts
@@ -467,9 +467,65 @@ describe("tako_answer series-in-first-response (the punt-and-retry fix)", () => 
       takoAnswer.inputSchema.parse({ query: "hotel RevPAR Q3" }),
       CTX,
     );
-    expect(out.guidance).toContain("and no web results");
+    expect(out.guidance).toContain("zero web results");
     expect(out.guidance).toContain("Do NOT rephrase-and-retry");
     expect(out.guidance).not.toContain("web-grounded only");
+    // The ban names what it is about. A flat "do not retry" reads as "stop
+    // working", and on a web-shaped question one narrower ask is the right move.
+    expect(out.guidance).toContain("hoping the same question lands a data series");
+    expect(out.guidance).toMatch(/WEB axis only/);
+  });
+
+  // tako_answer synthesizes ONE answer per call, so a multi-entity web question
+  // ("how does each of these handle X") returns one blended answer. Re-asking
+  // the same broad question is the loop that does not converge; asking it once
+  // per entity is not a retry at all. The guidance has to say so, or the
+  // anti-retry sentence reads as "stop after one call".
+  it("tells a web-grounded answer to DECOMPOSE rather than re-ask", async () => {
+    mockFetchSequence([
+      jsonResponse(200, {
+        answer: "Per the docs, both support it.",
+        cards: [],
+        web_results: [{ title: "docs", url: "https://example.com/docs" }],
+        request_id: "req-gap-web",
+      }),
+    ]);
+    const out = await takoAnswer.handler(
+      takoAnswer.inputSchema.parse({ query: "how do these APIs handle pagination" }),
+      CTX,
+    );
+    const g = out.guidance ?? "";
+    expect(g).toContain("web-grounded only");
+    expect(g).toContain("DECOMPOSE");
+    expect(g).toMatch(/One narrow question per entity, provider or site/);
+    // Scoped, not blanket: the ban is about hunting a data series.
+    expect(g).toContain("do NOT rephrase-and-retry tako_answer for it");
+  });
+
+  // The default sources are ["data","web"], so this branch is only reached by a
+  // caller who narrowed to ["data"] — meaning the web was never queried. The
+  // verdict used to be built from `hasWebResults` alone and therefore claimed
+  // "and no web results", reporting a second source's outcome from the first
+  // source's evidence, then told the model to treat the metric as absent.
+  it("does not claim the web came back empty when the web was never searched", async () => {
+    mockFetchSequence([
+      jsonResponse(200, {
+        answer: "I couldn't find that in the provided sources.",
+        cards: [],
+        web_results: [],
+        request_id: "req-gap-data-only",
+      }),
+    ]);
+    const out = await takoAnswer.handler(
+      takoAnswer.inputSchema.parse({ query: "hotel RevPAR Q3", sources: ["data"] }),
+      CTX,
+    );
+    const g = out.guidance ?? "";
+    expect(g).not.toContain("zero web results");
+    expect(g).toContain("DATA source only");
+    // Names the cheap next step instead of declaring the figure unavailable.
+    expect(g).toMatch(/sources:\["data","web"\]/);
+    expect(g).not.toMatch(/genuinely absent/);
   });
 
   it("no guidance on a web-only ask (no data verdict to render)", async () => {

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -14,6 +14,11 @@ import {
   INLINE_PREVIEW_ROW_CAP,
   MAX_PREVIEW_ROWS,
   orderCardsByUsefulness,
+  // The web-axis half of the anti-retry rule, shared with tako_search's
+  // zero-result guidance for the same reason PINNED_RETRY is: a recovery
+  // protocol that differs between the two tools teaches the model that one of
+  // them is wrong.
+  DECOMPOSE_WEB_ASK,
   // The single source of the pin recipe: tako_search's zero-result guidance and
   // this tool's zero-card verdict must name the SAME form, or the model learns
   // two and only one works. Measured on prod (2026-07-29): re-asking here with
@@ -183,12 +188,22 @@ export function buildAnswerBody(input: Input): z.input<typeof SearchRequest> {
  * index, not read as "this answer failed". Without web grounding it is the
  * hard anti-retry stop. Both are deterministic (cards.length === 0), never
  * inferred from the prose.
+ *
+ * `searchedWebToo` is what keeps the no-web-results branch honest. It used to
+ * read "ZERO curated data cards (and no web results)" off `hasWebResults`
+ * alone, so a deliberate `sources: ["data"]` ask — where the web was never
+ * queried — was told the web had come back empty as well, and then told to
+ * treat the metric as absent. Two sources' worth of verdict from one source's
+ * evidence. When web was not searched, the honest recovery is to search it.
  */
-function buildDataGapGuidance(hasWebResults: boolean): string {
-  if (hasWebResults) {
-    return `Data-coverage note: ZERO curated data cards ground this answer — it is web-grounded only (machine check: cards.length === 0). If the prose answers the question, use it as-is. If you specifically wanted Tako's proprietary series, do NOT rephrase-and-retry tako_answer (priced, rarely converges): confirm coverage once with tako_available_data (free), then re-ask ONCE — ${PINNED_RETRY} — and state the period you need in the query. Do NOT reach for tako_contents: it cannot return rows for a card this answer did not cite, and it always 403s on license-gated cards.`;
+function buildDataGapGuidance(hasWebResults: boolean, searchedWebToo: boolean): string {
+  if (!hasWebResults && !searchedWebToo) {
+    return `Data-coverage verdict: ZERO curated data cards ground this answer (machine check: cards.length === 0). This ran with the DATA source only, so nothing here says anything about web coverage — do not read it as "not available anywhere". Cheapest next step: re-ask with sources:["data","web"] (same price) before concluding the figure is unavailable. If you want the proprietary series specifically, confirm coverage once with tako_available_data (free), then re-ask ONCE — ${PINNED_RETRY} — stating the period you need. Do NOT reach for tako_contents: it returns rows only for an exportable card you already have, and 403s on license-gated ones.`;
   }
-  return `Data-coverage verdict: ZERO curated data cards (and no web results) ground this answer — treat the metric as NOT in Tako's data index for this phrasing (machine check: cards.length === 0). Do NOT rephrase-and-retry tako_answer; every retry is priced and this loop rarely converges. Recover in ONE step: call tako_available_data (free) to confirm coverage, then re-ask HERE once (${PINNED_RETRY}), stating the period you need in the query. Do NOT reach for tako_contents — it returns rows only for an exportable card you already have, and 403s on license-gated ones. If tako_available_data shows no coverage, the metric is genuinely absent: say so and use another source.`;
+  if (hasWebResults) {
+    return `Data-coverage note: ZERO curated data cards ground this answer — it is web-grounded only (machine check: cards.length === 0). If the prose answers the question, use it as-is. If you specifically wanted Tako's proprietary series, do NOT rephrase-and-retry tako_answer for it (priced, rarely converges): confirm coverage once with tako_available_data (free), then re-ask ONCE — ${PINNED_RETRY} — and state the period you need in the query. Do NOT reach for tako_contents: it cannot return rows for a card this answer did not cite, and it always 403s on license-gated cards. ${DECOMPOSE_WEB_ASK}`;
+  }
+  return `Data-coverage verdict: ZERO curated data cards AND zero web results ground this answer — treat the metric as NOT in Tako's data index for this phrasing (machine check: cards.length === 0). Do NOT rephrase-and-retry tako_answer hoping the same question lands a data series; every retry is priced and that loop rarely converges. Recover in ONE step: call tako_available_data (free) to confirm coverage, then re-ask HERE once (${PINNED_RETRY}), stating the period you need in the query. Do NOT reach for tako_contents — it returns rows only for an exportable card you already have, and 403s on license-gated ones. If tako_available_data shows no coverage, the metric is genuinely absent from the graph: say so and use another source. One exception to the stop, on the WEB axis only: a genuinely narrower question (one entity, one provider, one site) is worth a single attempt, because an empty web result usually means the question was too broad rather than unanswerable.`;
 }
 
 const takoAnswer = {
@@ -285,7 +300,12 @@ const takoAnswer = {
       // a web-cited answer may be complete and correct — the verdict then
       // scopes itself to the DATA index instead of impugning the answer.
       ...(searchedData(input.sources) && cards.length === 0
-        ? { guidance: buildDataGapGuidance(web_results.length > 0) }
+        ? {
+            guidance: buildDataGapGuidance(
+              web_results.length > 0,
+              input.sources.includes("web"),
+            ),
+          }
         : {}),
       // Glossary spreads on LAST so it serializes after the data — truncating
       // clients then drop boilerplate first.

--- a/workers/src/tools/tako_search.test.ts
+++ b/workers/src/tools/tako_search.test.ts
@@ -331,8 +331,12 @@ describe("tako_search response mapping", () => {
 
     expect(out.web_results).toHaveLength(1);
     expect(out.web_results[0]?.url).toBe("https://example.com/a");
-    // Zero cards (even with web hits) still carries anti-retry guidance.
-    expect(out.guidance).toMatch(/do not re-search/i);
+    // Zero cards still carries guidance — but this is a WEB-ONLY search, so it
+    // must not claim anything about data coverage, and must not ban the one
+    // recovery available (refining the query). It previously asserted a blanket
+    // "do not re-search", which is the misfire.
+    expect(out.guidance).toMatch(/Refine and re-search/i);
+    expect(out.guidance).not.toMatch(/do NOT re-search/i);
   });
 
   it("populates auto-chain widget fields when the top card has card_id", async () => {


### PR DESCRIPTION
## The bug

"Do not rephrase and retry" was measured on **data** queries, where rewording almost never flips a miss into a hit and every attempt is priced. It was then written as advice about the whole call — so it misfires on every question the graph was never going to answer.

Reported case: a dev-docs question. `tako_search` returns web results and zero cards, and the guidance says *"the data graph does not cover this — do NOT re-search with rephrasings."* For a docs or reference lookup, re-searching per provider is exactly how the question gets answered. A competing web-search MCP wins those with 5-6 targeted calls each; our own response payload was telling the model to stop after one. **We were suppressing the winning strategy in our own guidance.**

There are two independent retry axes and the guidance only knew about one:

| axis | rephrasing works? | evidence |
|---|---|---|
| data card | no, and each attempt is priced | measured; the loop does not converge |
| web query | **yes**, and fanning out beats one broad query | the whole basis of per-provider web research |

## The fix

The ban is scoped to what it was measured on, and the carve-out is **explicit** rather than left for the model to infer.

**zero cards WITH web results** — the verdict now names the DATA GRAPH, and `REFINE_WEB_FREELY` follows it: refine freely, prefer several narrow queries (one per entity, provider or site) over one broad one, with `sources:["web"]`. Narrowing there is evidence-backed rather than a guess — a response with web hits and zero cards has just *demonstrated* the graph does not hold this, which is the precondition `sources`' own description sets for narrowing.

**web-only search, nothing back** — previously *"do NOT retry this query or rephrasings of it"*. There is no data verdict to report on this path (the data source was never queried) and the query is the **only** lever available, so that banned the single recovery there is. Now: refine, narrow per entity/provider/site, stop once a couple of genuinely different framings come back empty.

**data searched, nothing at all** — keeps the data recovery protocol, but the ban now says what it is about ("hoping a data card appears") and carves out one narrower attempt on the web axis.

`tako_answer` gets the same carve-out as `DECOMPOSE_WEB_ASK`, shared from `_search_results.ts` for the reason `PINNED_RETRY` is: two tools whose recovery advice disagrees teach the model that one of them is wrong. Answer's move is **decomposition** rather than refinement — it synthesizes one answer per call, so a multi-entity web question returns one blended answer, and asking once per entity is not a retry but the shape the tool answers best.

Stated as guidance rather than implemented as internal fan-out (the other option in the report): splitting a question server-side would multiply a priced call the caller never asked for, and the model is the only party that knows which entities the question actually covers.

## Second misfire, found in the same function

The no-web-results verdict was built from `hasWebResults` alone, so a deliberate `sources: ["data"]` ask — where the web was **never queried** — was told *"and no web results"* and then to treat the metric as absent. Two sources' worth of verdict from one source's evidence. It now takes `searchedWebToo` and, when web was not searched, names the cheap next step (re-ask with both sources, same price) instead of declaring the figure unavailable.

## Before / after

Web-only search, zero results:

> **before:** No results — do NOT retry this query or rephrasings of it; every search is priced, and the live web returned nothing here.
>
> **after:** No results from the web for this query. The data source was not searched, so this is NOT a coverage verdict about Tako's graph — it means the query itself came back empty. Refine and re-search: narrow to one entity, provider or site per query rather than one broad query, or name the specific doc/page you expect to find. […] Stop only once a couple of genuinely different framings have come back empty.

Zero cards with web results (tail of the string):

> **before:** …That usually means the data graph does not cover this query, not that the wording was unlucky, so do NOT re-search with rephrasings.
>
> **after:** …That is a verdict about the DATA GRAPH only […] Re-searching is NOT banned here — what does not converge is rephrasing to hunt for a data CARD. If what you actually need is web content (docs, reference pages, news, qualitative claims), refine and re-search freely: prefer SEVERAL narrow queries (one per entity, provider or site) over one broad one, and pass `sources:["web"]` on them.

## Scope

Deliberately **not** mirrored into the three bundled skills. They are data-domain skills (equity research, macro indicators, site traffic) whose questions are metric lookups by construction, so the data-axis recipe is the whole story there. Recorded in the code comment so the absence does not later read as drift.

No tool descriptions changed, so no registry regeneration is needed (`registry:check` confirms).

## What this does NOT do

- **No internal per-entity fan-out in web-mode `tako_answer`** — the other option in the report. That multiplies a priced call without the caller asking; the guidance now tells the model to decompose instead. Worth revisiting with measurements if agent traces show models ignoring the instruction.
- **No machine-readable axis signal.** `guidance` stays prose. A structured `retry_ok: {data: false, web: true}` would be stronger for programmatic clients but widens the advertised schema.
- **Not measured against agent traces yet.** The reasoning is sound and the reported misfire is fixed, but whether models actually fan out on reading this is an eval question, not a unit-test one.

## Test plan

- [x] 741 worker + 16 widget tests
- [x] 4 typecheck projects, `schemas:check`, `registry:check`
- [x] 4 tests that pinned the old over-broad wording rewritten to pin the scoped semantics; 3 added for the carve-outs
- [x] rendered guidance inspected by hand for all four branches
- [ ] CI green
- [ ] agent-trace eval: does a docs-shaped question now produce a per-provider fan-out?
