### PR TITLE
fix+feat: staging OAuth connect, Claude card theme, and email/password sign-in

### DIFF
--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -203,6 +203,18 @@ export interface Env {
    * block, so local dev is not silently reduced to Google-only.
    */
   LOGIN_RATE_LIMITER?: RateLimit;
+  /**
+   * DEV ONLY. Suffix appended to the widget's resource URI (see
+   * `appUiResourceUri`). Hosts cache the widget BY URI and claude.ai's cache
+   * outlives removing and re-adding the connector, so during local development
+   * every widget change is otherwise invisible — you end up debugging a bundle
+   * that is not running. Set it to a timestamp to force a re-read.
+   *
+   * MUST stay unset in staging and production: the shipped URI is effectively
+   * permanent (Claude desktop caches it beyond connector lifecycle, so renaming
+   * it 404s previously-installed sessions).
+   */
+  WIDGET_URI_SUFFIX?: string;
 }
 
 /**

--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -190,6 +190,19 @@ export interface Env {
    * be present for the free tier to activate.
    */
   FREE_TIER_GLOBAL_RATE_LIMITER?: RateLimit;
+  /**
+   * Cloudflare rate-limit binding throttling `POST /login/password`, keyed
+   * BOTH per client IP and per (hashed) email — see `handleLoginPassword`.
+   *
+   * Fail-CLOSED and load-bearing, unlike the free-tier limiters whose absence
+   * merely reverts to a 401: `/login/password` is an unauthenticated endpoint
+   * that checks a password on a public host, so without a limiter it is a
+   * credential-stuffing oracle. When this is unbound the endpoint 503s and
+   * only Google sign-in works. Declared under `ratelimits` in
+   * `wrangler.jsonc` for every env INCLUDING the top-level `wrangler dev`
+   * block, so local dev is not silently reduced to Google-only.
+   */
+  LOGIN_RATE_LIMITER?: RateLimit;
 }
 
 /**

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -7,6 +7,7 @@ import {
   handleAuthorize,
   handleAuthServerMetadata,
   handleLogin,
+  handleLoginPassword,
   handleProtectedResourceMetadata,
   handleRegister,
   handleRevoke,
@@ -157,6 +158,13 @@ export default {
     }
     if (url.pathname === "/login") {
       return handleLogin(request, env);
+    }
+    // Email + password sign-in. A server-side form POST rather than a
+    // browser-SDK call, so the password never passes through the CDN-loaded
+    // Stytch script and the session lands via the same cookie Google's
+    // redirect uses. Must be matched BEFORE any `/login` prefix handling.
+    if (url.pathname === "/login/password") {
+      return handleLoginPassword(request, env);
     }
     if (url.pathname === "/oauth/stytch_callback") {
       return handleStytchCallback(request, env);

--- a/workers/src/oauth/handlers.test.ts
+++ b/workers/src/oauth/handlers.test.ts
@@ -5,6 +5,7 @@ import {
   handleAuthorize,
   handleAuthServerMetadata,
   handleLogin,
+  handleLoginPassword,
   handleProtectedResourceMetadata,
   handleRegister,
   handleToken,
@@ -994,6 +995,341 @@ describe("/login", () => {
       expect(html).toContain("/oauth/stytch_callback");
       expect(html).toContain("Continue with Google");
     });
+  });
+
+  it("offers email + password directly, and no magic link", async () => {
+    // Plugin review requires a password field on the page itself. The magic
+    // link is gone deliberately, so its copy must not linger.
+    const res = handleLogin(new Request("https://mcp.example.com/login"), envWith());
+    const html = await res.text();
+    expect(html).toContain('type="password"');
+    expect(html).toContain('action="/login/password"');
+    expect(html).not.toContain("Email me a sign-in link");
+    expect(html).not.toContain("magicLinks");
+  });
+
+  it("links out for password reset and account creation", async () => {
+    const res = handleLogin(new Request("https://mcp.example.com/login"), envWith());
+    const html = await res.text();
+    expect(html).toContain("Forgot password?");
+    expect(html).toContain("New to Tako?");
+  });
+
+  it("renders only errors it issued itself, reflecting nothing", async () => {
+    // `?error=` is attacker-controllable, so the page maps a CLOSED set of
+    // codes to copy rather than escaping and echoing. Stronger than escaping:
+    // there is no path from URL text to the document at all, so the page can
+    // never become a phishing surface ("session expired, call this number").
+    for (const attempt of [
+      "<img src=x onerror=alert(1)>",
+      "call_this_number_now",
+    ]) {
+      const res = handleLogin(
+        new Request(
+          "https://mcp.example.com/login?error=" + encodeURIComponent(attempt),
+        ),
+        envWith(),
+      );
+      const html = await res.text();
+      expect(html).not.toContain(attempt);
+      expect(html).not.toContain("<img src=x");
+      // The error slot renders empty and CSS hides it (`.err:empty`).
+      expect(html).toContain('id="err" role="alert" aria-live="polite"></div>');
+    }
+  });
+
+  it("renders the mapped copy for a code it did issue", async () => {
+    const res = handleLogin(
+      new Request("https://mcp.example.com/login?error=no_user_password"),
+      envWith(),
+    );
+    expect(await res.text()).toContain("Continue with Google");
+  });
+});
+
+/* --------------------------- Password login --------------------------- */
+
+describe("POST /login/password", () => {
+  function limiterEnv(overrides: Partial<Env> = {}): Env {
+    return envWith({
+      LOGIN_RATE_LIMITER: { limit: async () => ({ success: true }) },
+      ...overrides,
+    });
+  }
+
+  function form(email: string, password: string): Request {
+    return new Request("https://mcp.example.com/login/password", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "sec-fetch-site": "same-origin",
+      },
+      body: new URLSearchParams({ email, password }).toString(),
+    });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects a non-POST", async () => {
+    const res = await handleLoginPassword(
+      new Request("https://mcp.example.com/login/password"),
+      limiterEnv(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("503s when OAuth is not configured", async () => {
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "pw"),
+      ENV_NO_OAUTH,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("refuses a cross-site POST", async () => {
+    const req = new Request("https://mcp.example.com/login/password", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "sec-fetch-site": "cross-site",
+      },
+      body: new URLSearchParams({ email: "e@t.com", password: "pw" }).toString(),
+    });
+    const spy = vi.spyOn(globalThis, "fetch");
+    const res = await handleLoginPassword(req, limiterEnv());
+    expect(res.status).toBe(403);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the rate limiter binding is missing", async () => {
+    // An unauthenticated password endpoint with no limiter is a
+    // credential-stuffing oracle. Google sign-in still works.
+    const spy = vi.spyOn(globalThis, "fetch");
+    const res = await handleLoginPassword(form("e@t.com", "pw"), envWith());
+    expect(res.status).toBe(503);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("blocks a rate-limited attempt without calling Stytch", async () => {
+    // A browser form post, so the block comes back as the same redirect every
+    // other error uses — the message renders on the page instead of a bare
+    // 429 body. The property that matters is that Stytch is never reached.
+    const spy = vi.spyOn(globalThis, "fetch");
+    const env = envWith({
+      LOGIN_RATE_LIMITER: { limit: async () => ({ success: false }) },
+    });
+    const res = await handleLoginPassword(form("e@t.com", "pw"), env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("error=rate_limited");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("blocks when the limiter itself throws (never fails open)", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const env = envWith({
+      LOGIN_RATE_LIMITER: {
+        limit: async () => {
+          throw new Error("limiter exploded");
+        },
+      },
+    });
+    const res = await handleLoginPassword(form("e@t.com", "pw"), env);
+    expect(res.headers.get("location")).toContain("error=rate_limited");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("tells an MFA account to use Google rather than implying a bad password", async () => {
+    // Stytch answers 200 with an intermediate token and no session_jwt. This
+    // Worker has no second-factor UI, and Tako has /login/mfa routes, so real
+    // accounts hit this.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ intermediate_session_token: "ist-abc" }),
+        { status: 200 },
+      ),
+    );
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "correct-password"),
+      limiterEnv(),
+    );
+    expect(res.headers.get("location")).toContain("error=mfa_required");
+  });
+
+  it("meters on both the client IP and the email", async () => {
+    // Per-IP alone misses a slow spray from a botnet at one account; per-email
+    // alone misses one host trying many accounts.
+    const keys: string[] = [];
+    const env = envWith({
+      LOGIN_RATE_LIMITER: {
+        limit: async (opts: { key: string }) => {
+          keys.push(opts.key);
+          return { success: true };
+        },
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error_type: "invalid_credentials" }), {
+        status: 401,
+      }),
+    );
+    const req = form("eric@trytako.com", "pw");
+    req.headers.set("cf-connecting-ip", "203.0.113.7");
+    await handleLoginPassword(req, env);
+    expect(keys.some((k) => k.includes("203.0.113.7"))).toBe(true);
+    expect(keys.length).toBe(2);
+    // The email is hashed, never keyed in the clear.
+    expect(keys.some((k) => k.includes("eric@trytako.com"))).toBe(false);
+  });
+
+  it("redirects back to /login with a generic code on bad credentials", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error_type: "invalid_credentials" }), {
+        status: 401,
+      }),
+    );
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "wrong"),
+      limiterEnv(),
+    );
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("location")!;
+    expect(loc).toContain("/login?error=invalid_credentials");
+  });
+
+  it("does not distinguish an unknown email from a wrong password", async () => {
+    // Enumeration: both must produce the same code.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error_type: "email_not_found" }), {
+        status: 404,
+      }),
+    );
+    const res = await handleLoginPassword(
+      form("nobody@trytako.com", "pw"),
+      limiterEnv(),
+    );
+    expect(res.headers.get("location")).toContain("error=invalid_credentials");
+  });
+
+  it("tells a Google-signup user to use Google", async () => {
+    // The one case that must NOT be collapsed: with the magic link gone, a
+    // passwordless account has no other hint about how to get in.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error_type: "no_user_password" }), {
+        status: 401,
+      }),
+    );
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "pw"),
+      limiterEnv(),
+    );
+    expect(res.headers.get("location")).toContain("error=no_user_password");
+  });
+
+  it("surfaces a reset-required password distinctly", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error_type: "reset_password" }), {
+        status: 401,
+      }),
+    );
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "pw"),
+      limiterEnv(),
+    );
+    expect(res.headers.get("location")).toContain("error=reset_password");
+  });
+
+  it("never puts the password or email in the redirect", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error_type: "invalid_credentials" }), {
+        status: 401,
+      }),
+    );
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "sup3rs3cret"),
+      limiterEnv(),
+    );
+    const loc = res.headers.get("location")!;
+    expect(loc).not.toContain("sup3rs3cret");
+    expect(loc).not.toContain("eric@trytako.com");
+  });
+
+  it("rejects a missing email or password before calling Stytch", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    const res = await handleLoginPassword(form("", ""), limiterEnv());
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("error=missing_fields");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("mints the session cookie and resumes /authorize on success", async () => {
+    // The whole point: a password login must land in exactly the same place a
+    // Google login does, via the same session cookie.
+    const env = limiterEnv();
+    const { challenge } = await pkcePair();
+    const clientId = await mintClientId(env, "https://client.example/cb");
+    const stateJwt = await signJwt(
+      {
+        type: "state",
+        client_id: clientId,
+        redirect_uri: "https://client.example/cb",
+        response_type: "code",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        state: "xyz",
+        scope: "mcp",
+        resource: null,
+        exp: Math.floor(Date.now() / 1000) + 600,
+      },
+      SIGN_KEY,
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          session_jwt: "aaa.bbb.ccc",
+          user: {
+            user_id: "user-test-1",
+            emails: [{ email: "eric@trytako.com" }],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const req = form("eric@trytako.com", "correct-password");
+    req.headers.set("cookie", `${STATE_COOKIE}=${stateJwt}`);
+
+    const res = await handleLoginPassword(req, env);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("/authorize");
+    // Both cookies ride on one response (session set, state cleared), so read
+    // the repeated header rather than the single-value getter.
+    const cookies = (res.headers as unknown as {
+      getSetCookie(): string[];
+    }).getSetCookie();
+    expect(cookies.some((c: string) => c.startsWith(SESSION_COOKIE))).toBe(true);
+    expect(cookies.some((c: string) => c.startsWith(STATE_COOKIE))).toBe(true);
+  });
+
+  it("explains the lost state cookie instead of a bare redirect loop", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          session_jwt: "aaa.bbb.ccc",
+          user: {
+            user_id: "u",
+            emails: [{ email: "eric@trytako.com" }],
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    const res = await handleLoginPassword(
+      form("eric@trytako.com", "correct-password"),
+      limiterEnv(),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("authorization request was lost");
   });
 });
 

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -692,6 +692,17 @@ export async function handleAuthorize(
       if (err.kind === "unauthorized") {
         // Stytch session was revoked or expired — force re-login by
         // clearing the now-useless session cookie.
+        //
+        // Log it: a 401/403 here is ALSO what a Worker↔Django misconfiguration
+        // looks like (TAKO-3754 — the Worker sent the wrong session-cookie
+        // NAME to staging, so Django saw no cookie and 403'd). Without this
+        // line the two are indistinguishable and a config break masquerades
+        // as a user's expired sign-in with nothing in `wrangler tail`.
+        console.error(
+          "Tako rejected the Stytch session at /authorize POST:",
+          err.status,
+          err.message,
+        );
         return htmlResponse(
           sessionExpiredPage(
             "Your Tako sign-in expired. Please sign in again.",

--- a/workers/src/oauth/handlers.ts
+++ b/workers/src/oauth/handlers.ts
@@ -39,7 +39,7 @@
  *   • Auth codes / access tokens / refresh tokens — all signed JWTs, no DB
  */
 
-import type { Env } from "../env.js";
+import { type Env, resolvePublicBase } from "../env.js";
 import {
   decryptAesGcm,
   encryptAesGcm,
@@ -48,11 +48,13 @@ import {
   verifyJwt,
 } from "./jwt.js";
 import {
+  authenticateStytchPassword,
   authenticateStytchToken,
   primaryEmail,
   StytchError,
   type StytchTokenKind,
 } from "./stytch.js";
+import type { StytchAuthenticateResult } from "./types.js";
 import {
   IdentityError,
   mintTakoApiKey,
@@ -1175,9 +1177,183 @@ export function handleLogin(req: Request, env: Env): Response {
   if (req.method !== "GET") {
     return new Response("method not allowed", { status: 405 });
   }
-  const origin = new URL(req.url).origin;
-  const callbackUrl = `${origin}/oauth/stytch_callback`;
-  return htmlResponse(loginPage(cfg.stytch.publicToken, callbackUrl));
+  const url = new URL(req.url);
+  const callbackUrl = `${url.origin}/oauth/stytch_callback`;
+  // Closed-set lookup, not free text — see `LOGIN_ERROR_COPY`.
+  const errorCode = url.searchParams.get("error");
+  const errorMessage =
+    errorCode !== null ? (LOGIN_ERROR_COPY[errorCode] ?? "") : "";
+  return htmlResponse(
+    loginPage(cfg.stytch.publicToken, callbackUrl, errorMessage, env),
+  );
+}
+
+/**
+ * Error codes `/login/password` may hand back to `/login` via `?error=`.
+ *
+ * A CLOSED set, mapped to copy server-side. The redirect param is
+ * attacker-controllable, so rendering arbitrary text from it would turn the
+ * sign-in page into a phishing surface ("your session expired, call this
+ * number"). Unknown codes render nothing at all.
+ *
+ * The split mirrors Tako's own `PasswordSignInPage.tsx`:
+ * `invalid_credentials` deliberately absorbs unknown-email AND wrong-password
+ * so the page cannot be used to enumerate accounts, while `no_user_password`
+ * and `reset_password` stay distinct because they are the two cases where the
+ * user needs to be told to do something different.
+ */
+const LOGIN_ERROR_COPY: Record<string, string> = {
+  invalid_credentials: "Incorrect email or password.",
+  missing_fields: "Enter both your email and password.",
+  no_user_password:
+    "This account signs in with Google. Use “Continue with Google” above.",
+  reset_password:
+    "Your password needs to be reset. Use “Forgot password?” below to get a reset link.",
+  rate_limited: "Too many sign-in attempts. Wait a minute and try again.",
+  server_error: "Something went wrong signing you in. Please try again.",
+  // This Worker has no second-factor UI. Google carries the factor itself, so
+  // it is the way through for an MFA account — say so rather than implying the
+  // password was wrong.
+  mfa_required:
+    "This account uses two-factor authentication, which isn’t supported here yet. Use “Continue with Google” above.",
+};
+
+/**
+ * Map a Stytch failure to one of `LOGIN_ERROR_COPY`'s codes.
+ *
+ * Stytch reports wrong-password as `invalid_credentials`/401 and unknown-email
+ * as `email_not_found`/`user_not_found`/404; both collapse to
+ * `invalid_credentials` here. Only the two actionable states survive as
+ * themselves.
+ */
+function loginErrorCode(err: StytchError): string {
+  switch (err.errorType) {
+    case "mfa_required":
+      return "mfa_required";
+    case "no_user_password":
+      return "no_user_password";
+    case "reset_password":
+    case "password_reset_required":
+      return "reset_password";
+    case "invalid_credentials":
+    case "email_not_found":
+    case "user_not_found":
+    case "password_does_not_match":
+      return "invalid_credentials";
+    default:
+      // An unmapped 401/404 is still a credential failure as far as the user
+      // is concerned; anything else is ours, not theirs.
+      return err.status === 401 || err.status === 404
+        ? "invalid_credentials"
+        : "server_error";
+  }
+}
+
+/**
+ * `POST /login/password` — authenticate an email + password against Stytch and
+ * resume the OAuth dance, landing in exactly the same place Google does.
+ *
+ * Ordering is deliberate: method → config → same-site → limiter → field
+ * presence → Stytch. Every gate that can reject without touching a password
+ * check runs first, so the expensive, attackable call is last.
+ */
+export async function handleLoginPassword(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", { status: 405 });
+  }
+  const cfg = readConfig(env);
+  if (cfg === null) return oauthDisabledResponse();
+  const url = new URL(req.url);
+
+  // CSRF: the form is same-origin, so a cross-site POST is either a forged
+  // login or a scanner. `Sec-Fetch-Site` is set by the browser and cannot be
+  // spoofed from page JS; a missing header (older browser, curl) is allowed
+  // through because the limiter below still bounds it.
+  const fetchSite = req.headers.get("sec-fetch-site");
+  if (fetchSite !== null && fetchSite !== "same-origin" && fetchSite !== "none") {
+    return new Response("cross-site form post rejected", { status: 403 });
+  }
+
+  // Fail-closed on the limiter — see `Env.LOGIN_RATE_LIMITER`.
+  const limiter = env.LOGIN_RATE_LIMITER;
+  if (typeof limiter?.limit !== "function") {
+    console.error(
+      "[login] LOGIN_RATE_LIMITER is unbound — refusing password sign-in " +
+        "(Google sign-in unaffected). Declare it under `ratelimits`.",
+    );
+    return errorPage(
+      503,
+      "Password sign-in is unavailable on this deployment. " +
+        "Use “Continue with Google”.",
+    );
+  }
+
+  const body = await req.formData().catch(() => null);
+  const email = String(body?.get("email") ?? "").trim();
+  const password = String(body?.get("password") ?? "");
+
+  // Meter BEFORE validating fields, on both axes. Per-IP alone misses a slow
+  // distributed spray at one account; per-email alone misses one host walking
+  // a list. The email is hashed so the rate-limit key space never holds
+  // plaintext addresses.
+  const ip = req.headers.get("cf-connecting-ip") ?? "unknown";
+  const emailKey = email === "" ? "empty" : await sha256B64Url(email.toLowerCase());
+  const verdicts = await Promise.all([
+    limiter.limit({ key: `login:ip:${ip}` }),
+    limiter.limit({ key: `login:email:${emailKey}` }),
+  ]).catch(() => null);
+  // A limiter that throws must not fail OPEN on this endpoint.
+  if (verdicts === null || verdicts.some((v) => !v.success)) {
+    // The response is a 302 (this is a browser form post, so the message
+    // belongs on the page) which means the status code carries no signal for
+    // abuse monitoring — log it so a stuffing run is visible in `wrangler
+    // tail`. IP only; the email is the thing being guessed at.
+    console.warn(
+      "[login] password sign-in rate-limited",
+      verdicts === null ? "(limiter threw)" : `ip=${ip}`,
+    );
+    return redirectToLogin(url, "rate_limited");
+  }
+
+  if (email === "" || password === "") {
+    return redirectToLogin(url, "missing_fields");
+  }
+
+  let stytchResult: StytchAuthenticateResult;
+  try {
+    stytchResult = await authenticateStytchPassword(cfg.stytch, email, password);
+  } catch (err) {
+    if (err instanceof StytchError) {
+      const code = loginErrorCode(err);
+      // Log the classification, never the credentials. `err.message` is built
+      // by `stytch.ts` from the path and status only.
+      console.error(
+        "[login] password sign-in failed:",
+        code,
+        err.errorType ?? err.status,
+      );
+      return redirectToLogin(url, code);
+    }
+    throw err;
+  }
+  return completeStytchLogin(req, url, cfg, stytchResult);
+}
+
+/**
+ * Bounce back to the sign-in page with a closed-set error code. Never carries
+ * the email or password — a redirect URL lands in browser history, `Referer`
+ * headers, and proxy logs.
+ */
+function redirectToLogin(url: URL, code: string): Response {
+  const target = new URL("/login", url.origin);
+  target.searchParams.set("error", code);
+  return new Response(null, {
+    status: 302,
+    headers: { location: target.toString(), "cache-control": "no-store" },
+  });
 }
 
 /**
@@ -1193,54 +1369,147 @@ function jsStringLiteral(s: string): string {
   return JSON.stringify(s).replace(/</g, "\\u003c");
 }
 
-function loginPage(stytchPublicToken: string, callbackUrl: string): string {
-  // The Stytch SDK is loaded over their CDN; `publicToken` and
-  // `callbackUrl` are the only Worker-side data the page needs.
-  // Both are embedded as JS string literals via `jsStringLiteral`,
-  // not HTML-escaped — they live inside <script>, not in HTML
-  // attributes / text.
+function loginPage(
+  stytchPublicToken: string,
+  callbackUrl: string,
+  errorMessage: string,
+  env: Env,
+): string {
+  // `publicToken` and `callbackUrl` are embedded as JS string literals via
+  // `jsStringLiteral`, not HTML-escaped — they live inside <script>, not in
+  // HTML attributes or text. `errorMessage` is the reverse: it lands in HTML
+  // text, so it goes through `escapeHtml`. It is already a value from the
+  // closed `LOGIN_ERROR_COPY` set, so this is belt-and-suspenders.
+  const safeError = escapeHtml(errorMessage);
+  // Deep links into Tako's real web app, which owns account creation, password
+  // reset, and MFA. Routes verified against `routeTree.gen.ts`
+  // (`/login/forgot-password`, `/signup`) — a dead link here is precisely the
+  // kind of thing a plugin reviewer clicks first.
+  const webBase = resolvePublicBase(env);
+  const forgotUrl = escapeHtml(`${webBase}/login/forgot-password`);
+  const signupUrl = escapeHtml(`${webBase}/signup`);
   return `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Sign in — Tako</title>
+<title>Sign in to Tako</title>
+<link rel="icon" href="/icons/favicon.svg">
 <style>
-  :root { color-scheme: light dark; --fg: #111; --bg: #fff; --muted: #555; --border: #ddd; --accent: #111; --on-accent: #fff; --error: #c1121f; }
-  @media (prefers-color-scheme: dark) {
-    :root { --fg: #f5f5f5; --bg: #0b0b0b; --muted: #aaa; --border: #2a2a2a; --accent: #fff; --on-accent: #111; --error: #ff6b6b; }
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff; --surface: #ffffff; --fg: #141413; --muted: #73726c;
+    --line: #e5e4df; --line-strong: #d3d1ca; --accent: #141413;
+    --on-accent: #ffffff; --error-fg: #b4241f; --error-bg: #fdf3f2;
+    --error-line: #f3d3d1; --focus: #6b6a64; --shadow: 0 1px 2px rgba(20,20,19,.04), 0 8px 24px -12px rgba(20,20,19,.12);
   }
-  body { font-family: -apple-system, system-ui, "Segoe UI", sans-serif; margin: 0; padding: 3rem 1.5rem; max-width: 24rem; margin-inline: auto; color: var(--fg); background: var(--bg); }
-  h1 { font-size: 1.4rem; margin: 0 0 0.25rem; }
-  p { color: var(--muted); margin: 0 0 1.5rem; line-height: 1.55; }
-  button { width: 100%; padding: 0.75rem 1rem; font-size: 1rem; font-weight: 500; border-radius: 0.5rem; border: 1px solid var(--border); background: transparent; color: var(--fg); cursor: pointer; }
-  button.primary { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
-  button:hover { opacity: 0.85; }
-  .row { margin-bottom: 0.75rem; }
-  .or { text-align: center; color: var(--muted); margin: 1rem 0; font-size: 0.9rem; }
-  input[type=email] { width: 100%; padding: 0.7rem 0.9rem; font-size: 1rem; border-radius: 0.5rem; border: 1px solid var(--border); background: transparent; color: var(--fg); box-sizing: border-box; margin-bottom: 0.5rem; }
-  .err { color: var(--error); font-size: 0.85rem; min-height: 1.2rem; margin-top: 0.5rem; }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #191817; --surface: #201f1e; --fg: #f5f4ef; --muted: #a3a29c;
+      --line: #34332f; --line-strong: #44433d; --accent: #f5f4ef;
+      --on-accent: #191817; --error-fg: #f79f9a; --error-bg: #2a1d1c;
+      --error-line: #4a2e2c; --focus: #8a8880; --shadow: 0 1px 2px rgba(0,0,0,.3), 0 8px 24px -12px rgba(0,0,0,.5);
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; display: flex; align-items: center;
+    justify-content: center; padding: 2rem 1.25rem; background: var(--bg);
+    color: var(--fg);
+    font: 15px/1.5 ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .card {
+    width: 100%; max-width: 25rem; background: var(--surface);
+    border: 1px solid var(--line); border-radius: 14px; padding: 2rem 1.75rem;
+    box-shadow: var(--shadow);
+  }
+  .mark { width: 34px; height: 34px; display: block; margin: 0 0 1.25rem; }
+  h1 { font-size: 1.3rem; line-height: 1.25; font-weight: 600; letter-spacing: -0.015em; margin: 0 0 0.375rem; }
+  .sub { color: var(--muted); font-size: 0.9rem; margin: 0 0 1.5rem; }
+  label { display: block; font-size: 0.8rem; font-weight: 500; margin: 0 0 0.375rem; }
+  input {
+    width: 100%; padding: 0.625rem 0.75rem; font-size: 0.9375rem; font-family: inherit;
+    color: var(--fg); background: transparent; border: 1px solid var(--line-strong);
+    border-radius: 8px; transition: border-color .12s ease, box-shadow .12s ease;
+  }
+  input:focus-visible {
+    outline: none; border-color: var(--focus);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus) 18%, transparent);
+  }
+  .field { margin-bottom: 0.875rem; }
+  button {
+    width: 100%; padding: 0.625rem 1rem; font: inherit; font-size: 0.9375rem;
+    font-weight: 500; border-radius: 8px; cursor: pointer;
+    transition: opacity .12s ease, border-color .12s ease;
+  }
+  button:hover { opacity: 0.88; }
+  button:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
+  .btn-primary { background: var(--accent); color: var(--on-accent); border: 1px solid var(--accent); }
+  .btn-social {
+    background: transparent; color: var(--fg); border: 1px solid var(--line-strong);
+    display: flex; align-items: center; justify-content: center; gap: 0.5rem;
+  }
+  .btn-social svg { width: 17px; height: 17px; flex: none; }
+  .divider { display: flex; align-items: center; gap: 0.75rem; margin: 1.25rem 0; color: var(--muted); font-size: 0.75rem; }
+  .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+  .err {
+    display: flex; gap: 0.5rem; padding: 0.625rem 0.75rem; margin: 0 0 1.25rem;
+    background: var(--error-bg); border: 1px solid var(--error-line);
+    border-radius: 8px; color: var(--error-fg); font-size: 0.85rem;
+  }
+  .err:empty { display: none; }
+  .foot { margin: 1.25rem 0 0; font-size: 0.8125rem; color: var(--muted); text-align: center; }
+  .foot + .foot { margin-top: 0.5rem; }
+  a { color: var(--fg); text-decoration: none; border-bottom: 1px solid var(--line-strong); }
+  a:hover { border-bottom-color: var(--fg); }
 </style>
 </head>
 <body>
-<h1>Sign in to Tako</h1>
-<p>Use your Tako account to authorize this connection.</p>
-<div class="row">
-  <button class="primary" id="google">Continue with Google</button>
-</div>
-<div class="or">or</div>
-<form id="magic">
-  <input type="email" name="email" placeholder="you@example.com" required autocomplete="email">
-  <button type="submit">Email me a sign-in link</button>
-</form>
-<div class="err" id="err"></div>
+<main class="card">
+  <img class="mark" src="/icons/favicon.svg" alt="Tako" width="34" height="34">
+  <h1>Sign in to Tako</h1>
+  <p class="sub">Authorize this connection with your Tako account.</p>
 
-<!-- Stytch's vanilla JS SDK. Loaded over their CDN without Subresource
-     Integrity because Stytch publishes a rolling URL and breaks SRI
-     pins on every revision. Trade-off: a compromise of js.stytch.com
-     would let an attacker run JS on this page (which only handles
-     login redirects — no Tako tokens are touched here). Revisit if
-     Stytch publishes versioned URLs with stable hashes. -->
+  <div class="err" id="err" role="alert" aria-live="polite">${safeError}</div>
+
+  <button type="button" class="btn-social" id="google">
+    <svg viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+      <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.91c1.7-1.57 2.69-3.88 2.69-6.62z"/>
+      <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.91-2.26c-.81.54-1.84.86-3.05.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.34A9 9 0 0 0 9 18z"/>
+      <path fill="#FBBC05" d="M3.97 10.72a5.41 5.41 0 0 1 0-3.44V4.94H.96a9 9 0 0 0 0 8.12l3.01-2.34z"/>
+      <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.59C13.46.89 11.43 0 9 0A9 9 0 0 0 .96 4.94l3.01 2.34C4.68 5.16 6.66 3.58 9 3.58z"/>
+    </svg>
+    Continue with Google
+  </button>
+
+  <div class="divider">or</div>
+
+  <form method="POST" action="/login/password" autocomplete="on">
+    <div class="field">
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required autocomplete="username"
+             inputmode="email" autocapitalize="none" spellcheck="false" placeholder="you@company.com">
+    </div>
+    <div class="field">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" required
+             autocomplete="current-password" placeholder="Your password">
+    </div>
+    <button type="submit" class="btn-primary">Sign in</button>
+  </form>
+
+  <p class="foot"><a href="${forgotUrl}" target="_blank" rel="noopener noreferrer">Forgot password?</a></p>
+  <p class="foot">New to Tako? <a href="${signupUrl}" target="_blank" rel="noopener noreferrer">Create an account</a></p>
+</main>
+
+<!-- Stytch's vanilla JS SDK, used for the Google redirect only. Loaded over
+     their CDN without Subresource Integrity because Stytch publishes a rolling
+     URL and breaks SRI pins on every revision. Trade-off: a compromise of
+     js.stytch.com would let an attacker run JS on this page. That is a
+     narrower exposure than it looks for Google (a redirect start, no secrets
+     here) but NOT for the password field, which is why the password path is a
+     plain server-side form POST that never touches the SDK. -->
 <script src="https://js.stytch.com/stytch.js"></script>
 <script>
   (function() {
@@ -1253,7 +1522,7 @@ function loginPage(stytchPublicToken: string, callbackUrl: string): string {
     try {
       client = Stytch(publicToken);
     } catch (e) {
-      showError("Could not initialize Stytch: " + (e && e.message ? e.message : e));
+      showError("Google sign-in is unavailable. Use your email and password below.");
       return;
     }
 
@@ -1265,23 +1534,8 @@ function loginPage(stytchPublicToken: string, callbackUrl: string): string {
           signup_redirect_url: callbackUrl
         });
       } catch (e) {
-        showError("Google sign-in failed to start: " + (e && e.message ? e.message : e));
+        showError("Google sign-in failed to start. Use your email and password below.");
       }
-    });
-
-    document.getElementById("magic").addEventListener("submit", function(ev) {
-      ev.preventDefault();
-      showError("");
-      var email = ev.target.email.value.trim();
-      if (!email) { showError("Enter an email address."); return; }
-      client.magicLinks.email.loginOrCreate(email, {
-        login_magic_link_url: callbackUrl,
-        signup_magic_link_url: callbackUrl
-      }).then(function() {
-        ev.target.innerHTML = "<p>Check your email for a sign-in link.</p>";
-      }).catch(function(e) {
-        showError("Could not send magic link: " + (e && e.message ? e.message : e));
-      });
     });
   })();
 </script>
@@ -1333,6 +1587,25 @@ export async function handleStytchCallback(
     throw err;
   }
 
+  return completeStytchLogin(req, url, cfg, stytchResult);
+}
+
+/**
+ * Turn an authenticated Stytch result into our session cookie and resume the
+ * OAuth dance at `/authorize`.
+ *
+ * Shared by the redirect callback (Google) and `POST /login/password`, because
+ * "how a user becomes logged in" must have exactly one implementation. A
+ * second copy would be a second place for the session-cookie claims, the TTL,
+ * or the state-cookie handling to drift — on the code path that authorizes
+ * access to someone's Tako account.
+ */
+async function completeStytchLogin(
+  req: Request,
+  url: URL,
+  cfg: OAuthConfig,
+  stytchResult: StytchAuthenticateResult,
+): Promise<Response> {
   // Step 2 — encrypt the Stytch session JWT and stash it in our own
   // session cookie. We deliberately do NOT fetch the Tako API token
   // here. Caching the Tako token in the session cookie would mean

--- a/workers/src/oauth/identity.test.ts
+++ b/workers/src/oauth/identity.test.ts
@@ -43,6 +43,32 @@ describe("mintTakoApiKey", () => {
     await expect(mintTakoApiKey(env, JWT, "Claude")).rejects.toMatchObject({ kind: "parse" });
   });
 
+  // The Stytch session cookie is NAME-namespaced on the `.staging.tako.com`
+  // zone (see `sessionCookieName`). Sending the default name there means Django
+  // reads no cookie at all and 403s, which the caller surfaces as the
+  // misleading "Your Tako sign-in expired." Table mirrors the `cases` in
+  // tako's `app/backend/auth/stytch/cookie_name_contract.json`.
+  const COOKIE_NAME_CASES: ReadonlyArray<readonly [string, string]> = [
+    ["https://staging.tako.com", "stytch_session_jwt_staging"],
+    ["https://developer.staging.tako.com", "stytch_session_jwt_staging"],
+    ["https://tako.com", "stytch_session_jwt"],
+    ["https://www.tako.com", "stytch_session_jwt"],
+    ["https://developer.tako.com", "stytch_session_jwt"],
+    ["http://localhost:8000", "stytch_session_jwt"],
+    ["https://staging.trytako.com", "stytch_session_jwt"],
+  ];
+
+  for (const [base, expectedName] of COOKIE_NAME_CASES) {
+    it(`sends the ${expectedName} cookie for ${base}`, async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ key: "tako_sk_RAW" }), { status: 201 }));
+      await mintTakoApiKey({ DJANGO_BASE_URL: base } as never, JWT, "Claude");
+      const cookie = (fetchSpy.mock.calls[0]![1]!.headers as Record<string, string>).cookie;
+      expect(cookie).toBe(`${expectedName}=${JWT}`);
+    });
+  }
+
   it("rejects a malformed stytch JWT before fetching", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     await expect(mintTakoApiKey(env, "not-a-jwt", "Claude")).rejects.toBeInstanceOf(IdentityError);

--- a/workers/src/oauth/identity.ts
+++ b/workers/src/oauth/identity.ts
@@ -9,8 +9,9 @@
  * API keys are hashed and shown exactly once (TAKO-3212) — there is no endpoint
  * that returns an existing raw key. Minting is additive and the backend
  * LRU-trims a user's MCP keys, so a fresh key per host never rotates another
- * host's still-valid key. Django authenticates the call from the
- * `stytch_session_jwt` cookie we set ourselves (server-to-server).
+ * host's still-valid key. Django authenticates the call from the Stytch session
+ * cookie we set ourselves (server-to-server) — whose NAME is per-zone, see
+ * `sessionCookieName`.
  */
 
 import type { Env } from "../env.js";
@@ -48,6 +49,39 @@ export class IdentityError extends Error {
 const STYTCH_JWT_SHAPE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
 /**
+ * Name of the Stytch session cookie Django reads, for a given backend origin.
+ *
+ * On the `.staging.tako.com` zone the session cookies are NAME-namespaced
+ * (`*_staging`), because the browser also delivers prod's `Domain=.tako.com`
+ * cookie — carrying the DEFAULT name — to `staging.tako.com`, where it would
+ * shadow the staging session. Django resolves the name per request host and
+ * reads ONLY that name (`candidate_session_jwts`), so sending the default name
+ * to `staging.tako.com` means it sees no cookie at all, 403s, and the caller
+ * surfaces the misleading "Your Tako sign-in expired."
+ *
+ * MIRRORS tako's `app/backend/auth/stytch/cookie_name_contract.json` — the
+ * single source of truth, which the Django backend and the frontend SDK each
+ * have a test against. This Worker lives in another repo, so no shared CI can
+ * catch drift here: if that contract gains a namespaced zone, update this rule
+ * too. The unauthorized branch in `handlers.ts` logs the status so the next
+ * drift shows up in `wrangler tail` instead of hiding as an expired sign-in.
+ */
+export function sessionCookieName(base: string): string {
+  let host: string;
+  try {
+    host = new URL(base).hostname.toLowerCase();
+  } catch {
+    // Unparseable origin — the default name is the safe choice; the caller's
+    // own `DJANGO_BASE_URL` guard rejects the value moments later anyway.
+    return "stytch_session_jwt";
+  }
+  if (host === "staging.tako.com" || host.endsWith(".staging.tako.com")) {
+    return "stytch_session_jwt_staging";
+  }
+  return "stytch_session_jwt";
+}
+
+/**
  * Mint the user's Tako API key by calling POST /api/v1/internal/mcp/api_key/
  * with the Stytch session JWT in a `Cookie` header. `clientName` (from the DCR
  * registration) names the key on the developer page. Returns the raw key.
@@ -78,8 +112,10 @@ export async function mintTakoApiKey(
       headers: {
         // `cookie` is a forbidden browser header, but Workers' fetch allows it
         // because the Worker is a server proxy. Django reads it via
-        // request.COOKIES.get("stytch_session_jwt").
-        cookie: `stytch_session_jwt=${stytchSessionJwt}`,
+        // `candidate_session_jwts(request)`, which resolves the cookie NAME
+        // from the request host — hence `sessionCookieName` rather than a
+        // hardcoded name.
+        cookie: `${sessionCookieName(base)}=${stytchSessionJwt}`,
         "content-type": "application/json",
         accept: "application/json",
       },

--- a/workers/src/oauth/stytch.test.ts
+++ b/workers/src/oauth/stytch.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  authenticateStytchPassword,
+  authenticateStytchToken,
+  primaryEmail,
+  StytchError,
+} from "./stytch.js";
+
+const cfg = {
+  projectId: "project-test-abc",
+  secret: "secret-test-xyz",
+  baseUrl: "https://test.stytch.com",
+};
+
+const OK_BODY = {
+  session_jwt: "aaa.bbb.ccc",
+  user: { user_id: "user-test-1", emails: [{ email: "eric@trytako.com" }] },
+};
+
+function ok(body: unknown = OK_BODY, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("authenticateStytchPassword", () => {
+  it("posts email + password to the passwords endpoint with Basic auth", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(ok());
+    const result = await authenticateStytchPassword(
+      cfg,
+      "eric@trytako.com",
+      "correct horse battery staple",
+    );
+    expect(result.session_jwt).toBe("aaa.bbb.ccc");
+    expect(result.user.user_id).toBe("user-test-1");
+
+    const [url, init] = spy.mock.calls[0]!;
+    expect(String(url)).toBe("https://test.stytch.com/v1/passwords/authenticate");
+    expect(init!.method).toBe("POST");
+    const headers = init!.headers as Record<string, string>;
+    expect(headers.authorization).toBe(
+      "Basic " + btoa(`${cfg.projectId}:${cfg.secret}`),
+    );
+    expect(JSON.parse(init!.body as string)).toEqual({
+      email: "eric@trytako.com",
+      password: "correct horse battery staple",
+      session_duration_minutes: 60,
+    });
+  });
+
+  it("surfaces the Stytch error_type so the caller can map it to copy", async () => {
+    // The whole point of keeping `error_type` is that `no_user_password` and
+    // `invalid_credentials` get different user-facing messages — collapsing
+    // them here would strand a Google-signup user with no usable hint.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      ok({ error_type: "no_user_password" }, 401),
+    );
+    await expect(
+      authenticateStytchPassword(cfg, "eric@trytako.com", "pw"),
+    ).rejects.toMatchObject({ errorType: "no_user_password", status: 401 });
+  });
+
+  it("rejects a 401 with no parseable error_type as a StytchError", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 401 }),
+    );
+    await expect(
+      authenticateStytchPassword(cfg, "eric@trytako.com", "pw"),
+    ).rejects.toBeInstanceOf(StytchError);
+  });
+
+  it("rejects a 2xx whose body is missing session_jwt", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok({ user: OK_BODY.user }));
+    await expect(
+      authenticateStytchPassword(cfg, "eric@trytako.com", "pw"),
+    ).rejects.toBeInstanceOf(StytchError);
+  });
+
+  it("rejects a 2xx whose user has no email addresses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      ok({ session_jwt: "a.b.c", user: { user_id: "u", emails: [] } }),
+    );
+    await expect(
+      authenticateStytchPassword(cfg, "eric@trytako.com", "pw"),
+    ).rejects.toBeInstanceOf(StytchError);
+  });
+
+  it("never puts the password in the thrown message", async () => {
+    // A StytchError message can reach a log line; a password must not.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      ok({ error_type: "invalid_credentials" }, 401),
+    );
+    const err = await authenticateStytchPassword(
+      cfg,
+      "eric@trytako.com",
+      "sup3rs3cret",
+    ).catch((e: unknown) => e);
+    expect(String((err as Error).message)).not.toContain("sup3rs3cret");
+  });
+});
+
+describe("authenticateStytchToken still shares the response contract", () => {
+  it("normalizes the oauth response the same way", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(ok());
+    const result = await authenticateStytchToken(cfg, "tok", "oauth");
+    expect(primaryEmail(result.user)).toBe("eric@trytako.com");
+  });
+
+  it("still routes magic_links to its own endpoint", async () => {
+    // The callback keeps accepting magic-link tokens even though the login
+    // page no longer offers them: links already sent must not 400.
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(ok());
+    await authenticateStytchToken(cfg, "tok", "magic_links");
+    expect(String(spy.mock.calls[0]![0])).toContain("/v1/magic_links/authenticate");
+  });
+});

--- a/workers/src/oauth/stytch.ts
+++ b/workers/src/oauth/stytch.ts
@@ -81,10 +81,70 @@ export async function authenticateStytchToken(
       // dance (consent → /token call). The session is later wrapped
       // into our own session cookie and the Stytch JWT is discarded
       // immediately after we use it to fetch the Tako token.
-      session_duration_minutes: 60,
+      session_duration_minutes: SESSION_DURATION_MINUTES,
     }),
   });
 
+  return parseAuthenticateResponse(response, path);
+}
+
+/**
+ * Session lifetime we ask Stytch for. Long enough to finish the OAuth dance
+ * (consent → `/token`); the JWT is wrapped into our own session cookie and
+ * discarded right after it mints the Tako key.
+ */
+const SESSION_DURATION_MINUTES = 60;
+
+/**
+ * Authenticate an email + password directly against Stytch.
+ *
+ * Server-side rather than through the browser SDK, unlike Tako's own
+ * `PasswordSignInPage`: this Worker already exchanges OAuth and magic-link
+ * tokens the same way, and keeping the session JWT server-side means the
+ * password flow reuses the existing session-cookie minting untouched instead
+ * of introducing a second way to become logged in.
+ *
+ * `error_type` is preserved on the thrown `StytchError` because the caller
+ * MUST distinguish the failures — notably `no_user_password`, which means the
+ * account exists but signed up via Google. Collapsing that into "incorrect
+ * email or password" would strand a Google user on a page that no longer
+ * offers a magic link.
+ *
+ * The password is never interpolated into a message or a URL — `StytchError`
+ * messages reach `console.error`.
+ */
+export async function authenticateStytchPassword(
+  cfg: StytchConfig,
+  email: string,
+  password: string,
+): Promise<StytchAuthenticateResult> {
+  const path = "/v1/passwords/authenticate";
+  const response = await fetch(`${cfg.baseUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: authHeader(cfg),
+    },
+    body: JSON.stringify({
+      email,
+      password,
+      session_duration_minutes: SESSION_DURATION_MINUTES,
+    }),
+  });
+
+  return parseAuthenticateResponse(response, path);
+}
+
+/**
+ * Shared response contract for every Stytch authenticate endpoint. One parser
+ * so the token and password paths cannot disagree about what a valid session
+ * looks like — they feed the same session-cookie minting downstream, so a
+ * shape one accepts and the other rejects would be a latent auth bug.
+ */
+async function parseAuthenticateResponse(
+  response: Response,
+  path: string,
+): Promise<StytchAuthenticateResult> {
   let payload: unknown;
   try {
     payload = await response.json();
@@ -112,6 +172,25 @@ export async function authenticateStytchToken(
   const obj = payload as Record<string, unknown>;
   const session_jwt = obj["session_jwt"];
   const user = obj["user"];
+  // MFA: Tako has `/login/mfa` and `/login/mfa-setup` routes, so accounts with
+  // a second factor exist. For those, Stytch answers 200 with an
+  // `intermediate_session_token` and NO usable `session_jwt` — the caller must
+  // complete the second factor before a session exists. This Worker
+  // implements no second-factor UI, so name the case instead of letting it
+  // fall into the generic "missing session_jwt" bucket, which would surface as
+  // "something went wrong" and send the user in circles.
+  const intermediate = obj["intermediate_session_token"];
+  if (
+    (typeof session_jwt !== "string" || session_jwt.length === 0) &&
+    typeof intermediate === "string" &&
+    intermediate.length > 0
+  ) {
+    throw new StytchError(
+      `Stytch ${path} requires a second factor`,
+      response.status,
+      "mfa_required",
+    );
+  }
   if (typeof session_jwt !== "string" || session_jwt.length === 0) {
     throw new StytchError(
       `Stytch ${path} response missing session_jwt`,

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -3,10 +3,61 @@ import { describe, expect, it } from "vitest";
 import type { Env } from "../env.js";
 import {
   __chart_widget_test_only__,
+  APP_UI_RESOURCE_URI,
+  appUiResourceUri,
   buildChartAppUiResourceFromOutputPubId,
 } from "./_chart_widget.js";
 
 const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
+
+describe("appUiResourceUri (dev cache-bust)", () => {
+  // Hosts cache the widget BY URI and claude.ai's cache outlives a connector
+  // remove/re-add, so a stale bundle is invisible unless the URI changes. This
+  // is the dev-only lever for that; it must be inert unless explicitly set.
+  it("is the stable URI when the suffix is unset", () => {
+    expect(appUiResourceUri({ DJANGO_BASE_URL: "https://x.test" } as never)).toBe(
+      APP_UI_RESOURCE_URI,
+    );
+  });
+
+  it("is the stable URI when the suffix is empty", () => {
+    expect(
+      appUiResourceUri({
+        DJANGO_BASE_URL: "https://x.test",
+        WIDGET_URI_SUFFIX: "",
+      } as never),
+    ).toBe(APP_UI_RESOURCE_URI);
+  });
+
+  it("appends a set suffix", () => {
+    expect(
+      appUiResourceUri({
+        DJANGO_BASE_URL: "https://x.test",
+        WIDGET_URI_SUFFIX: "dev42",
+      } as never),
+    ).toBe(APP_UI_RESOURCE_URI + "-dev42");
+  });
+
+  it("strips characters that would break the URI", () => {
+    // The value becomes a URI the host stores and reads back; a stray slash or
+    // space yields one that never resolves.
+    expect(
+      appUiResourceUri({
+        DJANGO_BASE_URL: "https://x.test",
+        WIDGET_URI_SUFFIX: "a b/c?d",
+      } as never),
+    ).toBe(APP_UI_RESOURCE_URI + "-abcd");
+  });
+
+  it("falls back to the stable URI when the suffix is all junk", () => {
+    expect(
+      appUiResourceUri({
+        DJANGO_BASE_URL: "https://x.test",
+        WIDGET_URI_SUFFIX: "///",
+      } as never),
+    ).toBe(APP_UI_RESOURCE_URI);
+  });
+});
 
 describe("chart widget HTML", () => {
   it("notifies height via the MCP Apps size-changed notification", () => {

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -690,6 +690,14 @@ const WIDGET_HTML = `<!doctype html>
   // right backdrop, where \`color-scheme\` can only get close.
   var mcpHostSurface = null;
 
+  // Proof we are talking to an MCP Apps host: set only when a message arrives
+  // over that wire (the \`ui/initialize\` RESPONSE, or a \`tool-result\`
+  // notification). ChatGPT drives the widget through \`window.openai\` and sends
+  // neither, so this stays false there — which is what keeps the approximate
+  // canvas tiers off that host. Distinct from \`initializedSent\`, which fires on
+  // a timeout even when no host ever answered.
+  var mcpHostSeen = false;
+
   // Per the MCP Apps spec, \`hostContext.styles.variables\` carries standardized
   // CSS custom properties. Take the primary background; fall back to the
   // surface variant if a host ships only that one.
@@ -789,7 +797,31 @@ const WIDGET_HTML = `<!doctype html>
       // exactly as it renders today. ChatGPT still gets themed — via the
       // \`dark_mode\` rewrite on the iframe url, which is what actually colours
       // its card.
-      if (mcpHostTheme !== null) root.style.colorScheme = mcpHostTheme;
+      if (mcpHostTheme !== null) {
+        root.style.colorScheme = mcpHostTheme;
+        return;
+      }
+      // Tier 3 — MCP Apps host that declares NOTHING. Still worth painting,
+      // because claude.ai's frame is white whether or not it sends a
+      // \`hostContext\`, and white corners were observed there twice.
+      //
+      // The signal is the OS (\`prefers-color-scheme\`), which is deliberately
+      // the SAME one \`dark_mode=auto\` resolves against inside the embed page.
+      // So the canvas and the card derive from one input and cannot disagree:
+      // an auto card that renders dark gets a dark canvas, a light one gets
+      // light. Guessing a fixed value is what would put black corners on a
+      // light host.
+      //
+      // Still gated to the MCP Apps path — \`hasOpenAiRuntime()\` hosts keep
+      // today's transparency, per the tier-2 reasoning.
+      if (!hasOpenAiRuntime() && mcpHostSeen) {
+        var osDark = false;
+        try {
+          osDark = !!(window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches);
+        } catch (e) { /* no matchMedia — leave it alone */ }
+        root.style.colorScheme = osDark ? "dark" : "light";
+      }
     } catch (e) { /* pre-body or hostile host — cosmetic, never fatal */ }
   }
 
@@ -1730,6 +1762,7 @@ const WIDGET_HTML = `<!doctype html>
       msg.id === INIT_REQUEST_ID &&
       (msg.result !== undefined || msg.error !== undefined)
     ) {
+      mcpHostSeen = true;
       if (msg.result && typeof msg.result === "object") {
         mergeHostContext(msg.result.hostContext);
         applyHostSurface();
@@ -1760,6 +1793,7 @@ const WIDGET_HTML = `<!doctype html>
       return;
     }
     if (fromHost && msg.jsonrpc === "2.0" && msg.method === "ui/notifications/tool-result") {
+      mcpHostSeen = true;
       var params = msg.params || {};
       // Forward both \`structuredContent\` (LLM-visible payload) and
       // \`_meta\` (metadata-only payload, where \`image_data_url\` lives).

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -650,23 +650,55 @@ const WIDGET_HTML = `<!doctype html>
   // surface. Hosts that expose their theme are believed over the OS; the rest
   // keep \`auto\`, which is still the best available guess.
   //
-  // Scope, stated plainly: \`window.openai.theme\` is the ONLY source, so this
-  // reads null on claude.ai. The MCP Apps path has no theme to read — the
-  // \`ui/initialize\` response carries none, and the spec defines none — so the
-  // native card there stays on \`dark_mode=auto\`, i.e. the OS-derived value.
-  // The proxy's \`dark_mode\` allow-list is deliberately forward-looking: it is
-  // exercised by ChatGPT's committed-iframe url today, and is ready for the
-  // MCP Apps path the day a host declares a theme.
+  // Two sources, because the two host families expose the theme differently:
+  //
+  //   - ChatGPT: \`window.openai.theme\`, readable synchronously at any time.
+  //   - MCP Apps (claude.ai): \`hostContext.theme\` on the \`ui/initialize\`
+  //     RESPONSE, with \`ui/notifications/host-context-changed\` for updates
+  //     (spec 2026-01-26). Asynchronous — it arrives with the handshake.
+  //
+  // ChatGPT's runtime wins when both are present: it is the authority on its
+  // own host, and a stale \`hostContext\` must not override it.
+  //
+  // An earlier revision of this comment asserted the spec defined no theme and
+  // left claude.ai on \`dark_mode=auto\` — i.e. on the OS. That was wrong, and
+  // the bug it caused was exactly the one you would predict: a light Claude on
+  // a dark machine rendering a dark card on a light surface (TAKO-3781).
+  //
+  // Ordering is what makes reading it asynchronously safe. A spec-compliant
+  // host MUST NOT send notifications before our \`initialized\`, which we only
+  // send once the \`ui/initialize\` response lands — so \`hostContext\` is
+  // already known by the time any \`tool-result\` arrives. Hosts that never
+  // answer the handshake fall through to \`auto\` via the 200 ms fallback,
+  // which is the same OS-derived guess as before.
+  var mcpHostTheme = null;
+
+  // Spec: "Views merge received fields with their current context state rather
+  // than replacing it entirely." So a partial update that omits \`theme\` must
+  // leave the known theme alone rather than clearing it.
+  function mergeHostContext(hostContext) {
+    if (!hostContext || typeof hostContext !== "object") return;
+    var t = normalizeTheme(hostContext.theme);
+    if (t !== null) mcpHostTheme = t;
+  }
+
+  // Substring, not equality: hosts have shipped values like
+  // \`dark-high-contrast\`. Anything unrecognised reads as "host said nothing",
+  // which leaves \`auto\` in place rather than guessing.
+  function normalizeTheme(value) {
+    if (typeof value !== "string" || !value) return null;
+    var v = value.toLowerCase();
+    if (v.indexOf("dark") !== -1) return "dark";
+    if (v.indexOf("light") !== -1) return "light";
+    return null;
+  }
+
   function hostTheme() {
     try {
-      var t = window.openai && window.openai.theme;
-      if (typeof t === "string" && t) {
-        var v = t.toLowerCase();
-        if (v.indexOf("dark") !== -1) return "dark";
-        if (v.indexOf("light") !== -1) return "light";
-      }
+      var t = normalizeTheme(window.openai && window.openai.theme);
+      if (t !== null) return t;
     } catch (e) { /* no host runtime */ }
-    return null;
+    return mcpHostTheme;
   }
 
   // Rewrite \`dark_mode\` on a chart url to match the host. Leaves the url alone
@@ -1560,17 +1592,42 @@ const WIDGET_HTML = `<!doctype html>
     if (!fromHost && msg.jsonrpc === "2.0") {
       console.warn("[tako-widget] dropped JSON-RPC message from untrusted source", msg.method || msg.id);
     }
-    // Init response → send the \`initialized\` notification so the host
-    // starts piping tool-result messages. Don't gate on response
-    // contents — any matching id (success or error) is sufficient
-    // signal that the host saw our \`ui/initialize\`.
+    // Init response → record the host's declared context, then send the
+    // \`initialized\` notification so the host starts piping tool-result
+    // messages. Don't gate on response contents — any matching id (success
+    // or error) is sufficient signal that the host saw our
+    // \`ui/initialize\`. \`hostContext\` is read opportunistically: an error
+    // response carries none, and a host that declares no theme leaves
+    // \`dark_mode=auto\` in place.
     if (
       fromHost &&
       msg.jsonrpc === "2.0" &&
       msg.id === INIT_REQUEST_ID &&
       (msg.result !== undefined || msg.error !== undefined)
     ) {
+      if (msg.result && typeof msg.result === "object") {
+        mergeHostContext(msg.result.hostContext);
+        log("host context at initialize", { theme: mcpHostTheme });
+      }
       sendInitializedNotification();
+      return;
+    }
+    // Theme (or display mode) changed after initialize. Merging keeps the
+    // next chart correct.
+    //
+    // What this does NOT do: re-theme a chart already on screen. The native
+    // upgrade replaces this document via \`document.open()\`, which discards
+    // this script and its listeners, and the baked PNG is a single
+    // pre-rendered \`data:\` URI with no light twin to swap to. So a mid-
+    // conversation toggle re-themes from the next tool call onward, and
+    // already-rendered cards keep the theme they were drawn with.
+    if (
+      fromHost &&
+      msg.jsonrpc === "2.0" &&
+      msg.method === "ui/notifications/host-context-changed"
+    ) {
+      mergeHostContext((msg.params || {}).hostContext);
+      log("host context changed", { theme: mcpHostTheme });
       return;
     }
     if (fromHost && msg.jsonrpc === "2.0" && msg.method === "ui/notifications/tool-result") {

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -106,6 +106,31 @@ export const PNG_HEAD_FETCH_TIMEOUT_MS = 3_000;
  * old one rather than replacing it.
  */
 export const APP_UI_RESOURCE_URI = "ui://tako/embed/chart";
+
+/**
+ * Widget URI for this deployment, optionally suffixed by `WIDGET_URI_SUFFIX`.
+ *
+ * Exists because hosts cache the widget resource BY URI, and claude.ai's cache
+ * outlives removing and re-adding the connector (see the note above). During
+ * local development that means every widget change is invisible: the host keeps
+ * serving the bundle it first read, and you debug code that is not running.
+ * This was not a hypothetical — three rounds of a rendering fix were tested
+ * against a stale bundle before the console log gave it away.
+ *
+ * Set the var to anything (a timestamp works) to mint a fresh URI and force a
+ * re-read. UNSET in staging and production, where the URI must stay stable
+ * forever — so this is a dev-only escape hatch, not a versioning scheme. If the
+ * SHIPPED bundle ever needs cache-busting, register a new URI ALONGSIDE the old
+ * one, per the note above.
+ */
+export function appUiResourceUri(env: Env): string {
+  const suffix = env.WIDGET_URI_SUFFIX;
+  if (typeof suffix !== "string" || suffix === "") return APP_UI_RESOURCE_URI;
+  // Constrain the value: it becomes a URI the host stores and reads back, and
+  // a stray `/` or space would make a URI that never resolves.
+  const safe = suffix.replace(/[^A-Za-z0-9._-]/g, "");
+  return safe === "" ? APP_UI_RESOURCE_URI : `${APP_UI_RESOURCE_URI}-${safe}`;
+}
 export const APP_UI_RESOURCE_NAME = "open_chart_ui_widget";
 
 /**
@@ -2104,7 +2129,7 @@ export function buildChartAppUiResource(
     // the widget URI from `_meta["openai/outputTemplate"]`) for its
     // interactive iframe path. Also serves any host that doesn't honor
     // per-call URI overrides.
-    uri: APP_UI_RESOURCE_URI,
+    uri: appUiResourceUri(env),
     name: APP_UI_RESOURCE_NAME,
     html: WIDGET_HTML,
     // `frameDomains` is the host CSP's allow-list for nested iframes —
@@ -2217,7 +2242,7 @@ export function buildChartAppUiResourceFromOutputPubId(
       typeof (output as { pub_id?: unknown } | undefined)?.pub_id === "string"
         ? (output as { pub_id: string }).pub_id
         : "";
-    if (pubId === "") return APP_UI_RESOURCE_URI;
+    if (pubId === "") return appUiResourceUri(env);
     return APP_UI_TEMPLATE_URI_PATTERN.replace("{pub_id}", encodeURIComponent(pubId));
   });
 }

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -690,14 +690,6 @@ const WIDGET_HTML = `<!doctype html>
   // right backdrop, where \`color-scheme\` can only get close.
   var mcpHostSurface = null;
 
-  // Proof we are talking to an MCP Apps host: set only when a message arrives
-  // over that wire (the \`ui/initialize\` RESPONSE, or a \`tool-result\`
-  // notification). ChatGPT drives the widget through \`window.openai\` and sends
-  // neither, so this stays false there — which is what keeps the approximate
-  // canvas tiers off that host. Distinct from \`initializedSent\`, which fires on
-  // a timeout even when no host ever answered.
-  var mcpHostSeen = false;
-
   // Per the MCP Apps spec, \`hostContext.styles.variables\` carries standardized
   // CSS custom properties. Take the primary background; fall back to the
   // surface variant if a host ships only that one.
@@ -797,31 +789,7 @@ const WIDGET_HTML = `<!doctype html>
       // exactly as it renders today. ChatGPT still gets themed — via the
       // \`dark_mode\` rewrite on the iframe url, which is what actually colours
       // its card.
-      if (mcpHostTheme !== null) {
-        root.style.colorScheme = mcpHostTheme;
-        return;
-      }
-      // Tier 3 — MCP Apps host that declares NOTHING. Still worth painting,
-      // because claude.ai's frame is white whether or not it sends a
-      // \`hostContext\`, and white corners were observed there twice.
-      //
-      // The signal is the OS (\`prefers-color-scheme\`), which is deliberately
-      // the SAME one \`dark_mode=auto\` resolves against inside the embed page.
-      // So the canvas and the card derive from one input and cannot disagree:
-      // an auto card that renders dark gets a dark canvas, a light one gets
-      // light. Guessing a fixed value is what would put black corners on a
-      // light host.
-      //
-      // Still gated to the MCP Apps path — \`hasOpenAiRuntime()\` hosts keep
-      // today's transparency, per the tier-2 reasoning.
-      if (!hasOpenAiRuntime() && mcpHostSeen) {
-        var osDark = false;
-        try {
-          osDark = !!(window.matchMedia &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches);
-        } catch (e) { /* no matchMedia — leave it alone */ }
-        root.style.colorScheme = osDark ? "dark" : "light";
-      }
+      if (mcpHostTheme !== null) root.style.colorScheme = mcpHostTheme;
     } catch (e) { /* pre-body or hostile host — cosmetic, never fatal */ }
   }
 
@@ -1762,7 +1730,6 @@ const WIDGET_HTML = `<!doctype html>
       msg.id === INIT_REQUEST_ID &&
       (msg.result !== undefined || msg.error !== undefined)
     ) {
-      mcpHostSeen = true;
       if (msg.result && typeof msg.result === "object") {
         mergeHostContext(msg.result.hostContext);
         applyHostSurface();
@@ -1793,7 +1760,6 @@ const WIDGET_HTML = `<!doctype html>
       return;
     }
     if (fromHost && msg.jsonrpc === "2.0" && msg.method === "ui/notifications/tool-result") {
-      mcpHostSeen = true;
       var params = msg.params || {};
       // Forward both \`structuredContent\` (LLM-visible payload) and
       // \`_meta\` (metadata-only payload, where \`image_data_url\` lives).

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -701,6 +701,27 @@ const WIDGET_HTML = `<!doctype html>
     return mcpHostTheme;
   }
 
+  // Match the UA base background to the host's theme.
+  //
+  // Both chart surfaces (the baked PNG and the native card) are rounded
+  // rectangles over a TRANSPARENT html/body, so their corners fall through to
+  // the document's backdrop. An iframe that declares no \`color-scheme\` gets a
+  // WHITE UA base background, which on a dark host shows as white triangles at
+  // each corner of the card.
+  //
+  // Setting \`color-scheme\` — not a background colour — is what keeps the
+  // surface transparent: an opaque colour here would restore the square block
+  // over the host's rounded container that the transparent surface removed.
+  // No-op when the host is silent: guessing dark would put black corners on a
+  // light host, which is the same bug mirrored.
+  function applyHostColorScheme() {
+    var theme = hostTheme();
+    if (!theme) return;
+    try {
+      document.documentElement.style.colorScheme = theme;
+    } catch (e) { /* pre-body or hostile host — cosmetic, never fatal */ }
+  }
+
   // Rewrite \`dark_mode\` on a chart url to match the host. Leaves the url alone
   // when the host is silent, so \`auto\` survives rather than being guessed at.
   //
@@ -1005,11 +1026,33 @@ const WIDGET_HTML = `<!doctype html>
           "__FALLBACK_HEIGHT__",
           String(fallbackHeight || 0),
         );
+        // The card paints its own surface with an 8px radius over a
+        // TRANSPARENT html/body, so its four corners fall through to whatever
+        // is behind the document — and for an iframe with no declared
+        // \`color-scheme\`, the UA base background is WHITE. On a dark host that
+        // rendered as four white triangles poking out from under the card's
+        // rounded corners.
+        //
+        // \`color-scheme\` is the fix rather than a background colour: it moves
+        // the UA base background to a dark value, so the corners composite
+        // against something near the host's own surface, while html/body stay
+        // transparent (a colour here would put an opaque square back over the
+        // host's rounded container — the thing the transparent surface was
+        // introduced to remove). Injected LAST so it wins over the page's own
+        // rules, and only when the host actually told us its theme; with no
+        // theme we leave the UA default alone rather than guess dark and put
+        // black corners on a light host.
+        var scheme = hostTheme();
+        var schemeStyle = scheme
+          ? '<style id="tako-host-scheme">:root{color-scheme:' + scheme +
+            ';background:transparent}body{background:transparent}</style>'
+          : "";
+        var injected = schemeStyle + reporter;
         var patched =
           html.indexOf("</body>") !== -1
-            ? html.replace("</body>", reporter + "</body>")
-            : html + reporter;
-        log("native card upgrading", { bytes: patched.length });
+            ? html.replace("</body>", injected + "</body>")
+            : html + injected;
+        log("native card upgrading", { bytes: patched.length, scheme: scheme || "(host silent)" });
         document.open();
         document.write(patched);
         document.close();
@@ -1237,6 +1280,9 @@ const WIDGET_HTML = `<!doctype html>
   function render(structuredContent, meta) {
     if (rendered) return true;
     if (!structuredContent || typeof structuredContent !== "object") return false;
+    // Also here, not just on the MCP handshake: ChatGPT never sends
+    // \`hostContext\`, so \`window.openai.theme\` is only readable on this path.
+    applyHostColorScheme();
     // No-chart short-circuit: structured content arrived but contains
     // no chart fields at all. \`tako_search\` produces this shape when it
     // returns zero cards (a clean empty result) or when the top card has
@@ -1607,6 +1653,7 @@ const WIDGET_HTML = `<!doctype html>
     ) {
       if (msg.result && typeof msg.result === "object") {
         mergeHostContext(msg.result.hostContext);
+        applyHostColorScheme();
         log("host context at initialize", { theme: mcpHostTheme });
       }
       sendInitializedNotification();
@@ -1627,6 +1674,9 @@ const WIDGET_HTML = `<!doctype html>
       msg.method === "ui/notifications/host-context-changed"
     ) {
       mergeHostContext((msg.params || {}).hostContext);
+      // Re-apply: a theme toggle mid-conversation cannot re-theme the chart
+      // itself, but the corners must not stay wrong.
+      applyHostColorScheme();
       log("host context changed", { theme: mcpHostTheme });
       return;
     }

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -680,6 +680,41 @@ const WIDGET_HTML = `<!doctype html>
     if (!hostContext || typeof hostContext !== "object") return;
     var t = normalizeTheme(hostContext.theme);
     if (t !== null) mcpHostTheme = t;
+    var surface = readHostSurface(hostContext);
+    if (surface !== null) mcpHostSurface = surface;
+  }
+
+  // The host's own page background, when it sends one. This is the EXACT fix
+  // for the card's exposed corners: painting the widget canvas in the host's
+  // surface colour makes the square canvas invisible AND gives the corners the
+  // right backdrop, where \`color-scheme\` can only get close.
+  var mcpHostSurface = null;
+
+  // Per the MCP Apps spec, \`hostContext.styles.variables\` carries standardized
+  // CSS custom properties. Take the primary background; fall back to the
+  // surface variant if a host ships only that one.
+  function readHostSurface(hostContext) {
+    var styles = hostContext.styles;
+    if (!styles || typeof styles !== "object") return null;
+    var vars = styles.variables;
+    if (!vars || typeof vars !== "object") return null;
+    var candidates = ["--color-background-primary", "--color-background-secondary"];
+    for (var i = 0; i < candidates.length; i++) {
+      var v = vars[candidates[i]];
+      if (safeCssColor(v)) return v;
+    }
+    return null;
+  }
+
+  // This value arrives over postMessage and is interpolated into a \`<style>\`
+  // block injected into the native card document, so it is an injection sink.
+  // Allow-list a colour grammar instead of trying to escape one: hex, and the
+  // functional notations, with no semicolons, braces, quotes, or \`url(\`.
+  // Anything else is dropped and we fall back to \`color-scheme\`.
+  function safeCssColor(v) {
+    if (typeof v !== "string" || v.length === 0 || v.length > 64) return false;
+    if (/^#[0-9a-fA-F]{3,8}$/.test(v)) return true;
+    return /^(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch)\\(\\s*[0-9a-zA-Z.,%\\/\\s+-]*\\)$/.test(v);
   }
 
   // Substring, not equality: hosts have shipped values like
@@ -701,24 +736,60 @@ const WIDGET_HTML = `<!doctype html>
     return mcpHostTheme;
   }
 
-  // Match the UA base background to the host's theme.
+  // Give the card's exposed corners the right backdrop.
   //
-  // Both chart surfaces (the baked PNG and the native card) are rounded
-  // rectangles over a TRANSPARENT html/body, so their corners fall through to
-  // the document's backdrop. An iframe that declares no \`color-scheme\` gets a
-  // WHITE UA base background, which on a dark host shows as white triangles at
-  // each corner of the card.
+  // Both chart surfaces (baked PNG and native card) are rounded rectangles over
+  // a TRANSPARENT html/body, so their corners fall through to the document's
+  // backdrop. Measured behaviour, in Chrome:
   //
-  // Setting \`color-scheme\` — not a background colour — is what keeps the
-  // surface transparent: an opaque colour here would restore the square block
-  // over the host's rounded container that the transparent surface removed.
-  // No-op when the host is silent: guessing dark would put black corners on a
-  // light host, which is the same bug mirrored.
-  function applyHostColorScheme() {
-    var theme = hostTheme();
-    if (!theme) return;
+  //   - same-origin frame, no \`color-scheme\`  -> canvas composites over the
+  //     parent, corners correct, nothing to fix.
+  //   - cross-origin / out-of-process frame    -> opaque WHITE base background.
+  //     This is the claude.ai case, and the white triangles people saw.
+  //   - document declares \`color-scheme: dark\` -> opaque base at CHROME's dark
+  //     value (~#121212), not transparent. Better than white on a dark host,
+  //     but a visible square against a host surface of any other shade.
+  //
+  // So there are two tiers, best first:
+  //
+  //   1. The host's own surface colour, when it sends one. Exact: the canvas
+  //      becomes indistinguishable from the host's page, so the square is
+  //      invisible and the corners are right.
+  //   2. \`color-scheme\` from the declared theme. Approximate, and only worth
+  //      it because the alternative on those hosts is WHITE.
+  //
+  // Both are no-ops when the host says nothing at all — that is the case where
+  // transparency already works (same-origin), and painting anything would
+  // introduce the opaque square the transparent surface exists to avoid.
+  function applyHostSurface() {
     try {
-      document.documentElement.style.colorScheme = theme;
+      var root = document.documentElement;
+      // Tier 1 — exact, and safe to apply on ANY host: the canvas becomes the
+      // host's own colour, so it cannot look like a box.
+      if (mcpHostSurface !== null) {
+        root.style.background = mcpHostSurface;
+        if (document.body) document.body.style.background = mcpHostSurface;
+        var t1 = hostTheme();
+        if (t1) root.style.colorScheme = t1;
+        return;
+      }
+      // Tier 2 — approximate, and deliberately gated to the MCP Apps path
+      // (\`mcpHostTheme\`, not \`hostTheme()\`), i.e. NOT ChatGPT.
+      //
+      // Measured against a claude.ai-like #191817 surface: \`color-scheme\`
+      // alone paints Chrome's #121212, which reads as a visible darker square.
+      // That is a clear win over WHITE — which is what claude.ai's
+      // cross-origin frame actually shows, per the bug this fixes — and a clear
+      // LOSS on any host where the frame already composites transparently.
+      //
+      // ChatGPT exposes a theme via \`window.openai.theme\`, but its frame's
+      // base background is not something we have measured, and on that host the
+      // chart is a NESTED cross-origin iframe whose document we cannot style
+      // anyway. So there is no upside to gamble for: leave it transparent,
+      // exactly as it renders today. ChatGPT still gets themed — via the
+      // \`dark_mode\` rewrite on the iframe url, which is what actually colours
+      // its card.
+      if (mcpHostTheme !== null) root.style.colorScheme = mcpHostTheme;
     } catch (e) { /* pre-body or hostile host — cosmetic, never fatal */ }
   }
 
@@ -1026,33 +1097,41 @@ const WIDGET_HTML = `<!doctype html>
           "__FALLBACK_HEIGHT__",
           String(fallbackHeight || 0),
         );
-        // The card paints its own surface with an 8px radius over a
-        // TRANSPARENT html/body, so its four corners fall through to whatever
-        // is behind the document — and for an iframe with no declared
-        // \`color-scheme\`, the UA base background is WHITE. On a dark host that
-        // rendered as four white triangles poking out from under the card's
-        // rounded corners.
+        // The card paints its own surface with an 8px radius over a TRANSPARENT
+        // html/body, so its corners fall through to the document's backdrop —
+        // which on claude.ai's cross-origin frame is opaque WHITE. Those were
+        // the white triangles under the card's corners.
         //
-        // \`color-scheme\` is the fix rather than a background colour: it moves
-        // the UA base background to a dark value, so the corners composite
-        // against something near the host's own surface, while html/body stay
-        // transparent (a colour here would put an opaque square back over the
-        // host's rounded container — the thing the transparent surface was
-        // introduced to remove). Injected LAST so it wins over the page's own
-        // rules, and only when the host actually told us its theme; with no
-        // theme we leave the UA default alone rather than guess dark and put
-        // black corners on a light host.
-        var scheme = hostTheme();
-        var schemeStyle = scheme
-          ? '<style id="tako-host-scheme">:root{color-scheme:' + scheme +
-            ';background:transparent}body{background:transparent}</style>'
-          : "";
+        // Same two tiers as \`applyHostSurface\`, and the same gate: the host's
+        // exact surface colour is safe anywhere, while bare \`color-scheme\`
+        // (Chrome's own #121212) only beats WHITE and would read as a visible
+        // square on a host that composites transparently — so it is limited to
+        // the MCP Apps path, where the white base is the measured behaviour.
+        //
+        // In practice this path is MCP-only anyway: ChatGPT commits to the
+        // nested iframe and never reaches the native upgrade. The gate is
+        // written explicitly so it stays correct if that changes. Injected LAST
+        // so it wins over the page's own rules.
+        var scheme = mcpHostSurface !== null ? hostTheme() : mcpHostTheme;
+        var surface = mcpHostSurface;
+        var schemeStyle = "";
+        if (surface !== null) {
+          // Exact host surface — the square canvas becomes invisible.
+          schemeStyle =
+            '<style id="tako-host-scheme">:root,body{background:' + surface + '}' +
+            (scheme ? ':root{color-scheme:' + scheme + '}' : "") + '</style>';
+        } else if (scheme) {
+          // Approximate: Chrome's base for the declared scheme. Worth it only
+          // because the alternative on a cross-origin frame is WHITE.
+          schemeStyle =
+            '<style id="tako-host-scheme">:root{color-scheme:' + scheme + '}</style>';
+        }
         var injected = schemeStyle + reporter;
         var patched =
           html.indexOf("</body>") !== -1
             ? html.replace("</body>", injected + "</body>")
             : html + injected;
-        log("native card upgrading", { bytes: patched.length, scheme: scheme || "(host silent)" });
+        log("native card upgrading", { bytes: patched.length, scheme: scheme || "(host silent)", surface: surface || "(none)" });
         document.open();
         document.write(patched);
         document.close();
@@ -1282,7 +1361,7 @@ const WIDGET_HTML = `<!doctype html>
     if (!structuredContent || typeof structuredContent !== "object") return false;
     // Also here, not just on the MCP handshake: ChatGPT never sends
     // \`hostContext\`, so \`window.openai.theme\` is only readable on this path.
-    applyHostColorScheme();
+    applyHostSurface();
     // No-chart short-circuit: structured content arrived but contains
     // no chart fields at all. \`tako_search\` produces this shape when it
     // returns zero cards (a clean empty result) or when the top card has
@@ -1653,7 +1732,7 @@ const WIDGET_HTML = `<!doctype html>
     ) {
       if (msg.result && typeof msg.result === "object") {
         mergeHostContext(msg.result.hostContext);
-        applyHostColorScheme();
+        applyHostSurface();
         log("host context at initialize", { theme: mcpHostTheme });
       }
       sendInitializedNotification();
@@ -1676,7 +1755,7 @@ const WIDGET_HTML = `<!doctype html>
       mergeHostContext((msg.params || {}).hostContext);
       // Re-apply: a theme toggle mid-conversation cannot re-theme the chart
       // itself, but the corners must not stay wrong.
-      applyHostColorScheme();
+      applyHostSurface();
       log("host context changed", { theme: mcpHostTheme });
       return;
     }

--- a/workers/src/tools/_render_markdown.ts
+++ b/workers/src/tools/_render_markdown.ts
@@ -93,6 +93,12 @@ export const answerSlimOutputShape = z.looseObject({
     .describe(
       "Present only when the data source grounded zero cards: the deterministic coverage verdict.",
     ),
+  // Same widget fields search advertises. Without them the chart for an
+  // answer's top cited card never renders: the widget reads `embed_url` /
+  // `image_url` / `height` off `structuredContent`, and the SDK rebuilds the
+  // advertised schema strictly at the top level, so fields absent here are
+  // dropped before the host ever sees them.
+  ...autoChainShape,
 });
 
 /** tako_answer's full handler output (internal; the advertised schema is

--- a/workers/src/tools/_search_results.ts
+++ b/workers/src/tools/_search_results.ts
@@ -1015,22 +1015,40 @@ export function buildSearchOutput(
         }
       : {}),
   };
+  return { ...base, ...topCardChartFields(cards, env) };
+}
+
+/**
+ * Widget fields for the top card, or `{}` when there is no renderable card.
+ *
+ * Shared by `tako_search` and `tako_answer` so a chart renders identically
+ * whichever tool produced it. They diverged before this existed: search lifted
+ * these fields and answer did not, so an answer's cited card came back as text
+ * with no chart even though the card ids were right there in the output.
+ *
+ * Only the TOP card gets a chart — the widget renders one, and `pub_id` is
+ * singular in the output schema.
+ */
+export function topCardChartFields(
+  // `card_id` is nullable on the wire (`takoCardSchema`), so accept null here
+  // rather than making each caller narrow it — the `typeof` check below is the
+  // one place that decides what counts as renderable.
+  cards: readonly { card_id?: string | null | undefined }[],
+  env: Env,
+): Record<string, unknown> {
   const topCardId = cards[0]?.card_id;
-  if (typeof topCardId === "string" && topCardId !== "") {
-    const { embed_url, image_url } = buildChartUrls(
-      env,
-      topCardId,
-      DEFAULT_DARK_MODE,
-    );
-    return {
-      ...base,
-      pub_id: topCardId,
-      embed_url,
-      image_url,
-      dark_mode: DEFAULT_DARK_MODE,
-      width: DEFAULT_WIDTH,
-      height: DEFAULT_HEIGHT,
-    };
-  }
-  return base;
+  if (typeof topCardId !== "string" || topCardId === "") return {};
+  const { embed_url, image_url } = buildChartUrls(
+    env,
+    topCardId,
+    DEFAULT_DARK_MODE,
+  );
+  return {
+    pub_id: topCardId,
+    embed_url,
+    image_url,
+    dark_mode: DEFAULT_DARK_MODE,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+  };
 }

--- a/workers/src/tools/tako_answer.test.ts
+++ b/workers/src/tools/tako_answer.test.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import type { Env } from "../env.js";
 import type { ToolContext } from "./types.js";
 import takoAnswer, { buildAnswerBody } from "./tako_answer.js";
+import takoSearch from "./tako_search.js";
 import { SearchRequest } from "../generated/schemas.js";
 import {
   bodyOf,
@@ -195,6 +196,81 @@ describe("tako_answer handler", () => {
     await expect(
       takoAnswer.handler({ query: "q", sources: ["tako", "web"], include_contents: false, preview_rows: 50, country_code: "US", locale: "en-US", strict: false }, CTX),
     ).rejects.toThrow(/unexpected wire shape/);
+  });
+});
+
+describe("tako_answer renders a chart, exactly like tako_search", () => {
+  // The gap this closes: an answer's citations ARE cards, but only search
+  // lifted the widget fields, so an answer came back as text with no chart
+  // even though the card ids were right there in the output.
+
+  it("lifts the top cited card's widget fields", async () => {
+    mockFetchSequence([jsonResponse(200, FULL_RESPONSE)]);
+    const out = await takoAnswer.handler(
+      {
+        query: "What was US GDP in 2024?",
+        sources: ["data", "web"], include_contents: false, preview_rows: 50,
+        country_code: "US", locale: "en-US", strict: false,
+      },
+      CTX,
+    );
+    const o = out as unknown as Record<string, unknown>;
+    expect(o.pub_id).toBe("abc123");
+    expect(String(o.embed_url)).toContain("/embed/abc123/");
+    expect(String(o.image_url)).toContain("/api/v1/image/abc123/");
+    expect(typeof o.height).toBe("number");
+  });
+
+  it("declares the same widget resource search does", () => {
+    // Without this the host has no widget to render the fields into.
+    expect(takoAnswer.appUiResource).toBeDefined();
+    expect(takoSearch.appUiResource).toBeDefined();
+    const ORIGIN = "https://mcp.example.test";
+    const a = takoAnswer.appUiResource!(ENV, ORIGIN);
+    const s = takoSearch.appUiResource!(ENV, ORIGIN);
+    expect(a.uri).toBe(s.uri);
+    expect(a.html).toBe(s.html);
+    // requestOrigin must reach the resource: it is what the native-card URL
+    // and the connectDomains declaration are derived from.
+    expect(a.frameDomains).toEqual(s.frameDomains);
+    expect(a.resourceDomains).toEqual(s.resourceDomains);
+    expect(a.connectDomains).toEqual(s.connectDomains);
+  });
+
+  it("carries the widget hooks search carries", () => {
+    expect(typeof takoAnswer.extraMeta).toBe("function");
+    expect(typeof takoAnswer.extraContentBlocks).toBe("function");
+  });
+
+  it("advertises the widget fields, or the SDK strips them", () => {
+    // The advertised schema is rebuilt strict at the top level, so a field
+    // that is not declared never reaches the host.
+    const shape = Object.keys(
+      (takoAnswer.outputSchema as unknown as { shape: Record<string, unknown> }).shape,
+    );
+    for (const key of ["pub_id", "embed_url", "image_url", "height"]) {
+      expect(shape).toContain(key);
+    }
+  });
+
+  it("emits no widget fields when nothing is citable", async () => {
+    // Zero cards must not produce a chart pointing at nothing; the widget
+    // collapses on this shape.
+    mockFetchSequence([
+      jsonResponse(200, { ...FULL_RESPONSE, cards: [], request_id: "req-empty" }),
+    ]);
+    const out = await takoAnswer.handler(
+      {
+        query: "something with no data",
+        sources: ["data", "web"], include_contents: false, preview_rows: 50,
+        country_code: "US", locale: "en-US", strict: false,
+      },
+      CTX,
+    );
+    const o = out as unknown as Record<string, unknown>;
+    expect(o.pub_id).toBeUndefined();
+    expect(o.embed_url).toBeUndefined();
+    expect(o.image_url).toBeUndefined();
   });
 });
 

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -10,6 +10,12 @@ import {
   type AnswerFullOutput,
 } from "./_render_markdown.js";
 import {
+  buildChartAppUiResourceFromOutputPubId,
+  buildChartExtraMeta,
+  fetchPngContentBlock,
+} from "./_chart_widget.js";
+import {
+  autoChainShape,
   hoistSourceGlossary,
   INLINE_PREVIEW_ROW_CAP,
   MAX_PREVIEW_ROWS,
@@ -34,10 +40,11 @@ import {
   slimCard,
   slimWebResult,
   takoCardSchema,
+  topCardChartFields,
   usageSchema,
   webResultSchema,
 } from "./_search_results.js";
-import type { ToolModule } from "./types.js";
+import type { AppUiResource, ToolContentBlock, ToolModule } from "./types.js";
 
 const DESCRIPTION = [
   "START HERE for any question that wants a value, figure, or finding: ask one specific data question, get one synthesized answer grounded in the data or web tako cites.",
@@ -137,6 +144,10 @@ const fullOutputSchema = z.object({
     .describe(
       "Source/methodology descriptions shared by the cards, keyed by name — hoisted here so each rides once instead of once per card.",
     ),
+  // Widget fields for the top cited card, same as tako_search. An answer's
+  // citations ARE cards, so a chart belongs here for the same reason it
+  // belongs there; before this they were dropped and only search rendered one.
+  ...autoChainShape,
 });
 
 // Advertised (slim) schema — see the fullOutputSchema comment above.
@@ -325,6 +336,10 @@ const takoAnswer = {
             ),
           }
         : {}),
+      // Chart for the top cited card — shared with tako_search via
+      // `topCardChartFields` so the two cannot render differently. Yields `{}`
+      // when nothing is citable, which is also the zero-card case.
+      ...topCardChartFields(cards, ctx.env),
       // Glossary spreads on LAST so it serializes after the data — truncating
       // clients then drop boilerplate first.
       ...(glossary === undefined ? {} : { sources_glossary: glossary }),
@@ -336,6 +351,33 @@ const takoAnswer = {
   },
   slimStructured(output) {
     return slimAnswerStructured(output as unknown as AnswerFullOutput);
+  },
+  // Widget plumbing, identical to tako_search's. Rationale for each gate lives
+  // there; the only reason it is duplicated rather than shared is that the
+  // hooks are per-tool fields on `ToolModule`.
+  async extraMeta(output, ctx) {
+    // ChatGPT renders `embed_url` in an iframe and never reads the baked PNG,
+    // but still needs the aspect ratio to size that iframe — dimensions only
+    // there (a 64-byte ranged read instead of a ~170 KB render).
+    return buildChartExtraMeta((output as { image_url?: string }).image_url, {
+      bakeImage: ctx.client !== "chatgpt",
+      env: ctx.env,
+      origin: ctx.origin,
+      pubId: (output as { pub_id?: string }).pub_id,
+    });
+  },
+  async extraContentBlocks(output, _ctx): Promise<ToolContentBlock[]> {
+    void _ctx;
+    const imageUrl = (output as { image_url?: string }).image_url;
+    if (imageUrl === undefined) return [];
+    return fetchPngContentBlock(imageUrl);
+  },
+  appUiResource(env, requestOrigin): AppUiResource {
+    // `requestOrigin` must be forwarded: it is what `nativeCardUrl` and the
+    // `connectDomains` CSP declaration are both derived from. Dropping it
+    // yields a widget that declares no origin and fetches nothing, i.e. no
+    // native card at all — a silent downgrade to the PNG.
+    return buildChartAppUiResourceFromOutputPubId(env, requestOrigin);
   },
 } satisfies ToolModule<typeof inputSchema, Output>;
 

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -1298,6 +1298,72 @@ describe("mcp apps host theme (executed)", () => {
     ).toContain("dark_mode=false");
   });
 
+  it("paints the host's own surface colour when the host sends one", () => {
+    // The exact fix for the exposed corners: an opaque canvas in the host's own
+    // colour is invisible against the host's page AND gives the corners the
+    // right backdrop. `color-scheme` can only approximate it.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      initResponse({
+        theme: "dark",
+        styles: { variables: { "--color-background-primary": "#191817" } },
+      }),
+      m.wrapperWin,
+    );
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
+    const root = m.widgetWin.document.documentElement;
+    // The DOM normalizes hex to rgb() on the way in.
+    expect(root.style.background).toBe("rgb(25, 24, 23)");
+    expect(root.style.colorScheme).toBe("dark");
+  });
+
+  it("refuses a host surface colour that is not a colour", () => {
+    // Arrives over postMessage and is interpolated into an injected <style>,
+    // so it is an injection sink. Allow-list a grammar, do not escape.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      initResponse({
+        theme: "dark",
+        styles: {
+          variables: {
+            "--color-background-primary": "red;} body{display:none} :root{x:",
+          },
+        },
+      }),
+      m.wrapperWin,
+    );
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
+    const root = m.widgetWin.document.documentElement;
+    expect(root.style.background).not.toContain("display:none");
+    // Falls back to the approximate tier rather than trusting the value.
+    expect(root.style.colorScheme).toBe("dark");
+  });
+
+  it("leaves the canvas alone entirely when the host says nothing", () => {
+    // A same-origin frame composites transparently over the parent, so the
+    // corners are already correct there. Painting anything would introduce the
+    // opaque square the transparent surface exists to avoid.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
+    const root = m.widgetWin.document.documentElement;
+    expect(root.style.colorScheme).toBe("");
+    expect(root.style.background).toBe("");
+  });
+
   it("declares color-scheme so the card's corners are not white", () => {
     // The card is a rounded rectangle over a transparent html/body, so its
     // corners fall through to the UA base background — WHITE unless the
@@ -1376,11 +1442,154 @@ describe("mcp apps host theme (executed)", () => {
     );
     fireImageLoad(m);
     await new Promise((r) => setTimeout(r, 30));
+    // Theme only, no surface colour sent -> the approximate tier, and NO
+    // background is painted (transparency is left intact).
     expect(written).toContain("color-scheme:dark");
-    expect(written).toContain("background:transparent");
+    expect(written).not.toContain("background:");
     // Injected before </body> so it wins over the page's own rules.
     expect(written.indexOf("color-scheme:dark")).toBeLessThan(
       written.indexOf("</body>"),
+    );
+  });
+
+  it("paints the native card document in the host's surface colour", async () => {
+    // The native path replaces this document, so the colour has to ride in the
+    // markup — and this is the tier that makes the corners exact rather than
+    // approximate.
+    const m = mountWidget(staticWidgetHtml());
+    let written = "";
+    (m.widgetWin as unknown as { fetch: unknown }).fetch = () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve("<!doctype html><html><body>c</body></html>"),
+      });
+    const doc = m.widgetWin.document as unknown as {
+      open(): void;
+      write(s: string): void;
+      close(): void;
+    };
+    doc.open = () => {};
+    doc.write = (t: string) => {
+      written += t;
+    };
+    doc.close = () => {};
+    deliver(
+      m,
+      initResponse({
+        theme: "dark",
+        styles: { variables: { "--color-background-primary": "rgb(25, 24, 23)" } },
+      }),
+      m.wrapperWin,
+    );
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 },
+        { image_data_url: DATA_URL, native_card_url: NATIVE_URL },
+      ),
+      m.wrapperWin,
+    );
+    fireImageLoad(m);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(written).toContain("background:rgb(25, 24, 23)");
+    expect(written).toContain("color-scheme:dark");
+  });
+
+  it("does not inject a hostile surface colour into the native document", async () => {
+    const m = mountWidget(staticWidgetHtml());
+    let written = "";
+    (m.widgetWin as unknown as { fetch: unknown }).fetch = () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve("<!doctype html><html><body>c</body></html>"),
+      });
+    const doc = m.widgetWin.document as unknown as {
+      open(): void;
+      write(s: string): void;
+      close(): void;
+    };
+    doc.open = () => {};
+    doc.write = (t: string) => {
+      written += t;
+    };
+    doc.close = () => {};
+    deliver(
+      m,
+      initResponse({
+        theme: "dark",
+        styles: {
+          variables: {
+            "--color-background-primary": "#fff}</style><script>x=1</script><style>",
+          },
+        },
+      }),
+      m.wrapperWin,
+    );
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 },
+        { image_data_url: DATA_URL, native_card_url: NATIVE_URL },
+      ),
+      m.wrapperWin,
+    );
+    fireImageLoad(m);
+    await new Promise((r) => setTimeout(r, 30));
+    // The payload never lands, and no background is painted — it falls back
+    // to the approximate tier instead of trusting the value.
+    expect(written).not.toContain("x=1");
+    expect(written).not.toContain("background:");
+    expect(written).toContain("color-scheme:dark");
+  });
+
+  it("leaves ChatGPT's canvas transparent — no box where none existed", () => {
+    // The gate that matters for cross-platform safety. ChatGPT exposes a theme,
+    // but bare `color-scheme` paints Chrome's #121212, which reads as a visible
+    // square on any host whose frame already composites transparently. Measured
+    // against a #191817 surface, that square is obvious. claude.ai's frame is
+    // WHITE (the bug), so the trade is worth it there and only there — and on
+    // ChatGPT the chart is a NESTED cross-origin iframe we could not style
+    // anyway. So: no paint, no color-scheme, nothing.
+    const m = mountWidget(staticWidgetHtml());
+    (m.widgetWin as unknown as { openai: Record<string, unknown> }).openai = {
+      theme: "dark",
+    };
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 }),
+      m.wrapperWin,
+    );
+    const root = m.widgetWin.document.documentElement;
+    expect(root.style.colorScheme).toBe("");
+    expect(root.style.background).toBe("");
+    // ChatGPT is still themed — via the dark_mode rewrite on the iframe url,
+    // which is what actually colours its card.
+    expect(widgetFrame(m).getAttribute("src")).toContain("dark_mode=true");
+  });
+
+  it("still paints ChatGPT's canvas when a surface colour IS supplied", () => {
+    // Tier 1 is exact, so it is safe on every host — the gate is only on the
+    // approximate tier.
+    const m = mountWidget(staticWidgetHtml());
+    (m.widgetWin as unknown as { openai: Record<string, unknown> }).openai = {
+      theme: "dark",
+    };
+    deliver(
+      m,
+      initResponse({
+        styles: { variables: { "--color-background-primary": "#191817" } },
+      }),
+      m.wrapperWin,
+    );
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 }),
+      m.wrapperWin,
+    );
+    expect(m.widgetWin.document.documentElement.style.background).toBe(
+      "rgb(25, 24, 23)",
     );
   });
 

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -1349,10 +1349,12 @@ describe("mcp apps host theme (executed)", () => {
     expect(root.style.colorScheme).toBe("dark");
   });
 
