### PR TITLE
fix(widget): production never had the switch the theme fix needs

### DIFF
--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -1,17 +1,31 @@
 name: workers-smoke
 
 # Triggers (TAKO-2611):
-#   - `workflow_run`: fire automatically after a successful `workers-deploy`
-#     run that was triggered by a `push` to `main` (which always deploys
-#     staging). We DO NOT auto-smoke after `workflow_dispatch` deploys —
-#     those can target production and we don't have a prod-aware smoke yet,
-#     so silently smoking staging while prod was deployed would produce a
-#     misleading green badge. Manually dispatch this workflow to smoke any
-#     post-promotion prod deploy.
+#   - `workflow_run`: fire automatically after a successful `workers-deploy`,
+#     smoking the env that run actually deployed. The target is derived from the
+#     UPSTREAM EVENT using the same mapping `workers-deploy.yml` uses to pick it:
+#     `push` to main -> staging, `release: published` -> production. Because both
+#     sides read the same signal, the badge cannot claim to have smoked an env
+#     the deploy did not touch.
 #   - `workflow_dispatch`: manual trigger to smoke any base URL.
 #
+# We still DO NOT auto-smoke after a `workflow_dispatch` deploy: that one takes
+# its env from an input this event does not carry, so the target would have to be
+# guessed — and guessing is exactly what produces a misleading green badge.
+# Dispatch this workflow with `base_url` after a manual deploy.
+#
+# Production was previously never smoked at all: prod deploys fire from
+# `release: published`, and this workflow admitted only `push`, so a
+# release-triggered deploy matched no branch here and ran nothing. Every prod
+# verification depended on someone remembering to dispatch by hand.
+#
+# NOTE: the smoke calls `tako_visualize`, which charges one credit and creates a
+# card in the target env. That is now a per-release cost on production, and it is
+# the point — a check that cannot create a card cannot prove the render path.
+#
 # `workflow_run` only fires for upstream runs that completed (any conclusion);
-# the `if:` on the job below filters to successful + push-triggered upstreams.
+# the `if:` on the job below filters to successful push- or release-triggered
+# upstreams.
 on:
   workflow_run:
     workflows: [workers-deploy]
@@ -27,16 +41,21 @@ on:
         # changes, update both the env var AND this default in lockstep.
         default: 'https://mcp.staging.tako.com'
 
-# Single source of truth for the staging URL. Referenced from the smoke step
-# below; the `workflow_dispatch` input default has to repeat the value (see
-# note on the input above).
+# Single source of truth for the two deployed URLs. Referenced from the smoke
+# step below; the `workflow_dispatch` input default has to repeat the staging
+# value (see note on the input above).
 env:
   STAGING_BASE_URL: 'https://mcp.staging.tako.com'
+  PRODUCTION_BASE_URL: 'https://mcp.tako.com'
 
-# Latest staging deploy is what we want to validate; cancel an in-flight
-# smoke if a newer deploy lands while it's running.
+# Latest deploy of a given env is what we want to validate; cancel an in-flight
+# smoke if a newer deploy to the SAME env lands while it's running. Keyed by the
+# resolved env rather than by base_url alone, so a release-triggered prod smoke
+# does not cancel a staging one that is still running.
 concurrency:
-  group: workers-smoke-${{ github.event.inputs.base_url || 'staging' }}
+  group: >-
+    workers-smoke-${{ github.event.inputs.base_url ||
+    (github.event.workflow_run.event == 'release' && 'production' || 'staging') }}
   cancel-in-progress: true
 
 permissions:
@@ -49,15 +68,18 @@ jobs:
     timeout-minutes: 5
     # Run when:
     #   - manually dispatched (any base URL the user picked), OR
-    #   - the upstream `workers-deploy` succeeded AND was triggered by a
-    #     `push` (which always deploys staging — see workers-deploy.yml). We
-    #     skip `workflow_dispatch`-triggered upstream runs because those may
-    #     have targeted production, and our smoke target is hardcoded to
-    #     staging here.
+    #   - the upstream `workers-deploy` succeeded AND was triggered by a `push`
+    #     (staging) or a published `release` (production) — the two events whose
+    #     target env `workers-deploy.yml` derives from the event itself, so this
+    #     workflow can derive the same one without guessing.
+    #
+    # Upstream `workflow_dispatch` runs are still skipped: their env comes from
+    # an input this event does not expose.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'release'))
     defaults:
       run:
         working-directory: workers
@@ -77,17 +99,27 @@ jobs:
 
       # Smoke target precedence:
       #   1. `workflow_dispatch` input (if set) — lets ops smoke any URL
-      #   2. `STAGING_BASE_URL` env (workflow-level constant)
+      #   2. upstream `release` -> production (mirrors workers-deploy.yml)
+      #   3. otherwise (upstream `push`) -> staging
+      #
+      # Step 2 is what makes production verifiable at all. `workers-deploy.yml`
+      # picks production with the same `event_name == 'release'` test, so the two
+      # workflows cannot disagree about which env was touched.
       #
       # The smoke script (`scripts/smoke.ts`) requires `SMOKE_BASE_URL` to be
       # set explicitly — there is no in-script default — so any source URL
-      # change happens in this YAML, not in TypeScript.
+      # change happens in this YAML, not in TypeScript. It also FAILS rather
+      # than warns when a deployed target is missing the native-card routes, so
+      # a prod deploy that silently lost `PUBLIC_CDN_URL` now reddens here.
       #
       # `TAKO_SMOKE_API_TOKEN` is a GitHub Actions secret, automatically
       # masked in logs; the smoke script also never prints it.
       - name: Smoke
         env:
-          SMOKE_BASE_URL: ${{ inputs.base_url || env.STAGING_BASE_URL }}
+          SMOKE_BASE_URL: >-
+            ${{ inputs.base_url ||
+            (github.event.workflow_run.event == 'release' &&
+             env.PRODUCTION_BASE_URL || env.STAGING_BASE_URL) }}
           TAKO_SMOKE_API_TOKEN: ${{ secrets.TAKO_SMOKE_API_TOKEN }}
         run: npm run smoke
 
@@ -102,9 +134,14 @@ jobs:
       # without anything being broken in this repo. The step surfaces the
       # failure in the run summary without blocking a deploy that smoke already
       # passed — tighten this once the case set has proven stable.
+      # Same target resolution as the Smoke step above — kept in lockstep so the
+      # two steps in one job can never be pointed at different environments.
       - name: Golden queries
         continue-on-error: true
         env:
-          GOLDEN_BASE_URL: ${{ inputs.base_url || env.STAGING_BASE_URL }}
+          GOLDEN_BASE_URL: >-
+            ${{ inputs.base_url ||
+            (github.event.workflow_run.event == 'release' &&
+             env.PRODUCTION_BASE_URL || env.STAGING_BASE_URL) }}
           TAKO_GOLDEN_API_TOKEN: ${{ secrets.TAKO_SMOKE_API_TOKEN }}
         run: npm run golden

