### PR TITLE
fix(widget): a chart-less call left an unexplained grey box

### DIFF
--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -642,13 +642,19 @@ describe("worker routing", () => {
       openWorldHint: false,
     });
 
-    // `tako_search` is the sole chart-widget tool on ChatGPT after 0.3.0.
-    // The empty-fast widget-gap problem (ChatGPT pins widget container
-    // height at the highest ever notified and ignores shrink notifications,
-    // so a clean `count: 0` result rendered as a persistent empty container)
-    // is handled by `tako_search`'s handler throwing on empty for ChatGPT —
-    // tool errors don't reserve a widget container, so the widget can stay
-    // shipped without leaving a gap on the empty path.
+    // Registration `_meta` is STATIC per tool, and deliberately so even
+    // though a chart-less call cannot use it: a tool descriptor is written
+    // once, before any call, so it cannot know whether the next result will
+    // carry a card. That is the root of the empty-widget-gap problem — ChatGPT
+    // keeps a minimum-height widget card for every mounted widget and ignores
+    // the shrink to zero, so a zero-card search left a grey void (reported
+    // 2026-08). An earlier revision of this comment claimed the handler threw
+    // on empty for ChatGPT to dodge it; it does not, and has not since the
+    // zero-result `guidance` path replaced the throw. What covers it now is
+    // two-sided: the bundle labels the box it cannot escape (`collapse()` in
+    // `_chart_widget.ts`), and the tool RESULT names no ui resource at all
+    // when there is no chart (`mcp.test.ts`), which removes the box outright
+    // on any host that decides per call rather than per descriptor.
     const takoSearchTool = body.result.tools.find((t) => t.name === "tako_search");
     expect(takoSearchTool?._meta).toMatchObject({
       ui: { resourceUri: "ui://tako/embed/chart" },

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -618,6 +618,42 @@ describe("chart render gates per client", () => {
       (result.structuredContent as { guidance?: string }).guidance,
     ).toMatch(/tako_available_data/);
   });
+
+  it("a chart-less result references no ui resource at all", async () => {
+    // The result-side half of the empty-widget fix. A zero-card call has
+    // nothing to render, so it must not point at a widget: a host that decides
+    // per RESULT then mounts nothing, and no empty card appears.
+    //
+    // This does NOT reach ChatGPT or claude.ai — both read the widget URI from
+    // `tools/list` registration `_meta`, which is static per tool and stays
+    // declared (asserted in index.test.ts). Their empty card is handled inside
+    // the bundle, by the labelled empty state. This is for spec-compliant hosts
+    // that honour the per-call reference, and it is the only lever that removes
+    // the box rather than dressing it.
+    mockFetchSequence([
+      jsonResponse(200, { cards: [], web_results: [], request_id: "req-3" }),
+    ]);
+
+    const result = await callSearch("claude");
+
+    const meta = result._meta as Record<string, unknown> | undefined;
+    expect(meta?.ui).toBeUndefined();
+    expect(meta?.["ui/resourceUri"]).toBeUndefined();
+  });
+
+  it("a chart-bearing result still points at its baked per-chart widget", async () => {
+    // The other side of the same branch: declining to reference a resource on
+    // an empty result must not cost the populated one its per-pub_id URI.
+    mockFetchSequence([searchResponse(), realPngResponse()]);
+
+    const result = await callSearch("claude");
+
+    const meta = result._meta as
+      | { ui?: { resourceUri?: string }; "ui/resourceUri"?: string }
+      | undefined;
+    expect(meta?.ui?.resourceUri).toBe("ui://tako/embed/chart/c1");
+    expect(meta?.["ui/resourceUri"]).toBe("ui://tako/embed/chart/c1");
+  });
 });
 
 describe("detectMcpClient", () => {

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -654,6 +654,61 @@ describe("chart render gates per client", () => {
     expect(meta?.ui?.resourceUri).toBe("ui://tako/embed/chart/c1");
     expect(meta?.["ui/resourceUri"]).toBe("ui://tako/embed/chart/c1");
   });
+
+  /**
+   * The full client × has-chart matrix for the resource reference, because the
+   * fix is per-RESULT and the surfaces it touches are per-CLIENT. Every cell is
+   * asserted, so a change that helps one client at another's expense fails
+   * here rather than in someone's chat window.
+   *
+   *                 chart          no chart
+   *   claude        per-pub_id     absent
+   *   chatgpt       per-pub_id     absent
+   *   unknown       absent         absent   ← never had a widget; PNG block instead
+   *
+   * The `unknown` row is the load-bearing one for "nothing else regressed":
+   * those clients never reach the resolver at all (`widgetSuppressed` leaves
+   * `ui` undefined in `registerTool`), so the branch cannot touch the long tail
+   * of MCP hosts even in principle.
+   */
+  it("references a widget per client and per result, and never for unknown clients", async () => {
+    const uiOf = (result: { _meta?: Record<string, unknown> }) =>
+      (result._meta as { ui?: { resourceUri?: string } } | undefined)?.ui
+        ?.resourceUri;
+
+    // chatgpt, chart present: keeps its reference. (One fetch only — ChatGPT
+    // skips the PNG bake, and a second would throw.)
+    mockFetchSequence([searchResponse()]);
+    expect(uiOf(await callSearch("chatgpt"))).toBe("ui://tako/embed/chart/c1");
+
+    // chatgpt, no chart: no reference. The registration `_meta` still carries
+    // `openai/outputTemplate`, so ChatGPT mounts anyway and the bundle's empty
+    // state is what covers it — see chatgpt-path.test.ts.
+    mockFetchSequence([
+      jsonResponse(200, { cards: [], web_results: [], request_id: "req-4" }),
+    ]);
+    expect(uiOf(await callSearch("chatgpt"))).toBeUndefined();
+
+    // unknown, chart present: no widget reference ever, and the PNG content
+    // block instead — the portable path, untouched by this branch.
+    mockFetchSequence([searchResponse(), pngResponse()]);
+    const unknownWithChart = await callSearch("unknown");
+    expect(uiOf(unknownWithChart)).toBeUndefined();
+    expect(
+      unknownWithChart.content.filter((b) => b.type === "image"),
+    ).toHaveLength(1);
+
+    // unknown, no chart: no reference, no image block, and no second fetch
+    // (no image_url to fetch) — nothing to render and nothing attempted.
+    mockFetchSequence([
+      jsonResponse(200, { cards: [], web_results: [], request_id: "req-5" }),
+    ]);
+    const unknownEmpty = await callSearch("unknown");
+    expect(uiOf(unknownEmpty)).toBeUndefined();
+    expect(unknownEmpty.content.filter((b) => b.type === "image")).toHaveLength(
+      0,
+    );
+  });
 });
 
 describe("detectMcpClient", () => {

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -1228,14 +1228,30 @@ function registerTool(
           // `AnyToolModule` erases handler types at the registry
           // boundary; resolvers narrow it themselves.
           const resolvedUri = ui.dynamic.resolveUriFromInput(input, output);
-          resultMeta = {
-            ...(resultMeta ?? {}),
-            ui: {
-              ...((resultMeta?.ui as Record<string, unknown> | undefined) ?? {}),
-              resourceUri: resolvedUri,
-            },
-            "ui/resourceUri": resolvedUri,
-          };
+          // `undefined` = this call produced nothing to render. Then the
+          // result names NO ui resource: pointing at the static bundle
+          // regardless (what this used to do) is an instruction to mount a
+          // widget for a result that has no chart in it, and on a host with a
+          // minimum widget-card height that instruction is exactly the empty
+          // grey box users report. A host that decides per RESULT now mounts
+          // nothing at all.
+          //
+          // Hosts that read the URI from `tools/list` registration `_meta`
+          // are unaffected — that metadata is static per tool and still
+          // declares the widget, because a tool descriptor cannot know
+          // whether a future call will have a card. ChatGPT and claude.ai are
+          // both in that bucket; their chart-less mount is handled inside the
+          // bundle by the labelled empty state in `collapse()`.
+          if (resolvedUri !== undefined) {
+            resultMeta = {
+              ...(resultMeta ?? {}),
+              ui: {
+                ...((resultMeta?.ui as Record<string, unknown> | undefined) ?? {}),
+                resourceUri: resolvedUri,
+              },
+              "ui/resourceUri": resolvedUri,
+            };
+          }
         } catch (err) {
           console.error(
             `dynamic.resolveUriFromInput failed for ${tool.name}:`,

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -87,19 +87,34 @@ describe("chart widget HTML", () => {
   });
 
   it("positions the empty state out of flow so it cannot grow the box", () => {
-    // Three properties carry the whole design and none is cosmetic:
-    // `position: fixed` fills the host's reserved viewport without
-    // contributing to `scrollHeight` (a host that sizes from content must not
-    // see the label as a reason to make room); `height: 100vh` makes that hold
-    // even on an engine that resolves fixed-in-iframe against the document
-    // rather than the viewport, where `top/bottom: 0` alone would collapse the
-    // label on a zero-height document; and the individual offsets rather than
-    // the `inset` shorthand keep it parseable by older engines.
+    // Two properties carry the design and neither is cosmetic: `position:
+    // fixed` fills the host's reserved viewport without contributing to
+    // `scrollHeight` (a host that sizes from content must not see the label as
+    // a reason to make room), and `height: 100vh` makes that hold even on an
+    // engine that resolves fixed-in-iframe against the document rather than
+    // the viewport, where `top/bottom: 0` alone would collapse the label on a
+    // zero-height document.
+    //
+    // Long-hand offsets vs the `inset` shorthand is NOT asserted: both have
+    // shipped everywhere since 2021, so pinning the spelling would only fail a
+    // future cleanup.
     const ui = buildChartAppUiResourceFromOutputPubId(ENV);
     expect(ui.html).toContain("#tako-empty");
     expect(ui.html).toMatch(/#tako-empty\s*\{[^}]*position:\s*fixed/);
     expect(ui.html).toMatch(/#tako-empty\s*\{[^}]*height:\s*100vh/);
-    expect(ui.html).not.toMatch(/#tako-empty\s*\{[^}]*inset:/);
+  });
+
+  it("ships a readable empty-label colour for a host that declares no theme", () => {
+    // The silent-host fallback lives in CSS, not in `collapse()`: base is the
+    // light value (an unstyled frame composites to an opaque white base) with a
+    // `prefers-color-scheme` dark override. A single compromise grey was worse
+    // in BOTH directions — 3.25:1 against 4.83:1 on white — and 13px normal
+    // text needs 4.5:1, not the 3:1 large-text threshold.
+    const ui = buildChartAppUiResourceFromOutputPubId(ENV);
+    expect(ui.html).toMatch(/#tako-empty\s*\{[^}]*color:\s*#6b7280/);
+    expect(ui.html).toMatch(
+      /@media\s*\(prefers-color-scheme:\s*dark\)\s*\{\s*#tako-empty\s*\{\s*color:\s*#b4b8bd/,
+    );
   });
 
   it("declares resourceDomains so the remote image fallback loads on claude.ai", () => {

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -87,14 +87,18 @@ describe("chart widget HTML", () => {
   });
 
   it("positions the empty state out of flow so it cannot grow the box", () => {
-    // Two properties carry the whole design and neither is cosmetic:
+    // Three properties carry the whole design and none is cosmetic:
     // `position: fixed` fills the host's reserved viewport without
     // contributing to `scrollHeight` (a host that sizes from content must not
-    // see the label as a reason to make room), and the individual offsets
-    // rather than the `inset` shorthand keep it parseable by older engines.
+    // see the label as a reason to make room); `height: 100vh` makes that hold
+    // even on an engine that resolves fixed-in-iframe against the document
+    // rather than the viewport, where `top/bottom: 0` alone would collapse the
+    // label on a zero-height document; and the individual offsets rather than
+    // the `inset` shorthand keep it parseable by older engines.
     const ui = buildChartAppUiResourceFromOutputPubId(ENV);
     expect(ui.html).toContain("#tako-empty");
     expect(ui.html).toMatch(/#tako-empty\s*\{[^}]*position:\s*fixed/);
+    expect(ui.html).toMatch(/#tako-empty\s*\{[^}]*height:\s*100vh/);
     expect(ui.html).not.toMatch(/#tako-empty\s*\{[^}]*inset:/);
   });
 

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -86,6 +86,18 @@ describe("chart widget HTML", () => {
     expect(html).toContain('addEventListener("load"');
   });
 
+  it("positions the empty state out of flow so it cannot grow the box", () => {
+    // Two properties carry the whole design and neither is cosmetic:
+    // `position: fixed` fills the host's reserved viewport without
+    // contributing to `scrollHeight` (a host that sizes from content must not
+    // see the label as a reason to make room), and the individual offsets
+    // rather than the `inset` shorthand keep it parseable by older engines.
+    const ui = buildChartAppUiResourceFromOutputPubId(ENV);
+    expect(ui.html).toContain("#tako-empty");
+    expect(ui.html).toMatch(/#tako-empty\s*\{[^}]*position:\s*fixed/);
+    expect(ui.html).not.toMatch(/#tako-empty\s*\{[^}]*inset:/);
+  });
+
   it("declares resourceDomains so the remote image fallback loads on claude.ai", () => {
     const ui = buildChartAppUiResourceFromOutputPubId(ENV);
     // image_url is served from the public API base; the embed page from

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -584,6 +584,24 @@ const WIDGET_HTML = `<!doctype html>
     display: flex; align-items: center; justify-content: center;
     width: 100%; min-height: 240px;
   }
+  /* The empty state — see \`collapse()\`. Two declarations here are load-bearing,
+     not cosmetic:
+       - \`position: fixed\` + explicit offsets: fills the host's reserved
+         viewport (whatever it kept after we asked for zero) while staying OUT
+         of flow, so a host that sizes the frame from content still measures a
+         zero-height document. The \`inset\` shorthand would read better and is
+         deliberately not used — the offsets parse in every engine that has
+         ever run this bundle.
+       - transparent background: \`applyHostSurface\` paints the canvas in the
+         host's own colour, and a second surface here would put a visible
+         rectangle inside the very box this label exists to explain. */
+  #tako-empty {
+    position: fixed; top: 0; right: 0; bottom: 0; left: 0;
+    display: flex; align-items: center; justify-content: center;
+    padding: 0 16px; box-sizing: border-box;
+    font-size: 13px; text-align: center;
+    pointer-events: none; background: transparent;
+  }
   .hidden { display: none !important; }
 </style>
 </head>
@@ -602,6 +620,11 @@ const WIDGET_HTML = `<!doctype html>
      un-hide the relevant element AND notifyHeight(actual height) in
      lockstep, so the widget grows naturally on success. -->
 <div id="tako-placeholder" class="hidden">Loading chart…</div>
+<!-- Shown only by \`collapse()\`, i.e. only once we know there is no chart to
+     draw. Never a loading state: on a host that honours the shrink this sits
+     inside a zero-height viewport and is invisible, which is the outcome we
+     prefer and must not spoil with a flash of text. -->
+<div id="tako-empty" class="hidden">No chart for this result</div>
 <iframe
   id="tako-embed"
   class="hidden"
@@ -624,6 +647,7 @@ const WIDGET_HTML = `<!doctype html>
   var image = document.getElementById("tako-embed-img");
   var imageLink = document.getElementById("tako-embed-link");
   var placeholder = document.getElementById("tako-placeholder");
+  var empty = document.getElementById("tako-empty");
   var rendered = false;
   // Origin of the iframe we loaded — used to gate the height handshake
   // listener below so we only honor resize messages from the actual
@@ -1483,10 +1507,41 @@ const WIDGET_HTML = `<!doctype html>
       return true;
   }
 
-  // Take the widget to zero height and mark it done. Used by the no-chart
-  // guard in render() and by the no-data watchdog at the bottom of the file.
+  // Take the widget to zero height, label whatever the host refuses to give
+  // back, and mark it done. Used by the no-chart guard in render() and by the
+  // no-data watchdog at the bottom of the file.
+  //
+  // Asking for zero is not enough, and that is the whole reason the label
+  // exists. The host mounts this widget from STATIC tool-registration metadata
+  // (\`openai/outputTemplate\` / \`ui.resourceUri\` in \`tools/list\`), which cannot
+  // know whether a given call produced a chart — so every chart-less call gets
+  // a mounted widget, and a host with a minimum card height (ChatGPT, reported
+  // 2026-08 on a zero-card search) keeps that card visible after the shrink to
+  // zero. What the user then sees is an unexplained grey void next to an answer
+  // that worked.
+  //
+  // So: paint a quiet line into the space instead. Painting is free in the good
+  // case — a host that honoured the zero is showing a zero-height viewport, and
+  // \`#tako-empty\` is \`position: fixed\`, so it neither renders nor adds to the
+  // document's measurable height there. And no height is notified after the
+  // zero: the label dresses a box the host chose to keep, and must never be a
+  // reason to reserve one that was already given up.
   function collapse() {
     placeholder.classList.add("hidden");
+    if (empty) {
+      // Contrast, not decoration. The label sits on the host's own surface
+      // (\`applyHostSurface\` paints the canvas to match), so the body's
+      // placeholder grey lands around 2:1 against a light host — legible to
+      // whoever wrote it and to nobody else. Pick per resolved theme instead:
+      // ~4.7:1 on light, ~5:1 on dark. \`hostTheme()\` is known by now on every
+      // path that has a theme at all (the no-chart guard runs after
+      // \`applyHostSurface\`); the fallback is the one grey that clears 3:1 in
+      // both directions, for the watchdog case where no host ever answered.
+      var t = hostTheme();
+      empty.style.color =
+        t === "light" ? "#6b7280" : t === "dark" ? "#b4b8bd" : "#8b8f95";
+      empty.classList.remove("hidden");
+    }
     document.documentElement.style.height = "0px";
     document.body.style.height = "0px";
     notifyHeight(0);
@@ -2326,13 +2381,15 @@ export async function fetchPngContentBlock(
  * static URI + baked `_meta.image_data_url` from `extraMeta`.
  *
  * `resolveUriFromInput` reads the top card's `pub_id` from the tool
- * output (the search input is a query, not a pub_id) and falls back to
- * the static URI when there's no renderable top card.
+ * output (the search input is a query, not a pub_id) and returns
+ * `undefined` when there's no renderable top card — see
+ * `buildChartAppUiResourceFromOutputPubId` for why declining beats
+ * naming the static bundle there.
  */
 export function buildChartAppUiResource(
   env: Env,
   requestOrigin: string | undefined,
-  resolveUriFromInput: (input: unknown, output?: unknown) => string,
+  resolveUriFromInput: (input: unknown, output?: unknown) => string | undefined,
 ): AppUiResource {
   const webBase = resolvePublicBase(env);
   return {
@@ -2441,8 +2498,15 @@ export function buildChartAppUiResource(
 /**
  * `appUiResource` variant that derives the per-call widget URI from the top
  * card's `pub_id` on the tool OUTPUT (the input is a query/spec, not a pub_id).
- * Falls back to the static URI when there's no renderable top card. Shared by
- * tako_search and tako_visualize, which both render a chart widget this way.
+ * Shared by tako_search, tako_answer and tako_visualize, which all render a
+ * chart widget this way.
+ *
+ * No top card → `undefined`, NOT the static URI. A chart-less result has
+ * nothing for a widget to draw, and naming a resource anyway is what asks a
+ * host to mount one; declining is the only way the empty card disappears
+ * rather than merely getting labelled. It changes nothing on ChatGPT or
+ * claude.ai (both mount from `tools/list` registration `_meta`, which is
+ * static per tool) — see `collapse()` in the bundle for what covers those.
  */
 export function buildChartAppUiResourceFromOutputPubId(
   env: Env,
@@ -2453,7 +2517,7 @@ export function buildChartAppUiResourceFromOutputPubId(
       typeof (output as { pub_id?: unknown } | undefined)?.pub_id === "string"
         ? (output as { pub_id: string }).pub_id
         : "";
-    if (pubId === "") return appUiResourceUri(env);
+    if (pubId === "") return undefined;
     return appUiTemplateUriPattern(env).replace(
       "{pub_id}",
       encodeURIComponent(pubId),

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -586,12 +586,12 @@ const WIDGET_HTML = `<!doctype html>
   }
   /* The empty state — see \`collapse()\`. Three declarations here are
      load-bearing, not cosmetic:
-       - \`position: fixed\` + explicit offsets: fills the host's reserved
-         viewport (whatever it kept after we asked for zero) while staying OUT
-         of flow, so a host that sizes the frame from content still measures a
-         zero-height document. The \`inset\` shorthand would read better and is
-         deliberately not used — the offsets parse in every engine that has
-         ever run this bundle.
+       - \`position: fixed\` + offsets: fills the host's reserved viewport
+         (whatever it kept after we asked for zero) while staying OUT of flow,
+         so a host that sizes the frame from content still measures a
+         zero-height document. Written long rather than as \`inset\` only
+         because the four sides read plainly next to the \`100vh\` below; the
+         shorthand would be equally safe.
        - \`height: 100vh\`: redundant wherever fixed positioning resolves against
          the viewport (every current engine), and the reason this does not
          depend on that. The widget renders inside an iframe on hosts we do not
@@ -603,14 +603,24 @@ const WIDGET_HTML = `<!doctype html>
          still cannot make a collapsed widget visible or measurable.
        - transparent background: \`applyHostSurface\` paints the canvas in the
          host's own colour, and a second surface here would put a visible
-         rectangle inside the very box this label exists to explain. */
+         rectangle inside the very box this label exists to explain.
+     The colour is the SILENT-HOST case only — \`collapse()\` overrides it inline
+     whenever the host declared a theme, which is the signal that actually
+     matches the backdrop. Base is the light value because an unstyled frame
+     composites to an opaque white base (measured; see \`applyHostSurface\`), and
+     the dark override uses the one signal an iframe gets for free. 4.83:1 on
+     white and 5.4:1 on a dark host, against 3.25:1 for any single grey that
+     tries to hedge both. */
   #tako-empty {
     position: fixed; top: 0; right: 0; bottom: 0; left: 0;
     height: 100vh;
     display: flex; align-items: center; justify-content: center;
     padding: 0 16px; box-sizing: border-box;
-    font-size: 13px; text-align: center;
+    font-size: 13px; text-align: center; color: #6b7280;
     pointer-events: none; background: transparent;
+  }
+  @media (prefers-color-scheme: dark) {
+    #tako-empty { color: #b4b8bd; }
   }
   .hidden { display: none !important; }
 </style>
@@ -1536,20 +1546,39 @@ const WIDGET_HTML = `<!doctype html>
   // document's measurable height there. And no height is notified after the
   // zero: the label dresses a box the host chose to keep, and must never be a
   // reason to reserve one that was already given up.
-  function collapse() {
+  function collapse(labelled) {
     placeholder.classList.add("hidden");
-    if (empty) {
-      // Contrast, not decoration. The label sits on the host's own surface
-      // (\`applyHostSurface\` paints the canvas to match), so the body's
-      // placeholder grey lands around 2:1 against a light host — legible to
-      // whoever wrote it and to nobody else. Pick per resolved theme instead:
-      // ~4.7:1 on light, ~5:1 on dark. \`hostTheme()\` is known by now on every
-      // path that has a theme at all (the no-chart guard runs after
-      // \`applyHostSurface\`); the fallback is the one grey that clears 3:1 in
-      // both directions, for the watchdog case where no host ever answered.
+    // \`labelled\` is only true where the emptiness is a FACT: structured content
+    // arrived and carried no chart. The watchdog path passes false, because
+    // "nothing arrived within 10 s" is not the same claim — a failed call and a
+    // merely slow delivery are indistinguishable from in here, and this
+    // function discards whatever lands afterwards (\`rendered = true\`). Saying
+    // "No chart for this result" there would be an affirmative statement that
+    // is wrong exactly when the chart was late rather than absent. Blank keeps
+    // that path's pre-existing behaviour, and hosts show their own error for
+    // the failed call.
+    if (empty && labelled) {
+      // Contrast, not decoration. The body's placeholder grey lands around
+      // 2:1 against a light host — legible to whoever wrote it and to nobody
+      // else. When the host DECLARED a theme, use its value: ~4.8:1 on light,
+      // ~5:1 on dark, and it beats any OS signal because the host's theme and
+      // the machine's can disagree (TAKO-3781).
+      //
+      // When it declared none, leave the CSS alone. The stylesheet's base is
+      // the light value with a \`prefers-color-scheme\` dark override, which is
+      // strictly better than a compromise grey: a silent host is also one
+      // \`applyHostSurface\` leaves untouched, and per the measured note above
+      // that is the same-origin case where the canvas composites over the
+      // host's own page — so the OS signal tracks the backdrop. Residual risk,
+      // accepted: a CROSS-origin host that sends no theme composites to an
+      // opaque white base regardless of the OS, so a dark-mode machine there
+      // reads ~1.9:1. No host we know of is in that intersection (claude.ai
+      // and ChatGPT both declare a theme), and it is not detectable from in
+      // here — the white is the compositor's base, not a style we can read.
       var t = hostTheme();
-      empty.style.color =
-        t === "light" ? "#6b7280" : t === "dark" ? "#b4b8bd" : "#8b8f95";
+      if (t === "light" || t === "dark") {
+        empty.style.color = t === "light" ? "#6b7280" : "#b4b8bd";
+      }
       empty.classList.remove("hidden");
     }
     document.documentElement.style.height = "0px";
@@ -1582,7 +1611,7 @@ const WIDGET_HTML = `<!doctype html>
       typeof structuredContent.embed_url !== "string" &&
       typeof structuredContent.image_url !== "string"
     ) {
-      collapse();
+      collapse(true);
       log("no-chart payload, collapsed widget");
       return true;
     }
@@ -1810,9 +1839,14 @@ const WIDGET_HTML = `<!doctype html>
   // treatment rather than a different one. \`rendered\` makes this a no-op once
   // any chart has painted, and the 10 s bound matches the polling window so it
   // cannot race a slow-but-arriving delivery.
+  //
+  // Collapsed WITHOUT the label, deliberately: from in here a failed call and a
+  // delivery that is merely late look identical, so "No chart for this result"
+  // would be an affirmative claim that is wrong in the second case. See
+  // \`collapse()\`.
   setTimeout(function () {
     if (rendered) return;
-    collapse();
+    collapse(false);
     log("no data arrived, collapsed widget");
   }, 10000);
 

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -584,19 +584,29 @@ const WIDGET_HTML = `<!doctype html>
     display: flex; align-items: center; justify-content: center;
     width: 100%; min-height: 240px;
   }
-  /* The empty state — see \`collapse()\`. Two declarations here are load-bearing,
-     not cosmetic:
+  /* The empty state — see \`collapse()\`. Three declarations here are
+     load-bearing, not cosmetic:
        - \`position: fixed\` + explicit offsets: fills the host's reserved
          viewport (whatever it kept after we asked for zero) while staying OUT
          of flow, so a host that sizes the frame from content still measures a
          zero-height document. The \`inset\` shorthand would read better and is
          deliberately not used — the offsets parse in every engine that has
          ever run this bundle.
+       - \`height: 100vh\`: redundant wherever fixed positioning resolves against
+         the viewport (every current engine), and the reason this does not
+         depend on that. The widget renders inside an iframe on hosts we do not
+         control, and WebKit has historically resolved fixed positioning inside
+         a frame against the DOCUMENT instead — where \`top/bottom: 0\` on a
+         zero-height document collapses the label to nothing. \`100vh\` is the
+         frame's own viewport either way, so the label fills the visible box on
+         both readings, and equals 0 when the host honoured the shrink, so it
+         still cannot make a collapsed widget visible or measurable.
        - transparent background: \`applyHostSurface\` paints the canvas in the
          host's own colour, and a second surface here would put a visible
          rectangle inside the very box this label exists to explain. */
   #tako-empty {
     position: fixed; top: 0; right: 0; bottom: 0; left: 0;
+    height: 100vh;
     display: flex; align-items: center; justify-content: center;
     padding: 0 16px; box-sizing: border-box;
     font-size: 13px; text-align: center;

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -263,8 +263,16 @@ export interface AppUiResource {
      * of a tool result (e.g. during pre-registration validation in
      * tests); resolvers should fall back to a sensible default URI in
      * that case.
+     *
+     * Return `undefined` to say "this call produced nothing to render".
+     * `mcp.ts` then omits the result-level `ui` keys entirely rather
+     * than falling back to the static URI, so a host that decides per
+     * RESULT mounts no widget at all. Hosts that read the URI from
+     * `tools/list` registration `_meta` (ChatGPT, claude.ai) mount
+     * regardless — for them the bundle's own empty state is what keeps
+     * a chart-less call from looking broken (see `collapse()`).
      */
-    resolveUriFromInput: (input: unknown, output?: unknown) => string;
+    resolveUriFromInput: (input: unknown, output?: unknown) => string | undefined;
   };
 }
 

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -261,8 +261,9 @@ export interface AppUiResource {
      *
      * `output` may be `undefined` when the resolver is called outside
      * of a tool result (e.g. during pre-registration validation in
-     * tests); resolvers should fall back to a sensible default URI in
-     * that case.
+     * tests). That is not a special case: a resolver with no output has
+     * nothing to render either, so it takes the same branch as a call
+     * that produced no chart — `undefined`.
      *
      * Return `undefined` to say "this call produced nothing to render".
      * `mcp.ts` then omits the result-level `ui` keys entirely rather

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -181,6 +181,32 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     expect(renderedIframe(m)).toBe(true);
   });
 
+  it("EMPTY: a chart-less toolOutput labels the card ChatGPT keeps anyway", () => {
+    // The host this was reported on. ChatGPT mounts the widget from static
+    // `openai/outputTemplate` registration metadata, so a zero-card search
+    // still gets a widget card, and it holds that card at its minimum height
+    // through the shrink to zero — an unexplained grey void beside a working
+    // answer. The bundle cannot un-mount itself; it can only make the space
+    // read as intentional. Delivered on PATH 1, the route ChatGPT actually
+    // uses, because a guard that only works over postMessage would not have
+    // covered this host at all.
+    const heights: number[] = [];
+    const m = mountWidget(html(), {
+      toolOutput: { cards: [], web_results: [], usage: {} },
+      notifyIntrinsicHeight: (h: number) => heights.push(h),
+    });
+    const empty = m.widgetWin.document.getElementById(
+      "tako-empty",
+    ) as HTMLElement;
+    expect(empty.classList.contains("hidden")).toBe(false);
+    expect(empty.textContent).toMatch(/no chart/i);
+    expect(renderedIframe(m)).toBe(false);
+    // ChatGPT reads `notifyIntrinsicHeight`, not the postMessage, and the last
+    // thing it hears must be zero: labelling a box the host kept is not a
+    // request for one. [1, 0] — the mount-time floor, then the collapse.
+    expect(heights).toEqual([1, 0]);
+  });
+
   it("NO PNG FALLBACK: with openai present the widget never paints an image", () => {
     const m = mountWidget(html(), { toolOutput: PROD_STRUCTURED_CONTENT });
     // ChatGPT skips extraMeta, so there is no image_data_url; confirm the

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -193,6 +193,7 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     const heights: number[] = [];
     const m = mountWidget(html(), {
       toolOutput: { cards: [], web_results: [], usage: {} },
+      theme: "light",
       notifyIntrinsicHeight: (h: number) => heights.push(h),
     });
     const empty = m.widgetWin.document.getElementById(
@@ -205,6 +206,34 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     // thing it hears must be zero: labelling a box the host kept is not a
     // request for one. [1, 0] — the mount-time floor, then the collapse.
     expect(heights).toEqual([1, 0]);
+  });
+
+  it("EMPTY: reads the label colour from window.openai.theme, both ways", () => {
+    // `window.openai.theme` is the ONLY theme source on ChatGPT — it never
+    // sends `hostContext`, so the MCP Apps coverage in widget-dom.test.ts says
+    // nothing about this read. Without this, a regression in it would surface
+    // as an unreadable label in a chat window rather than in CI.
+    const emptyOf = (m: Mounted) =>
+      (m.widgetWin.document.getElementById("tako-empty") as HTMLElement).style
+        .color;
+
+    const light = mountWidget(html(), {
+      toolOutput: { cards: [] },
+      theme: "light",
+    });
+    expect(emptyOf(light)).toBe("rgb(107, 114, 128)");
+
+    const dark = mountWidget(html(), {
+      toolOutput: { cards: [] },
+      theme: "dark",
+    });
+    expect(emptyOf(dark)).toBe("rgb(180, 184, 189)");
+
+    // No theme declared → no inline override at all, so the stylesheet's
+    // `prefers-color-scheme` pair decides. Asserting the ABSENCE is what keeps
+    // a compromise grey from creeping back into the JS.
+    const silent = mountWidget(html(), { toolOutput: { cards: [] } });
+    expect(emptyOf(silent)).toBe("");
   });
 
   it("NO PNG FALLBACK: with openai present the widget never paints an image", () => {

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -427,9 +427,13 @@ describe("static widget bundle (executed)", () => {
           "ui/notifications/size-changed",
       ) as Array<{ params: { height: number } }>;
       expect(sizeChanges.at(-1)?.params.height).toBe(0);
-      // A failed call gets the same labelled empty state as a zero-card one —
-      // the host reserved a box either way, and "No chart" is true of both.
-      expect(widgetEmpty(m).classList.contains("hidden")).toBe(false);
+      // Collapsed but NOT labelled. "Nothing arrived in 10 s" covers a failed
+      // call and a merely slow delivery alike, and this path discards whatever
+      // lands afterwards — so "No chart for this result" would be an
+      // affirmative claim that is wrong exactly when the chart was late. The
+      // label is reserved for the case the widget actually knows about:
+      // structured content arrived and carried no chart.
+      expect(widgetEmpty(m).classList.contains("hidden")).toBe(true);
     } finally {
       vi.useRealTimers();
     }

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -158,6 +158,10 @@ function widgetFrame(m: Mounted): HTMLIFrameElement {
   ) as HTMLIFrameElement;
 }
 
+function widgetEmpty(m: Mounted): HTMLElement {
+  return m.widgetWin.document.getElementById("tako-empty") as HTMLElement;
+}
+
 /**
  * Deliver a `tako-embed-height` resize message as if the embed iframe
  * posted it. The widget's handler gates on `event.origin` matching the
@@ -326,6 +330,83 @@ describe("static widget bundle (executed)", () => {
     expect(sizeChanges.at(-1)?.params.height).toBe(0);
   });
 
+  it("labels the empty state for hosts that keep the box anyway", () => {
+    // ChatGPT (and any host with a minimum widget-card height) ignores the
+    // shrink above and keeps a card-sized container. The collapse asked for
+    // zero and got a grey void — so paint an intentional line INTO whatever
+    // space the host insisted on keeping. Fixed positioning is what makes
+    // that safe: on a host that DID collapse us the viewport is 0 px tall and
+    // nothing shows, and an out-of-flow element cannot grow `scrollHeight`
+    // for hosts that size from content.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, toolResult({ cards: [], web_results: [] }), m.wrapperWin);
+    const empty = widgetEmpty(m);
+    expect(empty.classList.contains("hidden")).toBe(false);
+    expect(empty.textContent).toMatch(/no chart/i);
+  });
+
+  it("colours the empty label for the host's theme, not the bundle's grey", () => {
+    // The body grey the placeholder uses lands near 2:1 on a light host, which
+    // is a label only its author can read. Both themes get their own value; the
+    // theme arrives on the handshake, which is why this asserts through it
+    // rather than poking the variable.
+    const light = mountWidget(staticWidgetHtml());
+    deliver(
+      light,
+      {
+        jsonrpc: "2.0",
+        id: "tako-ui-init",
+        result: { hostContext: { theme: "light" } },
+      },
+      light.wrapperWin,
+    );
+    deliver(light, toolResult({ cards: [] }), light.wrapperWin);
+    expect(widgetEmpty(light).style.color).toBe("rgb(107, 114, 128)");
+
+    const dark = mountWidget(staticWidgetHtml());
+    deliver(
+      dark,
+      {
+        jsonrpc: "2.0",
+        id: "tako-ui-init",
+        result: { hostContext: { theme: "dark" } },
+      },
+      dark.wrapperWin,
+    );
+    deliver(dark, toolResult({ cards: [] }), dark.wrapperWin);
+    expect(widgetEmpty(dark).style.color).toBe("rgb(180, 184, 189)");
+  });
+
+  it("never notifies a height above zero once collapsed", () => {
+    // The invariant that keeps the empty state from RESURRECTING a box a host
+    // already threw away: painting content is free, asking for room is not.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(m, toolResult({ cards: [] }), m.wrapperWin);
+    const heights = (
+      m.toParent.filter(
+        (msg) =>
+          (msg as { method?: string }).method ===
+          "ui/notifications/size-changed",
+      ) as Array<{ params: { height: number } }>
+    ).map((msg) => msg.params.height);
+    // 1 px is the mount-time floor sent before any data arrives.
+    expect(Math.max(...heights.slice(1))).toBe(0);
+  });
+
+  it("leaves the empty state hidden when a chart renders", () => {
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 600 },
+        { image_data_url: DATA_URL },
+      ),
+      m.wrapperWin,
+    );
+    fireImageLoad(m);
+    expect(widgetEmpty(m).classList.contains("hidden")).toBe(true);
+  });
+
   it("collapses when NO tool-result ever arrives", () => {
     // The failed-tool-call case. An `isError` result carries no
     // `structuredContent`, but the host has already mounted the widget for
@@ -346,6 +427,9 @@ describe("static widget bundle (executed)", () => {
           "ui/notifications/size-changed",
       ) as Array<{ params: { height: number } }>;
       expect(sizeChanges.at(-1)?.params.height).toBe(0);
+      // A failed call gets the same labelled empty state as a zero-card one —
+      // the host reserved a box either way, and "No chart" is true of both.
+      expect(widgetEmpty(m).classList.contains("hidden")).toBe(false);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## The bug

Reported on ChatGPT, 2026-08-07: a tool call whose result carried no chart rendered an empty grey card above the answer.

It reproduces 100%. It is not a glitch — it is what a mounted widget with nothing to draw looks like on a host with a minimum card height, and it fires on every chart-less `tako_search` / `tako_answer` / `tako_visualize` call, plus every failed one.

## Why the mount can't just be skipped

Hosts read the widget URI from `tools/list` registration `_meta` (`openai/outputTemplate`, `ui.resourceUri`). That metadata is written once per tool, before any call, so it cannot know whether the next result will have a card. Confirmed on the wire against production — a zero-card search still ships `_meta: {"ui": {"resourceUri": "ui://tako/embed/chart"}}`.

The bundle's half was already right: it hides everything, sets the document to zero height, and notifies `size-changed {height: 0}`. I verified that against the **live production bundle bytes** pulled via `resources/read` and executed under jsdom. ChatGPT keeps its card regardless.

## The fix, one change per side

**The bundle labels the space it cannot escape.** `collapse()` shows a centered "No chart for this result".

`position: fixed` with explicit offsets is what makes this safe instead of a second bug:

| host behaviour | outcome |
|---|---|
| honours the shrink | viewport is 0 px tall, nothing renders — unchanged |
| keeps a minimum-height card (ChatGPT) | the line centers in the space already reserved |
| sizes the frame from content | measured in Chromium: `documentElement.scrollHeight` reads identically with the label shown or hidden, `body.scrollHeight` stays 0 |

No height above zero is notified after the collapse, so the label can never reserve a box a host already gave up.

The colour comes from the resolved host theme (`#6b7280` light, `#b4b8bd` dark). The bundle's placeholder grey measured ~2.2:1 against a light host — a label only its author can read. Caught by rendering it, not by a test.

**The server stops asking.** A chart-less result now names no ui resource at all: the per-call resolver returns `undefined` rather than falling back to the static bundle, and `mcp.ts` omits `ui` / `ui/resourceUri`. Production ships `_meta: {ui: {…}}` on a zero-card search today; after this it ships no `_meta`. This is the only lever that *removes* the box rather than dressing it, and it reaches hosts that decide per result. ChatGPT and claude.ai are not among them — hence both halves.

Also corrected a comment in `index.test.ts` claiming `tako_search` throws on empty for ChatGPT to dodge this exact gap. It does not, and has not since the zero-result `guidance` path replaced the throw.

## Verified

Rendered in a local MCP Apps host harness at a ChatGPT-like 145 px card, light and dark, with the real zero-card payload. Host log confirms `size-changed {"width":760,"height":0}` for both:

Both panes show the label centered in the reserved card, tinted for that theme, with the widget canvas painted in the host's own surface colour so no inner rectangle appears. (Screenshot available locally — GitHub attachments need a browser upload.)

- 1083 worker tests, 91 widget tests, 68 script tests pass; all four typecheck projects clean; `registry:check` ok.
- +5 tests: the empty state on both the MCP Apps and ChatGPT delivery paths, the theme-correct colour on both themes, the never-notify-above-zero invariant (`notifyIntrinsicHeight` called exactly `[1, 0]`), no empty state once a chart paints, and both sides of the resolver branch asserted on the wire.

## Cross-client verification (asked for explicitly)

Every client, both result shapes. The widget-reference matrix is now a test (`mcp.test.ts`), so a change that helps one host at another's expense fails in CI:

| client | chart | no chart |
|---|---|---|
| claude | per-`pub_id` reference | **absent** |
| chatgpt | per-`pub_id` reference | **absent** |
| unknown (Cursor, Windsurf, Gemini CLI, Claude Code, Agent SDK) | absent, PNG content block | absent, nothing attempted |

The `unknown` row is what says nothing else regressed: `widgetSuppressed` leaves `ui` undefined in `registerTool`, so those clients never reach the resolver at all — the branch cannot touch the long tail of MCP hosts even in principle, and the portable image block is asserted still present.

**Executed in Chromium against real production payloads**, driving each host's actual protocol (Claude: MCP Apps handshake with `hostContext` theme + surface, then `ui/notifications/tool-result`; ChatGPT: `window.openai.toolOutput` defined before the bundle runs):

| scenario | result |
|---|---|
| Claude, zero-card | label shown, fills the 760×145 box, light `rgb(107,114,128)` / dark `rgb(180,184,189)`, `size-changed height: 0`, `body.scrollHeight: 0`, `documentElement.scrollHeight` unchanged at 145 |
| Claude, real chart (baked `image_data_url`, 176 KB) | PNG paints at 349 px, then the native card upgrades in place, frame 409 px, label never shown |
| ChatGPT, real chart (32 KB structuredContent) | embed iframe committed to the right URL, heights `[1, 720, 460, 449]`, label never shown |

Nothing else reads what was removed: `scripts/smoke.ts` asserts the **registration** `_meta.ui.resourceUri` from `tools/list` (untouched) and hits `/embed-html/` directly; the baked per-chart resource and its `buildFallbackWidgetHtml` path always carry their own content. Omitting `_meta` entirely is an already-exercised path — every non-widget tool ships results that way today.

**Not executed on WebKit or Gecko.** `playwright install webkit` produces a broken 15 MB directory with no launcher in this environment, twice. Rather than claim coverage I do not have, the CSS now removes the dependency: `height: 100vh` alongside the fixed offsets, so the label fills the frame's viewport whether an engine resolves fixed-in-iframe against the viewport (all current engines) or against the document (WebKit historically, where `top/bottom: 0` on our deliberately zero-height document would have collapsed it to nothing). It is 0 either way when the host honoured the shrink, so a collapsed widget still cannot become visible or measurable. Worst case on an untested engine is the label not centering — never worse than today's blank box.

## Test plan

- [ ] Deploy to staging, run a `tako_search` that returns zero cards from ChatGPT dev mode, confirm the card reads "No chart for this result" instead of blank.
- [ ] Same call from claude.ai, confirm the label and the theme colour.
- [ ] Confirm a chart-bearing call is untouched: chart renders, and the result `_meta` still carries the per-`pub_id` `ui.resourceUri`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