-  it("leaves the canvas alone entirely when the host says nothing", () => {
-    // A same-origin frame composites transparently over the parent, so the
-    // corners are already correct there. Painting anything would introduce the
-    // opaque square the transparent surface exists to avoid.
+  it("falls back to the OS when an MCP host declares nothing", () => {
+    // claude.ai's frame is white whether or not it sends a hostContext, and
+    // white corners were observed there twice — so a silent MCP host still gets
+    // painted. The signal is `prefers-color-scheme`, deliberately the same one
+    // `dark_mode=auto` resolves against inside the embed page, so the canvas and
+    // the card derive from one input and cannot disagree.
     const m = mountWidget(staticWidgetHtml());
     deliver(
       m,
@@ -1360,7 +1362,10 @@ describe("mcp apps host theme (executed)", () => {
       m.wrapperWin,
     );
     const root = m.widgetWin.document.documentElement;
-    expect(root.style.colorScheme).toBe("");
+    // jsdom reports light; the assertion is that SOMETHING was applied, from
+    // the OS rather than a guess.
+    expect(["light", "dark"]).toContain(root.style.colorScheme);
+    // No background painted — only tier 1 (an exact host colour) does that.
     expect(root.style.background).toBe("");
   });
 
@@ -1397,16 +1402,13 @@ describe("mcp apps host theme (executed)", () => {
     expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("light");
   });
 
-  it("leaves the UA default alone when the host declares no theme", () => {
-    // Guessing dark here would put BLACK corners on a light host — the same
-    // bug mirrored.
+  it("never paints a canvas before an MCP host has spoken", () => {
+    // The tier-3 gate. Without a message over the MCP wire we have no evidence
+    // this is a white-based frame, so nothing is applied — that is what keeps
+    // the approximate tiers off hosts we have not measured.
     const m = mountWidget(staticWidgetHtml());
-    deliver(
-      m,
-      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
-      m.wrapperWin,
-    );
     expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("");
+    expect(m.widgetWin.document.documentElement.style.background).toBe("");
   });
 
   it("injects the scheme into the native card document too", async () => {

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -1349,12 +1349,10 @@ describe("mcp apps host theme (executed)", () => {
     expect(root.style.colorScheme).toBe("dark");
   });
 
-  it("falls back to the OS when an MCP host declares nothing", () => {
-    // claude.ai's frame is white whether or not it sends a hostContext, and
-    // white corners were observed there twice — so a silent MCP host still gets
-    // painted. The signal is `prefers-color-scheme`, deliberately the same one
-    // `dark_mode=auto` resolves against inside the embed page, so the canvas and
-    // the card derive from one input and cannot disagree.
+  it("leaves the canvas alone entirely when the host says nothing", () => {
+    // A same-origin frame composites transparently over the parent, so the
+    // corners are already correct there. Painting anything would introduce the
+    // opaque square the transparent surface exists to avoid.
     const m = mountWidget(staticWidgetHtml());
     deliver(
       m,
@@ -1362,10 +1360,7 @@ describe("mcp apps host theme (executed)", () => {
       m.wrapperWin,
     );
     const root = m.widgetWin.document.documentElement;
-    // jsdom reports light; the assertion is that SOMETHING was applied, from
-    // the OS rather than a guess.
-    expect(["light", "dark"]).toContain(root.style.colorScheme);
-    // No background painted — only tier 1 (an exact host colour) does that.
+    expect(root.style.colorScheme).toBe("");
     expect(root.style.background).toBe("");
   });
 
@@ -1402,13 +1397,16 @@ describe("mcp apps host theme (executed)", () => {
     expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("light");
   });
 
-  it("never paints a canvas before an MCP host has spoken", () => {
-    // The tier-3 gate. Without a message over the MCP wire we have no evidence
-    // this is a white-based frame, so nothing is applied — that is what keeps
-    // the approximate tiers off hosts we have not measured.
+  it("leaves the UA default alone when the host declares no theme", () => {
+    // Guessing dark here would put BLACK corners on a light host — the same
+    // bug mirrored.
     const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
     expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("");
-    expect(m.widgetWin.document.documentElement.style.background).toBe("");
   });
 
   it("injects the scheme into the native card document too", async () => {

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -1187,3 +1187,138 @@ describe("host theme (executed)", () => {
     expect(themedFrameSrc("solarized")).toContain("dark_mode=auto");
   });
 });
+
+/**
+ * The MCP Apps theme source. `window.openai.theme` is ChatGPT-only, so on
+ * claude.ai the theme used to resolve to null and both chart urls stayed on
+ * `dark_mode=auto` — i.e. the OS. A light Claude on a dark machine therefore
+ * rendered a dark card on a light surface.
+ *
+ * The spec DOES carry a theme: the `ui/initialize` RESPONSE includes
+ * `result.hostContext.theme`, and hosts send `ui/notifications/host-context-changed`
+ * when it changes. Both are read here.
+ *
+ * Asserted on the native-card url because that is the Claude path — no
+ * `window.openai`, so `render()` takes the image branch and then upgrades.
+ */
+describe("mcp apps host theme (executed)", () => {
+  const NATIVE_URL = "https://mcp.example.test/embed-html/abc123?dark_mode=auto";
+
+  /**
+   * Mount, feed the widget a sequence of host messages, deliver a chart with
+   * the native url armed, and return the url the native upgrade fetched.
+   * The upgrade runs from the image `load` handler, so that has to be fired.
+   */
+  function nativeUrlAfter(hostMessages: unknown[]): string | undefined {
+    const m = mountWidget(staticWidgetHtml());
+    const calls: string[] = [];
+    (m.widgetWin as unknown as { fetch: unknown }).fetch = (url: string) => {
+      calls.push(String(url));
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve("<!doctype html><html><body></body></html>"),
+      });
+    };
+    for (const msg of hostMessages) deliver(m, msg, m.wrapperWin);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 },
+        { image_data_url: DATA_URL, native_card_url: NATIVE_URL },
+      ),
+      m.wrapperWin,
+    );
+    fireImageLoad(m);
+    return calls[0];
+  }
+
+  function initResponse(hostContext: unknown): unknown {
+    return { jsonrpc: "2.0", id: "tako-ui-init", result: { hostContext } };
+  }
+
+  function contextChanged(hostContext: unknown): unknown {
+    return {
+      jsonrpc: "2.0",
+      method: "ui/notifications/host-context-changed",
+      params: { hostContext },
+    };
+  }
+
+  function nativeUrlWithHostContext(hostContext: unknown): string | undefined {
+    return nativeUrlAfter(
+      hostContext === undefined ? [] : [initResponse(hostContext)],
+    );
+  }
+
+  it("asks for a light card when the host declares a light theme", () => {
+    expect(nativeUrlWithHostContext({ theme: "light" })).toContain(
+      "dark_mode=false",
+    );
+  });
+
+  it("asks for a dark card when the host declares a dark theme", () => {
+    expect(nativeUrlWithHostContext({ theme: "dark" })).toContain(
+      "dark_mode=true",
+    );
+  });
+
+  it("stays on auto when the host declares no theme", () => {
+    // Still the best available guess — following the OS beats a coin flip.
+    expect(nativeUrlWithHostContext({})).toContain("dark_mode=auto");
+  });
+
+  it("stays on auto when the host never answers the handshake", () => {
+    expect(nativeUrlWithHostContext(undefined)).toContain("dark_mode=auto");
+  });
+
+  it("ignores an unrecognised hostContext theme", () => {
+    expect(nativeUrlWithHostContext({ theme: "solarized" })).toContain(
+      "dark_mode=auto",
+    );
+  });
+
+  it("honours a theme that only arrives via host-context-changed", () => {
+    // Hosts MAY omit `theme` at initialize and send it later; a toggle before
+    // the first tool call must still be reflected.
+    expect(
+      nativeUrlAfter([initResponse({}), contextChanged({ theme: "light" })]),
+    ).toContain("dark_mode=false");
+  });
+
+  it("merges a partial host-context-changed instead of replacing context", () => {
+    // Spec: "Views merge received fields with their current context state
+    // rather than replacing it entirely." A displayMode-only update must not
+    // wipe the theme learned at initialize.
+    expect(
+      nativeUrlAfter([
+        initResponse({ theme: "light" }),
+        contextChanged({ displayMode: "fullscreen" }),
+      ]),
+    ).toContain("dark_mode=false");
+  });
+
+  it("prefers window.openai.theme when both sources are present", () => {
+    // ChatGPT's own runtime is the authority on ChatGPT; a stale or spoofed
+    // hostContext must not override the host API that host actually drives.
+    const m = mountWidget(staticWidgetHtml());
+    (m.widgetWin as unknown as { openai: Record<string, unknown> }).openai = {
+      theme: "dark",
+    };
+    deliver(
+      m,
+      {
+        jsonrpc: "2.0",
+        id: "tako-ui-init",
+        result: { hostContext: { theme: "light" } },
+      },
+      m.wrapperWin,
+    );
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 }),
+      m.wrapperWin,
+    );
+    expect(widgetFrame(m).getAttribute("src")).toContain("dark_mode=true");
+  });
+});

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -1298,6 +1298,92 @@ describe("mcp apps host theme (executed)", () => {
     ).toContain("dark_mode=false");
   });
 
+  it("declares color-scheme so the card's corners are not white", () => {
+    // The card is a rounded rectangle over a transparent html/body, so its
+    // corners fall through to the UA base background — WHITE unless the
+    // document declares a scheme. On a dark host that showed as four white
+    // triangles. `color-scheme` and not a background colour, because an opaque
+    // colour would put a square block back over the host's rounded container.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, initResponse({ theme: "dark" }), m.wrapperWin);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 },
+        { image_data_url: DATA_URL },
+      ),
+      m.wrapperWin,
+    );
+    expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("dark");
+    // Still transparent — the fix must not reintroduce an opaque surface.
+    const bg = m.widgetWin.document.documentElement.style.background;
+    expect(bg === "" || bg.includes("transparent")).toBe(true);
+  });
+
+  it("follows a light host too", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, initResponse({ theme: "light" }), m.wrapperWin);
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
+    expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("light");
+  });
+
+  it("leaves the UA default alone when the host declares no theme", () => {
+    // Guessing dark here would put BLACK corners on a light host — the same
+    // bug mirrored.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult({ embed_url: EMBED_URL, image_url: IMAGE_URL }, { image_data_url: DATA_URL }),
+      m.wrapperWin,
+    );
+    expect(m.widgetWin.document.documentElement.style.colorScheme).toBe("");
+  });
+
+  it("injects the scheme into the native card document too", async () => {
+    // The native path replaces this document wholesale, so the widget's own
+    // <html> style does not survive — the scheme has to ride in the markup.
+    const m = mountWidget(staticWidgetHtml());
+    let written = "";
+    (m.widgetWin as unknown as { fetch: unknown }).fetch = () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () =>
+          Promise.resolve("<!doctype html><html><body><div>card</div></body></html>"),
+      });
+    const doc = m.widgetWin.document as unknown as {
+      open(): void;
+      write(s: string): void;
+      close(): void;
+    };
+    doc.open = () => {};
+    doc.write = (s: string) => {
+      written += s;
+    };
+    doc.close = () => {};
+    deliver(m, initResponse({ theme: "dark" }), m.wrapperWin);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 },
+        { image_data_url: DATA_URL, native_card_url: NATIVE_URL },
+      ),
+      m.wrapperWin,
+    );
+    fireImageLoad(m);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(written).toContain("color-scheme:dark");
+    expect(written).toContain("background:transparent");
+    // Injected before </body> so it wins over the page's own rules.
+    expect(written.indexOf("color-scheme:dark")).toBeLessThan(
+      written.indexOf("</body>"),
+    );
+  });
+
   it("prefers window.openai.theme when both sources are present", () => {
     // ChatGPT's own runtime is the authority on ChatGPT; a stale or spoofed
     // hostContext must not override the host API that host actually drives.

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -65,6 +65,20 @@
       "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
       "namespace_id": "1010",
       "simple": { "limit": 120, "period": 60 }
+    },
+    {
+      // Throttles `POST /login/password`, keyed per client IP AND per hashed
+      // email (two `limit()` calls, same namespace, different keys). Unlike
+      // the free-tier buckets above, this one is load-bearing: the endpoint
+      // checks a password on a public unauthenticated URL, so `handlers.ts`
+      // FAILS CLOSED and serves Google-only when the binding is absent.
+      // Declared in the top-level block too, so `wrangler dev` is not
+      // silently reduced to Google-only. 8/60s is per-key, and per the
+      // "Measured behaviour" note above the binding counts PER COLO — this
+      // dampens credential stuffing, Stytch's own lockout is the real bound.
+      "name": "LOGIN_RATE_LIMITER",
+      "namespace_id": "1020",
+      "simple": { "limit": 8, "period": 60 }
     }
   ],
   "env": {
@@ -123,6 +137,20 @@
           "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
           "namespace_id": "1011",
           "simple": { "limit": 120, "period": 60 }
+        },
+        {
+          // Throttles `POST /login/password`, keyed per client IP AND per hashed
+      // email (two `limit()` calls, same namespace, different keys). Unlike
+      // the free-tier buckets above, this one is load-bearing: the endpoint
+      // checks a password on a public unauthenticated URL, so `handlers.ts`
+      // FAILS CLOSED and serves Google-only when the binding is absent.
+      // Declared in the top-level block too, so `wrangler dev` is not
+      // silently reduced to Google-only. 8/60s is per-key, and per the
+      // "Measured behaviour" note above the binding counts PER COLO — this
+      // dampens credential stuffing, Stytch's own lockout is the real bound.
+      "name": "LOGIN_RATE_LIMITER",
+          "namespace_id": "1021",
+          "simple": { "limit": 8, "period": 60 }
         }
       ],
       // `custom_domain: true` provisions a Cloudflare Custom Domain (TLS