--- a/workers/README.md
+++ b/workers/README.md
@@ -28,6 +28,7 @@ requests 401 exactly as before):
 | `FREE_TIER_API_KEY` | secret | Tako API key of the dedicated free-tier account, forwarded to Django as `X-API-Key` (trimmed, so a piped `wrangler secret put` newline can't break it) |
 | `FREE_TIER_RATE_LIMITER` | `ratelimits` entry in `wrangler.jsonc` | per-IP fairness bucket: 10 free-tool `tools/call`s / 60 s |
 | `FREE_TIER_GLOBAL_RATE_LIMITER` | `ratelimits` entry in `wrangler.jsonc` | per-colo burst shaping: 120 anonymous requests / 60 s / colo, all callers |
+| `NATIVE_CARD_RATE_LIMITER` | `ratelimits` entry in `wrangler.jsonc` | per-IP bucket for the two native-card proxy routes: 200 / 60 s. Separate from the free-tier bucket because one card render is ~10 browser subresource fetches — sharing it made the render 429 its own assets |
 
 Declare every limiter under the first-class `ratelimits` key. **Never under
 `unsafe.bindings`** — that path is a raw passthrough: the API accepts it,

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -390,20 +390,25 @@ try {
   // Reuses the card `tako_visualize` just created, so there is no hardcoded
   // pub_id fixture to rot.
   //
-  // 404 is NOT a failure, and that distinction is the point. The route is
-  // gated on `PUBLIC_CDN_URL`, so a 404 can mean the native-card path is
-  // switched off in this environment — a legitimate configuration (local dev,
-  // or a deliberate rollback), not a regression. Failing on it would make the
-  // smoke cry wolf about a choice. What DOES fail is 200-but-broken: the route
-  // is live and answering, yet the rewrite it exists to perform did not happen.
+  // A 404 FAILS on a deployed env, and only warns off one.
   //
+  // It was a warning everywhere in the first draft, which got this exactly
+  // backwards: a 404 on `mcp.tako.com` is precisely the outcome that means the
+  // binding never took effect — the whole subject of this check — and warnings
+  // exit 0, so it would have been reported by a green job whose log nobody
+  // opens. Both deployed envs now set `PUBLIC_CDN_URL`, so there is no
+  // legitimate 404 there to cry wolf about. Off a deployed env (a local
+  // `wrangler dev` with no binding) it stays a warning, because there the
+  // absence is the expected configuration rather than a regression.
+  const isDeployedTarget = /^https:\/\/mcp(\.staging)?\.tako\.com$/.test(baseUrl);
   // The two 404s are told apart by body, because conflating them would report
   // "feature off" for a live route: a declined route falls through to the
   // router's generic `not found`, while a live route whose pub_id did not
   // resolve upstream answers `chart not found` (`embed_proxy.ts`, the
-  // `response.status === 404` branch). Both stay warnings — the second is most
-  // likely lag between creating the card and its embed page existing, which is
-  // not something to redden a deploy over.
+  // `response.status === 404` branch). The latter stays a warning even on a
+  // deployed env — it means the route IS serving, and the likeliest cause is lag
+  // between creating a card and its embed page existing, which is not something
+  // to redden a deploy over.
   const nativeRes = await fetch(
     `${baseUrl}/embed-html/${encodeURIComponent(tvStructured.card_id)}`,
   );
@@ -416,11 +421,23 @@ try {
           `between creating it and its embed page existing).`,
       );
     } else {
-      console.warn(
-        `[warn] /embed-html/ → 404 "${nativeBody.trim()}": the native-card ` +
-          `path is OFF here (PUBLIC_CDN_URL unset). Charts on claude.ai ` +
-          `render as a static dark PNG, not an interactive host-themed card.`,
-      );
+      // Deliberately does NOT name a cause. An ABSENT `PUBLIC_CDN_URL` and a
+      // MALFORMED one produce byte-identical responses: `resolveProxyOrigins`
+      // catches the throw from any resolver and declines, so the router answers
+      // the same generic body either way. Since promoting this feature is
+      // exactly "type a new URL into the production block", "set but broken" —
+      // a single trailing slash will do it — is the likelier of the two, and
+      // reporting it as a deliberate configuration choice would send the reader
+      // the wrong way. The worker logs the real cause; the smoke cannot read
+      // worker logs, so it points there instead of guessing.
+      const why =
+        `/embed-html/ → 404 "${nativeBody.trim()}": the native-card path is ` +
+        `not serving here. PUBLIC_CDN_URL is either unset or malformed (both ` +
+        `decline identically) — grep the worker log for "native-card proxy ` +
+        `disabled" to tell which. Charts on claude.ai render as a static dark ` +
+        `PNG, not an interactive host-themed card.`;
+      if (isDeployedTarget) fail(why);
+      console.warn(`[warn] ${why}`);
     }
   } else {
     assert(
@@ -438,14 +455,24 @@ try {
     // The rewrite is what makes the card renderable: Card.js is a
     // `type="module"` script, always a CORS fetch, and the CDN reflects CORS
     // for tako.com alone — so every asset url must be pointed back at
-    // `/cdn-asset/`. Zero occurrences means the distribution in
+    // `/cdn-asset/` on THIS origin. Zero occurrences means the distribution in
     // `PUBLIC_CDN_URL` does not match the one this page references.
+    //
+    // Origin-qualified, not a bare `/cdn-asset/` substring. `rewriteCdnUrls`
+    // writes `${widgetOrigin}${CDN_ASSET_PREFIX}` and `widgetOrigin` prefers the
+    // `PUBLIC_MCP_URL` binding over the request origin — so a prod deploy
+    // carrying a staging value would emit `https://mcp.staging.tako.com/cdn-asset/…`,
+    // satisfy a bare substring check, and serve every asset in the widget from
+    // the wrong worker. That is the same copy-paste class as the bug this PR
+    // fixes, so the check names the origin it expects.
+    const expectedPrefix = `${baseUrl}/cdn-asset/`;
     assert(
-      nativeBody.includes("/cdn-asset/"),
-      `/embed-html/ returned 200 but rewrote no CDN urls — PUBLIC_CDN_URL ` +
-        `does not match the distribution this env's embed page references ` +
-        `(prod: d12w4pyrrczi5e, staging: d1iyjvzoctsna). The card will mount ` +
-        `and no chart will draw. See the worker log for the 0-rewrite warning.`,
+      nativeBody.includes(expectedPrefix),
+      `/embed-html/ returned 200 but rewrote no CDN urls to ${expectedPrefix} — ` +
+        `either PUBLIC_CDN_URL does not match the distribution this env's embed ` +
+        `page references (prod: d12w4pyrrczi5e, staging: d1iyjvzoctsna), or ` +
+        `PUBLIC_MCP_URL names a different worker. The card will mount and no ` +
+        `chart will draw. See the worker log for the 0-rewrite warning.`,
     );
     // Belt-and-braces, stated honestly: the handler already refuses to serve a
     // body whose `csrfToken` it failed to strip (`embed_proxy.ts`, the
@@ -458,6 +485,48 @@ try {
       `/embed-html/ leaked a csrfToken into a body bound for a third-party sandbox`,
     );
     ok(`/embed-html/ → 200 text/plain, CDN urls rewritten, no csrfToken`);
+
+    // Then actually FETCH one, because everything above is still only a claim
+    // about a string. `embed_proxy.ts` calls these two routes "one feature" —
+    // the page is useless without its assets — and until something retrieves an
+    // asset, a syntactically valid, page-matching `PUBLIC_CDN_URL` behind a
+    // distribution that does not serve `archive/` passes every check here and
+    // still draws no chart.
+    //
+    // It also converts the count-flattened-to-a-boolean weakness above into
+    // something with teeth. `ASSET_PATH_PREFIX` confinement is MEASURED, not
+    // structural, so a frontend build that moves the entry bundle out of
+    // `archive/` while leaving the fonts in would keep `rewrites > 0` and a
+    // green check. Fetching the JS specifically — Card.js is the one asset whose
+    // absence means no chart at all — is what notices.
+    const assetUrls = [
+      ...nativeBody.matchAll(
+        new RegExp(`${expectedPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[^"'\\s)]+`, "g"),
+      ),
+    ].map((m) => m[0]);
+    assert(assetUrls.length > 0, `no rewritten asset urls to fetch`);
+    // Prefer the JS entry bundle; fall back to the first asset when the naming
+    // changes, so this degrades to "fetched something" rather than to a skip.
+    const probeAsset = assetUrls.find((u) => u.endsWith(".js")) ?? assetUrls[0]!;
+    const assetRes = await fetch(probeAsset);
+    const assetPath = probeAsset.slice(baseUrl.length);
+    assert(
+      assetRes.status === 200,
+      `rewritten asset ${assetPath} → ${assetRes.status}. The page rewrote its ` +
+        `CDN urls, but this origin cannot actually serve them: PUBLIC_CDN_URL ` +
+        `names a distribution that does not serve the "archive/" tree, or the ` +
+        `asset moved out of it. The card mounts and no chart draws.`,
+    );
+    // `ACAO: *` is not cosmetic here: a module script is always a CORS fetch, so
+    // without this header the widget's Card.js load fails even though the bytes
+    // arrived. This is the exact header the proxy exists to add.
+    assert(
+      assetRes.headers.get("access-control-allow-origin") === "*",
+      `rewritten asset ${assetPath} lacks "access-control-allow-origin: *" — a ` +
+        `type="module" script is always a CORS fetch, so the widget cannot load ` +
+        `it. Adding that header is this route's entire reason to exist.`,
+    );
+    ok(`/cdn-asset/ → 200 with ACAO:* for ${assetPath.slice(0, 72)}`);
   }
 } finally {
   await client.close().catch(() => {

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -20,6 +20,13 @@
  *        d. `get_credit_balance`          — `details.credit_balance`
  *                                           must be a number or numeric string (read-only)
  *        e. `tako_visualize`              — creates a card (charges 1 credit)
+ *   6. Native-card proxy (`/embed-html/`) on the card step 5e just created —
+ *      404 soft-warns (path gated off via `PUBLIC_CDN_URL`), 200 hard-asserts
+ *      inert content type, a nonzero CDN rewrite, and no leaked `csrfToken`
+ *
+ * The step-6 rewrite assertion is the one check here that exists to catch a
+ * failure with NO error signal: a `PUBLIC_CDN_URL` naming the wrong CloudFront
+ * distribution answers 200, mounts the card, and draws no chart.
  *
  * Excluded by design:
  *   - `tako_agent` / `tako_agent_start` / `tako_agent_wait` — long-running;
@@ -367,6 +374,91 @@ try {
     `tako_visualize.embed_url is not http(s): ${JSON.stringify(tvStructured?.embed_url)}`,
   );
   ok(`tako_visualize → card_id ${tvStructured.card_id}`);
+
+  // -------------------------------------------------------------------------
+  // 6. Native-card proxy — the interactive/themed chart path on claude.ai
+  // -------------------------------------------------------------------------
+  // Why this is asserted post-deploy rather than left to unit tests: its
+  // defining failure mode is SILENCE. `PUBLIC_CDN_URL` naming the wrong
+  // CloudFront distribution rewrites zero urls, the proxy still answers 200,
+  // the card still mounts, and no chart ever draws — a break with no error
+  // anywhere. Unit tests cannot see it because the value under test is the
+  // deployed binding, and the widget's own failure log lands in a sandboxed
+  // iframe console nobody reads. So the deployed page is the only place the
+  // question can be asked.
+  //
+  // Reuses the card `tako_visualize` just created, so there is no hardcoded
+  // pub_id fixture to rot.
+  //
+  // 404 is NOT a failure, and that distinction is the point. The route is
+  // gated on `PUBLIC_CDN_URL`, so a 404 can mean the native-card path is
+  // switched off in this environment — a legitimate configuration (local dev,
+  // or a deliberate rollback), not a regression. Failing on it would make the
+  // smoke cry wolf about a choice. What DOES fail is 200-but-broken: the route
+  // is live and answering, yet the rewrite it exists to perform did not happen.
+  //
+  // The two 404s are told apart by body, because conflating them would report
+  // "feature off" for a live route: a declined route falls through to the
+  // router's generic `not found`, while a live route whose pub_id did not
+  // resolve upstream answers `chart not found` (`embed_proxy.ts`, the
+  // `response.status === 404` branch). Both stay warnings — the second is most
+  // likely lag between creating the card and its embed page existing, which is
+  // not something to redden a deploy over.
+  const nativeRes = await fetch(
+    `${baseUrl}/embed-html/${encodeURIComponent(tvStructured.card_id)}`,
+  );
+  const nativeBody = await nativeRes.text();
+  if (nativeRes.status === 404) {
+    if (nativeBody.includes("chart not found")) {
+      console.warn(
+        `[warn] /embed-html/ → 404 "chart not found": the route is LIVE, but ` +
+          `card ${tvStructured.card_id} did not resolve upstream (likely lag ` +
+          `between creating it and its embed page existing).`,
+      );
+    } else {
+      console.warn(
+        `[warn] /embed-html/ → 404 "${nativeBody.trim()}": the native-card ` +
+          `path is OFF here (PUBLIC_CDN_URL unset). Charts on claude.ai ` +
+          `render as a static dark PNG, not an interactive host-themed card.`,
+      );
+    }
+  } else {
+    assert(
+      nativeRes.status === 200,
+      `/embed-html/ expected 200 or 404, got ${nativeRes.status} (${nativeBody.trim().slice(0, 120)})`,
+    );
+    // Inert content type is a security invariant, not a nicety: this is the
+    // OAuth origin, so the proxy must never hand the browser a document it
+    // will execute. A drift to text/html here is a real regression.
+    const nativeType = nativeRes.headers.get("content-type") ?? "";
+    assert(
+      nativeType.includes("text/plain"),
+      `/embed-html/ must answer text/plain on the OAuth origin, got ${JSON.stringify(nativeType)}`,
+    );
+    // The rewrite is what makes the card renderable: Card.js is a
+    // `type="module"` script, always a CORS fetch, and the CDN reflects CORS
+    // for tako.com alone — so every asset url must be pointed back at
+    // `/cdn-asset/`. Zero occurrences means the distribution in
+    // `PUBLIC_CDN_URL` does not match the one this page references.
+    assert(
+      nativeBody.includes("/cdn-asset/"),
+      `/embed-html/ returned 200 but rewrote no CDN urls — PUBLIC_CDN_URL ` +
+        `does not match the distribution this env's embed page references ` +
+        `(prod: d12w4pyrrczi5e, staging: d1iyjvzoctsna). The card will mount ` +
+        `and no chart will draw. See the worker log for the 0-rewrite warning.`,
+    );
+    // Belt-and-braces, stated honestly: the handler already refuses to serve a
+    // body whose `csrfToken` it failed to strip (`embed_proxy.ts`, the
+    // `!removedCsrf && html.includes("csrfToken")` 502), so on a correct build
+    // this can never fire. It is here to catch a DEPLOY of a build where that
+    // gate regressed — the one thing a unit test cannot check, since it asserts
+    // against source rather than against what is actually serving traffic.
+    assert(
+      !nativeBody.includes("csrfToken"),
+      `/embed-html/ leaked a csrfToken into a body bound for a third-party sandbox`,
+    );
+    ok(`/embed-html/ → 200 text/plain, CDN urls rewritten, no csrfToken`);
+  }
 } finally {
   await client.close().catch(() => {
     // ignore close errors — we already have the answer we care about

--- a/workers/src/embed_proxy.test.ts
+++ b/workers/src/embed_proxy.test.ts
@@ -781,3 +781,212 @@ describe("the asset route reflects only inert content types", () => {
     }
   });
 });
+
+describe("the rewrite is wired into handleEmbedProxy, not just exported", () => {
+  // `rewriteCdnUrls` has direct tests above, and the JS path is covered through
+  // `handleCdnAssetProxy` — but nothing asserted that the HANDLER actually calls
+  // it on the page body. That wiring is the whole feature: an unrewritten page
+  // sends Card.js straight to the CDN, which reflects CORS for tako.com alone,
+  // so a `type="module"` load fails and no chart draws. Until this test existed
+  // the property was verified only post-deploy, by smoke step 6.
+  it("rewrites the page's CDN urls to this origin", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(UPSTREAM_HTML, {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      ),
+    );
+    const res = await handleEmbedProxy(req(`/embed-html/${PUB_ID}`), ON);
+    const body = await res!.text();
+    // Origin-qualified: `widgetOrigin` prefers `PUBLIC_MCP_URL` over the request
+    // origin, so a bare `/cdn-asset/` substring would pass while every asset
+    // pointed at a different worker.
+    expect(body).toContain("https://mcp.tako.com/cdn-asset/archive/abc/");
+    // And the CDN origin is gone from the markup the widget receives.
+    expect(body).not.toContain("d12w4pyrrczi5e.cloudfront.net");
+  });
+});
+
+describe("NATIVE_CARD_RATE_LIMITER", () => {
+  // A binding of its own rather than the free tier's, because one card render is
+  // ~10 metered subresource fetches against a bucket of 10 sized for tool calls
+  // — measured on staging as requests 1-10 served and 11-14 all 429, i.e. the
+  // feature throttling its own assets.
+  const limiter = (success: boolean) => ({ limit: vi.fn().mockResolvedValue({ success }) });
+
+  it("429s both routes when the bucket is empty", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const env = { ...ON, NATIVE_CARD_RATE_LIMITER: limiter(false) } as unknown as Env;
+
+    const page = await handleEmbedProxy(req(`/embed-html/${PUB_ID}`), env);
+    expect(page?.status).toBe(429);
+    const asset = await handleCdnAssetProxy(req(ASSET_PATH), env);
+    expect(asset?.status).toBe(429);
+    // The point of metering: the upstream work never happened.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("meters BEFORE the upstream fetch, on both routes", async () => {
+    // Ordering is the property with teeth. A refactor that moves either
+    // `rateLimited` call below its fetch leaves a meter that reports honestly
+    // and bounds nothing — the ~1.5 MB buffer-and-rewrite it exists to prevent
+    // has already run. Nothing else in this file would go red.
+    const order: string[] = [];
+    // One implementation for both phases, swapping only the body it returns.
+    // Reassigning via `mockResolvedValue` would REPLACE this implementation and
+    // stop recording `fetch` — which is how the first draft of this test
+    // "passed" the asset route and then reported `['limit']` for the page route.
+    let upstream = () =>
+      new Response("export const x=1", {
+        status: 200,
+        headers: { "content-type": "application/javascript" },
+      });
+    const fetchMock = vi.fn().mockImplementation(() => {
+      order.push("fetch");
+      return Promise.resolve(upstream());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const env = {
+      ...ON,
+      NATIVE_CARD_RATE_LIMITER: {
+        limit: vi.fn().mockImplementation(() => {
+          order.push("limit");
+          return Promise.resolve({ success: true });
+        }),
+      },
+    } as unknown as Env;
+
+    await handleCdnAssetProxy(req(ASSET_PATH), env);
+    expect(order).toEqual(["limit", "fetch"]);
+
+    order.length = 0;
+    upstream = () =>
+      new Response(UPSTREAM_HTML, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    await handleEmbedProxy(req(`/embed-html/${PUB_ID}`), env);
+    expect(order).toEqual(["limit", "fetch"]);
+  });
+
+  it("fails OPEN when the limiter throws", async () => {
+    // Unlike the login buckets, which fail closed. A limiter outage here must
+    // degrade to an unmetered chart, never a missing one.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("export const x=1", {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        }),
+      ),
+    );
+    const env = {
+      ...ON,
+      NATIVE_CARD_RATE_LIMITER: {
+        limit: vi.fn().mockRejectedValue(new Error("limiter down")),
+      },
+    } as unknown as Env;
+    const res = await handleCdnAssetProxy(req(ASSET_PATH), env);
+    expect(res?.status).toBe(200);
+  });
+
+  it("serves unmetered when the binding is absent", async () => {
+    // `ON` carries no limiter, which is the local-dev shape.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("export const x=1", {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        }),
+      ),
+    );
+    const res = await handleCdnAssetProxy(req(ASSET_PATH), ON);
+    expect(res?.status).toBe(200);
+  });
+});
+
+describe("the asset route is not a cache-busting amplifier", () => {
+  it("drops the query string instead of forwarding it upstream", async () => {
+    // Forwarded, the query landed in CloudFront's cache key for the
+    // `cacheEverything` subrequest, so `Card.js?<nonce>` missed cache on every
+    // distinct nonce: a ~200-byte request bought a ~1.48 MB origin fetch, a
+    // decode, a whole-body rewrite copy and 1.48 MB of `ACAO: *` egress.
+    // Measured on staging at 0.11 s cached vs 0.32-0.44 s per fresh nonce.
+    // Content-hashed assets under `archive/<sha>/` carry their own buster, and
+    // `rewriteCdnUrls` never emits a query, so there is nothing legitimate to
+    // forward.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("export const x=1", {
+        status: 200,
+        headers: { "content-type": "application/javascript" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleCdnAssetProxy(req(`${ASSET_PATH}?nonce=abc123`), ON);
+    expect(res?.status).toBe(200);
+    const called = String(fetchMock.mock.calls[0]?.[0]);
+    expect(called).toBe(`${ON.PUBLIC_CDN_URL}/archive/abc/vite_dist/assets/Card.js`);
+    expect(called).not.toContain("nonce");
+    expect(called).not.toContain("?");
+  });
+});
+
+describe("path confinement survives percent-encoding", () => {
+  it("400s an encoded traversal that the raw guards let through", async () => {
+    // `%2f` is not a segment delimiter, so WHATWG parsing leaves `%2e%2e%2f`
+    // intact as ONE segment: the path still starts with `archive/`, holds no
+    // literal `..`, no leading `/` and no `\`, and so passed every guard and
+    // reached the upstream fetch. Verified on staging before the fix — 502 (the
+    // fetch was issued) where the unencoded `..%2f` gives 400.
+    //
+    // It was not exploitable, because CloudFront/S3 treat the encoded dots as a
+    // literal key. That is the problem: confinement rested on S3 key literalness
+    // rather than on this code, and any normalizing hop added later (a
+    // CloudFront Function, a URI-rewrite behavior, a move off the S3 origin)
+    // would have armed it with nothing going red.
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    for (const bad of [
+      "/cdn-asset/archive/x/%2e%2e%2fuser-images/evil.html",
+      "/cdn-asset/archive/x/%2E%2E%2fcontent-style/evil.html",
+      "/cdn-asset/archive/x/%2e%2e%2F%2e%2e%2Fstatic/x.js",
+    ]) {
+      const res = await handleCdnAssetProxy(req(bad), ON);
+      expect(res?.status, bad).toBe(400);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("400s a malformed escape rather than guessing at it", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleCdnAssetProxy(req("/cdn-asset/archive/x/%zz.js"), ON);
+    expect(res?.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("still serves an encoded slash, which names a real S3 key", async () => {
+    // Not traversal — an S3 key can literally contain a slash, so decoding must
+    // not become a reason to reject one.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("body", {
+          status: 200,
+          headers: { "content-type": "application/javascript" },
+        }),
+      ),
+    );
+    const res = await handleCdnAssetProxy(
+      req("/cdn-asset/archive/abc/b%2Fc.js"),
+      ON,
+    );
+    expect(res?.status).toBe(200);
+  });
+});

--- a/workers/src/embed_proxy.test.ts
+++ b/workers/src/embed_proxy.test.ts
@@ -5,9 +5,11 @@
  *
  * Three properties carry real weight here, in this order:
  *
- *   1. INVISIBLE IN PRODUCTION. Gated on `PUBLIC_CDN_URL`; unset means the
- *      handler declines and the router 404s, so no new surface exists. A
- *      MALFORMED value declines too — these handlers run ahead of the whole
+ *   1. ABSENT WITHOUT ITS BINDING. Gated on `PUBLIC_CDN_URL`; unset means the
+ *      handler declines and the router 404s, so no new surface exists. Both
+ *      deployed envs now SET it, so in staging and production these routes are
+ *      live and the properties below are load-bearing rather than theoretical.
+ *      A MALFORMED value declines too — these handlers run ahead of the whole
  *      OAuth surface, so a throw here would 500 `/authorize` and `/token`.
  *   2. NOT AN SSRF PRIMITIVE. The pub_id is interpolated into an upstream URL,
  *      so its shape is the security boundary. Neither route follows a redirect,

--- a/workers/src/embed_proxy.ts
+++ b/workers/src/embed_proxy.ts
@@ -47,9 +47,11 @@
  *     strip stays because it is the half that does not depend on an upstream
  *     template continuing to honour a query flag.
  *
- * Gated on `PUBLIC_CDN_URL`: with the experiment off (production default) this
- * route 404s exactly like any unknown path, so the surface is unchanged. A
- * MALFORMED value gates it off too rather than throwing — see
+ * Gated on `PUBLIC_CDN_URL`, which is now set in BOTH staging and production —
+ * so on the deployed envs these routes are LIVE, and this file is the public
+ * surface it describes rather than dormant code. Unset (local dev and the test
+ * env, unless a fixture supplies it) the route 404s exactly like any unknown
+ * path. A MALFORMED value gates it off too rather than throwing — see
  * `resolveProxyOrigins`, and note these handlers run ahead of the whole OAuth
  * subsystem in `index.ts`.
  *

--- a/workers/src/embed_proxy.ts
+++ b/workers/src/embed_proxy.ts
@@ -224,22 +224,30 @@ function resolveProxyOrigins(
 }
 
 /**
- * Meter a proxy request against the free-tier per-IP limiter.
+ * Meter a proxy request against the native-card per-IP limiter.
  *
- * These two routes sit above the rate-limited surface: `FREE_TIER_RATE_LIMITER`
- * is otherwise consulted only inside `handleMcpRequest`. Left unmetered,
- * `/cdn-asset/` is an unauthenticated `ACAO: *` mirror of a CloudFront
- * distribution that buffers and string-replaces ~1.5 MB per JavaScript request,
- * and `/embed-html/` lets an anonymous caller drive `/embed/{id}/` renders on
- * Tako's own origin at whatever rate it likes.
+ * Left unmetered, `/cdn-asset/` is an unauthenticated `ACAO: *` mirror of a
+ * CloudFront distribution that buffers and string-replaces ~1.5 MB per
+ * JavaScript request, and `/embed-html/` lets an anonymous caller drive
+ * `/embed/{id}/` renders on Tako's own origin at whatever rate it likes.
  *
- * Fails OPEN, like every other use of this binding: a limiter outage must not
- * take the card down. Returns a 429 rather than a JSON-RPC result because these
- * are browser subresource fetches, not MCP traffic — nothing here has a request
- * id to answer.
+ * Metered on its OWN binding, not the free tier's. These are browser
+ * SUBRESOURCE fetches: one card render costs ~10 of them before `Card.js`'s
+ * lazily imported chunks, against a free-tier bucket of 10 per 60 s sized for
+ * `tools/call`. Sharing it meant the render throttled its own assets — measured
+ * on staging, requests 1-10 served and 11-14 all 429 — so the chart failed to
+ * draw. See `NATIVE_CARD_RATE_LIMITER` in `env.ts`.
+ *
+ * Fails OPEN: a limiter outage must degrade to an unmetered chart, never a
+ * missing one. Returns a 429 rather than a JSON-RPC result because nothing here
+ * has a request id to answer.
+ *
+ * ORDER MATTERS: every caller must await this BEFORE its upstream fetch, or the
+ * meter becomes decorative — the work it exists to bound has already happened.
+ * `embed_proxy.test.ts` pins that ordering.
  */
 async function rateLimited(request: Request, env: Env): Promise<Response | undefined> {
-  const limiter = env.FREE_TIER_RATE_LIMITER;
+  const limiter = env.NATIVE_CARD_RATE_LIMITER;
   if (limiter === undefined) return undefined;
   const key = freeTierRateLimitKey(request.headers.get("CF-Connecting-IP"));
   try {
@@ -660,20 +668,63 @@ export async function handleCdnAssetProxy(
   // outside the one tree the card actually loads from. The origin is fixed
   // above, so the rest only has to keep the PATH from climbing out of it —
   // see `ASSET_PATH_PREFIX` for why confinement is not merely belt-and-braces.
-  if (
-    assetPath === "" ||
-    !assetPath.startsWith(ASSET_PATH_PREFIX) ||
-    assetPath.includes("..") ||
-    assetPath.startsWith("/") ||
-    assetPath.includes("\\")
-  ) {
+  //
+  // Applied to the raw path AND to a percent-decoded copy, because the raw form
+  // alone did not deliver what the note above claims. `%2f` is not a segment
+  // delimiter, so WHATWG parsing leaves `%2e%2e%2f` intact as ONE segment: the
+  // path `archive/x/%2e%2e%2fuser-images/evil.html` starts with `archive/`,
+  // holds no literal `..`, no leading `/` and no `\`, and so passed every guard
+  // and reached the upstream fetch (verified on staging — 502, i.e. issued,
+  // where the unencoded `..%2f` gives 400).
+  //
+  // It was not exploitable: CloudFront/S3 treat the encoded dots as a literal
+  // key. But that means confinement rested on S3 key literalness rather than on
+  // this code, and `ASSET_PATH_PREFIX` names what is on the other side of it —
+  // a presigned-upload `.html` under `user-images/` served as a document on the
+  // OAuth origin. Any normalizing hop added later (a CloudFront Function, a
+  // URI-rewrite behavior, a move off the S3 origin) would arm it silently.
+  //
+  // Decoding rather than rejecting `%` outright, because an encoded slash is
+  // legitimate here — it names an S3 key that literally contains one, and no
+  // real asset path carries a percent-escape today (measured, 9 of 9 clean). A
+  // malformed escape cannot be reasoned about, so it is refused.
+  let decodedAssetPath: string;
+  try {
+    decodedAssetPath = decodeURIComponent(assetPath);
+  } catch {
+    return textResponse("bad asset path", 400);
+  }
+  const confined = (p: string): boolean =>
+    p !== "" &&
+    p.startsWith(ASSET_PATH_PREFIX) &&
+    !p.includes("..") &&
+    !p.startsWith("/") &&
+    !p.includes("\\");
+  if (!confined(assetPath) || !confined(decodedAssetPath)) {
     return textResponse("bad asset path", 400);
   }
 
   const limited = await rateLimited(request, env);
   if (limited !== undefined) return limited;
 
-  const upstream = `${cdnBase}/${assetPath}${url.search}`;
+  // Query string deliberately DROPPED rather than forwarded.
+  //
+  // Forwarding it made this an amplifier. The query reaches CloudFront and lands
+  // in the cache key for the `cacheEverything` subrequest below, so
+  // `Card.js?<nonce>` misses cache on every distinct nonce: a ~200-byte request
+  // buys a ~1.48 MB origin fetch, an `arrayBuffer()`, a `TextDecoder` decode, a
+  // whole-body rewrite copy, and 1.48 MB of `ACAO: *` egress. Measured on
+  // staging: 0.11 s cached vs 0.32-0.44 s per fresh nonce, so the query did
+  // reach upstream and did defeat the cache. These handlers run ahead of the
+  // whole OAuth subsystem (`index.ts`), so that pressure lands on `/authorize`,
+  // `/token` and `/register` too, and the per-IP meter above fails open and
+  // counts per colo.
+  //
+  // Safe to drop: `rewriteCdnUrls` never emits a query, and these are
+  // content-hashed assets under `archive/<sha>/` — the hash IS the cache-buster,
+  // so a query could only ever be someone else's. Measured on a real production
+  // page, 0 of 9 rewritten urls carried one.
+  const upstream = `${cdnBase}/${assetPath}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
   let response: Response;

--- a/workers/src/env.ts
+++ b/workers/src/env.ts
@@ -49,9 +49,11 @@ export interface Env {
    * e.g. `https://d12w4pyrrczi5e.cloudfront.net`. Must NOT include a
    * trailing slash.
    *
-   * EXPERIMENT SWITCH, and unset everywhere by default. Setting it turns on the
-   * NATIVE CARD path — Claude rendering Tako's own `Card.js` instead of a PNG
-   * of it — which is materially more than a declared CSP entry. Specifically:
+   * FEATURE SWITCH, set in BOTH deployed envs and unset only where no one is
+   * serving traffic (local dev, and tests that do not supply it). Setting it
+   * turns on the NATIVE CARD path — Claude rendering Tako's own `Card.js`
+   * instead of a PNG of it — which is materially more than a declared CSP
+   * entry. Specifically:
    *
    *   1. Two public HTTP routes come into existence, `/embed-html/{pub_id}` and
    *      `/cdn-asset/{path}` (`embed_proxy.ts`). Unset, both decline and the
@@ -79,7 +81,12 @@ export interface Env {
    * `embed_proxy.ts`, and note those handlers run ahead of the whole OAuth
    * surface.
    *
-   * Leave unset in production. Set it on staging to run the experiment.
+   * Set in staging AND production. It shipped staging-only, and that gap was
+   * itself the bug: prod ran the native-card code with the switch off, served
+   * the baked PNG, and — because that PNG is rendered server-side at
+   * `dark_mode=true` before any host theme is knowable, and a raster cannot be
+   * re-themed — gave a light-themed Claude a dark, unhoverable chart. Leaving
+   * it unset in an env that serves users is a regression, not a safe default.
    */
   PUBLIC_CDN_URL?: string;
   /**
@@ -230,6 +237,33 @@ export interface Env {
    * be present for the free tier to activate.
    */
   FREE_TIER_GLOBAL_RATE_LIMITER?: RateLimit;
+  /**
+   * Cloudflare rate-limit binding metering the two native-card proxy routes
+   * (`/embed-html/`, `/cdn-asset/`) per CLIENT IP.
+   *
+   * A SEPARATE binding from `FREE_TIER_RATE_LIMITER`, and the separation is a
+   * bug fix rather than tidiness. Both routes originally shared that binding —
+   * same key function, same namespace — which put browser SUBRESOURCE fetches
+   * in the same 10-per-60 s bucket as MCP `tools/call`. The two have unit costs
+   * that differ by an order of magnitude: one card render issues ~10 metered
+   * requests before `Card.js`'s lazily imported chunks (9 rewritten asset URLs
+   * on a measured production page, plus `/embed-html/` itself). Measured on
+   * staging against the shared bucket: requests 1-10 served, 11-14 all 429. So
+   * the feature throttled its OWN assets, and the chart failed to draw — the
+   * precise symptom the native-card path exists to fix.
+   *
+   * Sized for asset fan-out (200 / 60 s / colo ≈ 12-20 renders per minute per
+   * IP) rather than for tool calls. Note the per-colo caveat that applies to
+   * every binding here: the enforced number is `limit × colos reached`, so this
+   * shapes bursts and makes abuse visible in `wrangler tail` — it is not a hard
+   * ceiling.
+   *
+   * Fails OPEN, like the free-tier buckets and unlike the login ones: a limiter
+   * outage must degrade to an unmetered chart, never to a missing one. Absent
+   * entirely, the routes serve unmetered — which is why it is declared in the
+   * top-level block as well as both env blocks.
+   */
+  NATIVE_CARD_RATE_LIMITER?: RateLimit;
   /**
    * Cloudflare rate-limit binding throttling `POST /login/password` per CLIENT
    * IP — the sender's own axis, charged for every attempt including ones with

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -58,10 +58,13 @@ describe("worker routing", () => {
   // catch-all 404. `index.ts` now awaits both on every request that gets past
   // the icon route, so the wiring is worth one assertion of its own.
   //
-  // The test environment has no `PUBLIC_CDN_URL` (it was added only under the
-  // `staging` env block in `wrangler.jsonc`), which makes this the production
-  // configuration — and "invisible in production" is property #1 of the whole
-  // feature.
+  // The test environment has no `PUBLIC_CDN_URL`, so this pins the BINDING-ABSENT
+  // configuration: local dev, and any env where the switch has been pulled. It is
+  // no longer the production configuration — both deployed envs set the binding
+  // (`wrangler.jsonc`) — so what this asserts is that the routes are gated on
+  // that binding and vanish cleanly without it, not that they are invisible in
+  // prod. The live-route properties are covered in `embed_proxy.test.ts` and
+  // post-deploy by smoke step 6.
   describe("the native-card proxy routes do not exist without PUBLIC_CDN_URL", () => {
     it("404s /embed-html/{pub_id}", async () => {
       const res = await SELF.fetch(

--- a/workers/src/index.ts
+++ b/workers/src/index.ts
@@ -50,8 +50,10 @@ export default {
     // CORS-readable proxy for Tako's chart embed page, so the MCP Apps widget
     // can render the REAL interactive card rather than a PNG of it. Returns
     // `undefined` — falling through to the 404 below — when the
-    // `PUBLIC_CDN_URL` experiment is off or the pub_id is malformed, so this
-    // route does not exist at all in production. See `embed_proxy.ts`.
+    // `PUBLIC_CDN_URL` binding is absent or the pub_id is malformed. Both
+    // deployed envs set that binding, so this route is LIVE in staging and
+    // production; it ceases to exist only where the binding does. See
+    // `embed_proxy.ts`.
     const embedProxied = await handleEmbedProxy(request, env);
     if (embedProxied !== undefined) return embedProxied;
 

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -256,7 +256,9 @@ export async function buildChartExtraMeta(
   },
 ): Promise<Record<string, unknown> | undefined> {
   // Native-card field rides along on whatever else this returns. Empty unless
-  // `PUBLIC_CDN_URL` is set, so production is byte-identical.
+  // `PUBLIC_CDN_URL` is set — which both deployed envs now do, so this field is
+  // present in staging and production alike, and absent only where the binding
+  // is (local dev, and tests that don't supply it).
   const probe: Record<string, unknown> = {};
   const native =
     opts.env !== undefined
@@ -916,8 +918,11 @@ const WIDGET_HTML = `<!doctype html>
   // when the host is silent, so \`auto\` survives rather than being guessed at.
   //
   // The \`!url\` bail is load-bearing, not defensive noise. \`nativeCardUrl\` is
-  // \`""\` whenever \`_meta.native_card_url\` is absent — the production default —
-  // and \`""\` IS a string, so without this it fell past the \`typeof\` check into
+  // \`""\` whenever \`_meta.native_card_url\` is absent. No longer the deployed
+  // default, but still reachable three ways: an env without \`PUBLIC_CDN_URL\`, a
+  // resolve that fails, and any cached tool result from before the field
+  // existed. And \`""\` IS a string, so without this it fell past the
+  // \`typeof\` check into
   // the append branch and returned \`"?dark_mode=true"\`. That cleared
   // \`upgradeToNativeCard\`'s own \`nativeUrl === ""\` guard (it sees the
   // transformed value, not the original) and reached

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -989,8 +989,10 @@ describe("native card upgrade (executed)", () => {
   });
 
   it("never fetches a relative url when the server armed no native card", () => {
-    // `nativeCardUrl` is `""` whenever `_meta.native_card_url` is absent — the
-    // production default — and `""` IS a string, so it slipped past
+    // `nativeCardUrl` is `""` whenever `_meta.native_card_url` is absent — no
+    // longer the deployed default, but still an env without `PUBLIC_CDN_URL`, a
+    // failed resolve, or a cached result from before the field existed — and
+    // `""` IS a string, so it slipped past
     // `withHostTheme`'s `typeof` bail, took the append branch, and came back
     // `"?dark_mode=true"`. That cleared `upgradeToNativeCard`'s own
     // `nativeUrl === ""` guard, which sees the TRANSFORMED value, and reached

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -38,7 +38,7 @@
   // view`, and `limit()` resolves without throwing — but it never counts,
   // so every call comes back `{success: true}`. No unit test can catch
   // that (the suite injects fake limiters), so the only proof is a live
-  // burst against a deployed Worker. Two buckets:
+  // burst against a deployed Worker. Buckets:
   //  - FREE_TIER_RATE_LIMITER: per-IP fairness bucket (10 free-tool
   //    tools/call per 60 s). Do NOT put this number in any user-facing
   //    message — a drift test in `src/freetier.test.ts` fails if a
@@ -53,7 +53,14 @@
   //    "Measured behaviour" section in README.md: this bucket is hit
   //    before the metering decision, so it also gates `initialize` and
   //    `tools/list`, and lowering it rejects legitimate handshakes.
-  // NB: the bindings alone do NOT enable the free tier; the
+  //  - NATIVE_CARD_RATE_LIMITER: per-IP bucket for the two native-card
+  //    proxy routes (200 / 60 s). Its own binding rather than the
+  //    free-tier one because these are browser SUBRESOURCE fetches: one
+  //    card render costs ~10 of them, so the 10-per-60 s bucket sized for
+  //    tools/call made the render 429 its own assets and the chart never
+  //    drew. Measured on staging against the shared bucket: requests 1-10
+  //    served, 11-14 all 429.
+  // NB: the free-tier bindings alone do NOT enable the free tier; the
   // FREE_TIER_API_KEY secret must also be set (fail-closed).
   "ratelimits": [
     {
@@ -65,6 +72,19 @@
       "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
       "namespace_id": "1010",
       "simple": { "limit": 120, "period": 60 }
+    },
+    {
+      // Meters the two native-card proxy routes per client IP. SEPARATE from
+      // the free-tier bucket above because browser subresource fetches and MCP
+      // `tools/call` have unit costs an order of magnitude apart: one card
+      // render is ~10 metered asset requests before Card.js's lazy chunks,
+      // against a free-tier limit of 10. Sharing it made the render throttle
+      // its own assets (measured on staging: 1-10 served, 11-14 all 429) so the
+      // chart never drew. Sized for asset fan-out instead — ~12-20 renders per
+      // minute per IP. Fails open; see `env.ts`.
+      "name": "NATIVE_CARD_RATE_LIMITER",
+      "namespace_id": "1040",
+      "simple": { "limit": 200, "period": 60 }
     },
     {
       // Throttles `POST /login/password` per CLIENT IP — the sender's own axis,
@@ -143,6 +163,13 @@
           "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
           "namespace_id": "1011",
           "simple": { "limit": 120, "period": 60 }
+        },
+        {
+          // Native-card proxy bucket — sized for asset fan-out, not tool calls.
+          // See the top-level declaration for why it is not the free-tier one.
+          "name": "NATIVE_CARD_RATE_LIMITER",
+          "namespace_id": "1041",
+          "simple": { "limit": 200, "period": 60 }
         },
         {
           // Per-IP login bucket — fail-closed, see the top-level declaration.
@@ -226,6 +253,13 @@
           "name": "FREE_TIER_GLOBAL_RATE_LIMITER",
           "namespace_id": "1012",
           "simple": { "limit": 120, "period": 60 }
+        },
+        {
+          // Native-card proxy bucket — sized for asset fan-out, not tool calls.
+          // See the top-level declaration for why it is not the free-tier one.
+          "name": "NATIVE_CARD_RATE_LIMITER",
+          "namespace_id": "1042",
+          "simple": { "limit": 200, "period": 60 }
         },
         {
           // Per-IP login bucket — fail-closed, see the top-level declaration.

--- a/workers/wrangler.jsonc
+++ b/workers/wrangler.jsonc
@@ -99,10 +99,10 @@
       "vars": {
         "DJANGO_BASE_URL": "https://staging.tako.com",
         "PUBLIC_BASE_URL": "https://staging.tako.com",
-        // STAGING ONLY — arms the NATIVE CARD experiment: Claude rendering
-        // Tako's own `Card.js` instead of a PNG of it. Origin of the CDN
-        // serving Tako's front-end assets (the real chart renderer, its lazily
-        // imported chunks, and the Geist/Inter fonts).
+        // Arms the NATIVE CARD path: Claude rendering Tako's own `Card.js`
+        // instead of a PNG of it. Origin of the CDN serving Tako's front-end
+        // assets (the real chart renderer, its lazily imported chunks, and the
+        // Geist/Inter fonts). Set in BOTH envs — see the production block.
         //
         // Setting it is not a one-line CSP tweak. It brings TWO PUBLIC HTTP
         // ROUTES into existence — `/embed-html/{pub_id}` and `/cdn-asset/{path}`
@@ -114,12 +114,6 @@
         // `resourceDomains`, never the CDN, because the assets are served
         // through `/cdn-asset/` (the CDN answers CORS for tako.com alone, and a
         // module script is always a CORS fetch). See `src/env.ts`.
-        //
-        // Deliberately ABSENT from the production block. Before copying it
-        // there: both routes are unauthenticated and were metered through the
-        // free-tier per-IP limiter for this reason, `/embed-html/` is confined
-        // to inert content types and `/cdn-asset/` to the `archive/` prefix.
-        // Re-read `embed_proxy.ts`'s header before promoting.
         //
         // Staging's asset distribution — NOT production's
         // (`d12w4pyrrczi5e`, see `src/icons.ts`). The embed page references the
@@ -183,6 +177,31 @@
       "vars": {
         "DJANGO_BASE_URL": "https://tako.com",
         "PUBLIC_BASE_URL": "https://tako.com",
+        // PRODUCTION's asset distribution — NOT staging's (`d1iyjvzoctsna`).
+        // Verified against the live prod embed page, which references this host
+        // 16 times; pointing at the wrong distribution fails SILENTLY (zero URLs
+        // rewritten, card mounts, no chart draws), so this value is not
+        // interchangeable with staging's.
+        //
+        // Why it is set here at all, having shipped staging-only first: without
+        // it, prod serves the baked PNG and nothing else. That PNG is rendered
+        // server-side at `dark_mode=true` (`DEFAULT_DARK_MODE`) before the host
+        // theme is knowable, and a raster cannot be re-themed in the widget — so
+        // a light-themed Claude got a dark, unhoverable image of a chart
+        // (TAKO-3781's user-visible half). `withHostTheme` only ever rewrites the
+        // native-card and iframe urls, so the theme fix has nothing to act on
+        // until this var exists. Interactivity and correct theming are the same
+        // switch.
+        //
+        // What it exposes, reviewed before promoting: `/embed-html/{pub_id}` and
+        // `/cdn-asset/{path}` become public and unauthenticated on the OAuth
+        // origin. Mitigations already in `embed_proxy.ts` — both metered through
+        // the free-tier per-IP limiter, `/embed-html/` answers `text/plain` under
+        // `Content-Security-Policy: sandbox`, `/cdn-asset/` is confined to the
+        // `archive/` prefix and reflects only inert content types, and the
+        // proxied page has its `csrfToken` and GA bootstrap stripped. Neither
+        // route serves a document the browser will execute.
+        "PUBLIC_CDN_URL": "https://d12w4pyrrczi5e.cloudfront.net",
         // OpenAI connector-directory domain-verification token issued
         // for `mcp.tako.com`. Served as plain text from
         // `/.well-known/openai-apps-challenge`. If OpenAI rotates the


### PR DESCRIPTION
## The report

On prod, the chart in a `tako_answer` result renders as the real Tako card but is **not interactive** (no hover), and is **dark even when Claude is light-themed**. Both were believed fixed and tested in #208.

## Why the fix appeared not to work

It did work — on staging, which is where it was tested. #208 gated the whole native-card path behind `PUBLIC_CDN_URL`, and that var was set in the **staging block only**, with a comment saying it was deliberately absent from production.

So prod ran the new code with the feature switched off. Confirmed rather than assumed:

- `5b71fa9` (#208) is an ancestor of `origin/main`, `workers-deploy` on main succeeded, and `_chart_widget.ts` on `origin/main` is byte-identical to the branch. The code is live.
- `/cdn-asset/archive/x.js` → **502 on staging** (route exists, bogus path) vs **404 on prod** (route absent). That route only exists when `PUBLIC_CDN_URL` is set.

## One binding, both symptoms

`resolvePublicCdnBase` → undefined ⇒ `nativeCardUrl` → undefined ⇒ `_meta.native_card_url` never emitted ⇒ `upgradeToNativeCard` never runs. Prod stays on the baked PNG, and a PNG is:

1. **Not interactive** — a raster inside a click-through anchor. Exactly the "it's the real card but I can't hover it" report.
2. **Permanently dark** — `image_url` is built server-side at `dark_mode=DEFAULT_DARK_MODE` (`true`) before the host theme is knowable, and a raster can't be re-themed client-side. `withHostTheme` only rewrites the native-card and iframe urls (`_chart_widget.ts:1401`, `:1435`, `:1540`), so on prod the theme fix had nothing to act on.

Interactivity and theming were never two bugs. They were one switch, and it was off.

## The change

`PUBLIC_CDN_URL: "https://d12w4pyrrczi5e.cloudfront.net"` in the production block, plus corrections to four comments that now assert something false ("production is byte-identical", "INVISIBLE IN PRODUCTION", "the experiment off (production default)", "the production default").

**Distribution verified, because a mismatch fails silently** (zero urls rewritten → card mounts → no chart draws): prod's live embed page references `d12w4pyrrczi5e.cloudfront.net` 16 times, and never staging's `d1iyjvzoctsna`.

## Security posture

Unchanged from the staging review in `embed_proxy.ts`, but it is now a **production** surface, so restating it: `/embed-html/{pub_id}` and `/cdn-asset/{path}` become public and unauthenticated on the OAuth origin.

- Both metered through the free-tier per-IP limiter.
- `/embed-html/` answers `text/plain` under `Content-Security-Policy: sandbox`; `/cdn-asset/` is confined to the `archive/` prefix and reflects only inert content types. Neither serves a document the browser will execute.
- Proxied page has `csrfToken` and the GA bootstrap stripped.
- Handlers run ahead of the OAuth subsystem, so a malformed value declines rather than throwing (a throw would 500 `/authorize` and `/token`) — covered by tests.

## Test plan

- [x] `npm run typecheck` — all 4 tsconfig projects clean
- [x] `npm test` — 1,068 passed (937 + 85 + 46), 0 failures
- [x] `wrangler deploy --env production --dry-run` confirms the binding resolves: `env.PUBLIC_CDN_URL ("https://d12w4pyrrczi5e.cloudfront.net")`
- [x] `registry:check` / `schemas:check` clean
- [ ] **After deploy:** `/cdn-asset/archive/x.js` on prod returns 502 not 404 (route exists)
- [ ] **After deploy:** a `tako_search` / `tako_answer` chart on claude.ai web is hoverable, and renders light on a light-themed Claude