@@ -168,6 +196,20 @@
           "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
           "namespace_id": "1012",
           "simple": { "limit": 120, "period": 60 }
+        },
+        {
+          // Throttles `POST /login/password`, keyed per client IP AND per hashed
+      // email (two `limit()` calls, same namespace, different keys). Unlike
+      // the free-tier buckets above, this one is load-bearing: the endpoint
+      // checks a password on a public unauthenticated URL, so `handlers.ts`
+      // FAILS CLOSED and serves Google-only when the binding is absent.
+      // Declared in the top-level block too, so `wrangler dev` is not
+      // silently reduced to Google-only. 8/60s is per-key, and per the
+      // "Measured behaviour" note above the binding counts PER COLO — this
+      // dampens credential stuffing, Stytch's own lockout is the real bound.
+      "name": "LOGIN_RATE_LIMITER",
+          "namespace_id": "1022",
+          "simple": { "limit": 8, "period": 60 }
         }
       ],
       "routes": [


### PR DESCRIPTION
Two independent bugs, both reported from a real staging session.

## 1. Staging OAuth connect returns "Your Tako sign-in expired"

The sign-in was never the problem. `mintTakoApiKey` hardcoded the session-cookie
name:

```ts
cookie: `stytch_session_jwt=${stytchSessionJwt}`
```

On the `.staging.tako.com` zone Django reads `stytch_session_jwt_staging` — the
names are namespaced there because the browser also delivers prod's
`Domain=.tako.com` cookie (under the *default* name) to `staging.tako.com`,
where it would shadow the staging session (TakoData/tako#26763). Django resolves
the name per request host and reads **only** that name, so our cookie was
invisible: no credentials → 403 → `IdentityError("unauthorized")` → the
expired-sign-in page.

| host | cookie name Django reads |
|---|---|
| `staging.tako.com`, `*.staging.tako.com` | `stytch_session_jwt_staging` |
| everything else | `stytch_session_jwt` |

**Timeline:** the mint path landed 2026-06-21 (`f73068d`); the staging
namespacing landed 2026-06-23 (tako `93e4a1d976`, confirmed on `origin/staging`).
Staging connect has been broken ~6 weeks. **Production was never affected** — its
host uses the default name, which is what we sent.

Ruled out as a cause: both `mcp.staging.tako.com` and staging Django serve the
same Stytch **test** project (`public-token-test-7ed0ae82…`), verified live.

`sessionCookieName` now derives the name from `DJANGO_BASE_URL`'s host, mirroring
tako's `app/backend/auth/stytch/cookie_name_contract.json`. Both the Django
backend and the frontend SDK have tests against that contract, but this Worker is
a separate repo with no shared CI — so the mirror is labelled as one, and the
table test walks all seven hosts from the contract's `cases`.

The `unauthorized` branch also now logs. A genuinely expired session and a
Worker↔Django misconfiguration are indistinguishable from the outside, and that
branch logged nothing — which is how six weeks of broken staging connect left no
trace in `wrangler tail`.

## 2. Claude's cards ignored Claude's theme

`hostTheme()` read `window.openai.theme` and nothing else. That is null off
ChatGPT, so on claude.ai both chart urls kept `dark_mode=auto`, which the embed
page resolves from `prefers-color-scheme` inside the widget iframe — from the
**OS**, not the host. A light Claude on a dark Mac renders a dark card on a light
surface.

The comment shipped in #203 called this unfixable: *"the `ui/initialize` response
carries none, and the spec defines none."* That's wrong. MCP Apps 2026-01-26 puts
`hostContext.theme` on the `ui/initialize` **response** and defines
`ui/notifications/host-context-changed` for updates. Both are read now, and
`hostContext` is merged rather than replaced, per the spec's *"Views merge
received fields with their current context state."*

Reading it asynchronously is safe because of handshake ordering: a host MUST NOT
send notifications before our `initialized`, which we only send once the
`ui/initialize` response lands — so the theme is known before any `tool-result`.
Hosts that never answer still fall through to `auto`. `window.openai.theme` keeps
priority where both exist.

### Scope, stated plainly

This themes the two URL-borne charts — the native card and the committed iframe.
It does **not**:

- re-theme a chart already on screen (the native upgrade `document.open()`s the
  page, discarding these listeners), so a mid-conversation toggle applies from the
  next tool call onward;
- theme the baked PNG, which is a single pre-rendered `data:` URI with no light
  twin.

So **production is unaffected**: `PUBLIC_CDN_URL` is staging-only, the PNG is the
chart there, and it stays `dark_mode=true` until the native card is promoted to
prod. Fixing that needs either the promotion or a second baked PNG; neither
belongs in this PR.

## Testing

- `npx vitest run` — 880 passed
- `npx vitest run -c vitest.widget.config.ts` — 63 passed
- `npx vitest run -c vitest.scripts.config.ts` — 46 passed
- `tsc --noEmit` on `src`, `tsconfig.test.json`, `test/widget` — clean.
  `scripts/tsconfig.json` fails on a missing `@anthropic-ai/sdk` in my local
  `node_modules`; the dep is declared in `package.json` and the failure is
  pre-existing and unrelated.

Both fixes were written test-first; each new test was confirmed RED against the
old behaviour before the fix landed.

### Not verified by me

The staging connect fix needs a staging deploy and one real connect attempt —
I have no Cloudflare token in this environment, so nothing here was exercised
against a deployed Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)