### PR TITLE
feat(widget): opt every displayed card into the embed page's share control

### DIFF
--- a/docs/chatgpt-app-review.md
+++ b/docs/chatgpt-app-review.md
@@ -115,13 +115,18 @@ the declaration and the URL cannot drift. No wildcards, no third-party frames, o
 (`/embed/{pub_id}/`).
 
 **What the framed page contains** (measured on production, `pub_id`
-`VKd7qE8K9Ba16kMFENNQ`, 2026-08-04): the chart, its title, and source attribution. Three
-external origins are referenced — Tako's own asset CDN (`d12w4pyrrczi5e.cloudfront.net`,
-16 refs: `Card.js`, its chunks, fonts, card images), `www.spglobal.com` (4 refs, all inside
-the card's own JSON island as the `source_details.url` for an S&P-sourced series), and —
-before this change — `www.googletagmanager.com`. There are **no advertisements, no checkout,
-no signup, no sign-in, and no upgrade UI**: the served markup contains zero `<a>` elements,
-and no occurrence of "sign up", "log in", "upgrade", "pricing", "subscribe" or "checkout".
+`VKd7qE8K9Ba16kMFENNQ`, 2026-08-04; re-measured 2026-08-13 with `showShare=true`): the
+chart, its title, source attribution, and — since the share opt-in — a share control in the
+card's action cluster, opening a dialog of copyable Tako URLs for this same card (copy
+fields, not navigation; the control mounts client-side and is Tako PR #28735's opt-in
+surface). Three external origins are referenced — Tako's own asset CDN
+(`d12w4pyrrczi5e.cloudfront.net`, 16 refs: `Card.js`, its chunks, fonts, card images),
+`www.spglobal.com` (4 refs, all inside the card's own JSON island as the
+`source_details.url` for an S&P-sourced series), and — before this change —
+`www.googletagmanager.com`. There are **no advertisements, no checkout, no signup, no
+sign-in, and no upgrade UI**: the served markup contains zero `<a>` elements (re-verified
+with `showShare=true`, 2026-08-13), and no occurrence of "sign up", "log in", "upgrade",
+"pricing", "subscribe" or "checkout".
 
 **Analytics removed.** Every iframe load the widget performs now carries
 `disable_tracking=true` (`withoutTracking` in `workers/src/tools/_chart_widget.ts`). On
@@ -131,8 +136,9 @@ references only the Tako CDN and the S&P attribution links, and contains zero
 `googletagmanager` references. Asserted by `test/widget/chatgpt-path.test.ts`
 (`renderedIframe`) and `test/widget/widget-dom.test.ts` (`EMBED_IFRAME_SRC`).
 
-The shareable `embed_url` in `structuredContent` is deliberately left plain — a link a
-person clicks in their own browser is an ordinary tako.com visit. The flag applies only to
+The shareable `embed_url` in `structuredContent` carries `showShare=true` (the card share
+opt-in) but no tracking flag — a link a person clicks in their own browser is an ordinary
+tako.com visit, now with the share control visible. `disable_tracking` applies only to
 loads the widget itself performs.
 
 **The nested-frame fallback exists.** On hosts whose CSP blocks the frame, the widget

--- a/workers/src/embed_proxy.test.ts
+++ b/workers/src/embed_proxy.test.ts
@@ -254,9 +254,12 @@ describe("handleEmbedProxy — experiment on", () => {
     // into a third-party widget sandbox, where a Google Tag Manager beacon has
     // no business (and would only trip the sandbox CSP). The sanitizer still
     // strips GA if the flag is ever not honoured — see `sanitizeEmbedHtml`.
+    // `showShare=true` is the card-share opt-in, carried here because the
+    // document.write delivery hides the widget's own query string from the
+    // page's location-based gates.
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
-      `https://tako.com/embed/${PUB_ID}/?dark_mode=auto&disable_tracking=true`,
+      `https://tako.com/embed/${PUB_ID}/?dark_mode=auto&disable_tracking=true&showShare=true`,
     );
   });
 

--- a/workers/src/embed_proxy.ts
+++ b/workers/src/embed_proxy.ts
@@ -666,7 +666,15 @@ export async function handleEmbedProxy(
   // sanitizer below still strips GA belt-and-braces, in case an upstream
   // change stops honouring the flag), and a proxy read is a machine fetch, not
   // a person viewing a chart, so counting it was always noise.
-  const upstream = `${origins.publicBase}/embed/${pubId}/?dark_mode=${darkMode}&disable_tracking=true`;
+  //
+  // `showShare=true` opts the card into its share control (tako PR #28735) on
+  // the ONLY path where the browser url can't carry the opt-in: this document
+  // is document.written into the widget sandbox, so the page's location-based
+  // gates never see the widget's query string. The param here reaches Django
+  // at render time instead — inert until the tako side bakes it (and the
+  // pub_id + canonical origin) into json_script islands the gates can fall
+  // back on; a page that ignores it renders exactly as before.
+  const upstream = `${origins.publicBase}/embed/${pubId}/?dark_mode=${darkMode}&disable_tracking=true&showShare=true`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
   let response: Response;

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -163,3 +163,17 @@ describe("widget iframe clipboard delegation", () => {
     );
   });
 });
+
+describe("embed origin pin (clipboard-write scope)", () => {
+  // The widget's iframe delegates clipboard-write, and Permissions-Policy's
+  // default 'src' allowlist follows the frame wherever it navigates — so the
+  // served bundle must pin the frame to the env's own web origin, the same
+  // value buildChartUrls writes into embed_url.
+  it("substitutes the placeholder with the env's public web origin", () => {
+    const ui = buildChartAppUiResourceFromOutputPubId(ENV);
+    expect(ui.html).not.toContain("__EXPECTED_EMBED_ORIGIN__");
+    expect(ui.html).toContain(
+      'var EXPECTED_EMBED_ORIGIN = "https://staging.trytako.com"',
+    );
+  });
+});

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -75,7 +75,10 @@ describe("chart widget HTML", () => {
     // separate template strings — a size-changed regression in one is
     // invisible to assertions on the other.
     const html = __chart_widget_test_only__.buildBakedWidgetHtml({
-      embedUrl: "https://staging.trytako.com/embed/abc123/?dark_mode=auto",
+      // Production-shaped url (buildChartUrls output), so the `&` in the
+      // query exercises htmlEscape on the baked anchor.
+      embedUrl:
+        "https://staging.trytako.com/embed/abc123/?dark_mode=auto&showShare=true",
       imageDataUrl: "data:image/png;base64,AAAA",
       naturalWidth: 800,
       naturalHeight: 600,

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -6,6 +6,7 @@ import {
   APP_UI_RESOURCE_URI,
   appUiResourceUri,
   buildChartAppUiResourceFromOutputPubId,
+  buildChartUrls,
 } from "./_chart_widget.js";
 
 const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
@@ -126,5 +127,36 @@ describe("chart widget HTML", () => {
     for (const d of ui.resourceDomains!) {
       expect(d).toMatch(/^https:\/\//);
     }
+  });
+});
+
+describe("buildChartUrls (card share opt-in)", () => {
+  // The share control on the embed page is OPT-IN per host (tako PR #28735):
+  // nothing renders unless the embedding URL carries ?showShare=true. MCP
+  // surfaces want it on every displayed card, so the one URL builder opts in.
+  it("opts the embed url into the card share control", () => {
+    const { embed_url } = buildChartUrls(ENV, "abc123", true);
+    expect(embed_url).toBe(
+      "https://staging.trytako.com/embed/abc123/?dark_mode=auto&showShare=true",
+    );
+  });
+
+  it("keeps the param off the PNG url — a static image has no chrome", () => {
+    const { image_url } = buildChartUrls(ENV, "abc123", false);
+    expect(image_url).toBe(
+      "https://staging.trytako.com/api/v1/image/abc123/?dark_mode=false",
+    );
+  });
+});
+
+describe("widget iframe clipboard delegation", () => {
+  // The share dialog copies links via navigator.clipboard.writeText, which
+  // only works in a nested browsing context when every ancestor delegates
+  // clipboard-write down the chain. We control this hop; the host controls
+  // the one above it.
+  it("delegates clipboard-write to the embed iframe", () => {
+    expect(__chart_widget_test_only__.WIDGET_HTML).toContain(
+      'allow="fullscreen; clipboard-write"',
+    );
   });
 });

--- a/workers/src/tools/_chart_widget.test.ts
+++ b/workers/src/tools/_chart_widget.test.ts
@@ -7,6 +7,7 @@ import {
   appUiResourceUri,
   buildChartAppUiResourceFromOutputPubId,
   buildChartUrls,
+  withShareOptIn,
 } from "./_chart_widget.js";
 
 const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
@@ -174,6 +175,59 @@ describe("embed origin pin (clipboard-write scope)", () => {
     expect(ui.html).not.toContain("__EXPECTED_EMBED_ORIGIN__");
     expect(ui.html).toContain(
       'var EXPECTED_EMBED_ORIGIN = "https://staging.trytako.com"',
+    );
+  });
+});
+
+describe("withShareOptIn (passthrough embed urls)", () => {
+  it("appends with ? on a bare url and & on a queried one", () => {
+    expect(withShareOptIn("https://tako.com/embed/a/")).toBe(
+      "https://tako.com/embed/a/?showShare=true",
+    );
+    expect(withShareOptIn("https://tako.com/embed/a/?dark_mode=auto")).toBe(
+      "https://tako.com/embed/a/?dark_mode=auto&showShare=true",
+    );
+  });
+
+  it("is idempotent and never overrides an explicit value", () => {
+    const once = withShareOptIn("https://tako.com/embed/a/");
+    expect(withShareOptIn(once)).toBe(once);
+    const optedOut = "https://tako.com/embed/a/?showShare=false";
+    expect(withShareOptIn(optedOut)).toBe(optedOut);
+  });
+});
+
+describe("pin substitution edge cases", () => {
+  it("pins the ORIGIN even when the configured base carries a path", () => {
+    // validatePublicOrigin tolerates a path; substituting the raw base
+    // verbatim could never equal any URL.origin, silently degrading every
+    // chart to the PNG.
+    const ui = buildChartAppUiResourceFromOutputPubId({
+      DJANGO_BASE_URL: "https://staging.trytako.com",
+      PUBLIC_BASE_URL: "https://staging.trytako.com/app",
+    } as Env);
+    expect(ui.html).toContain(
+      'var EXPECTED_EMBED_ORIGIN = "https://staging.trytako.com"',
+    );
+  });
+
+  it("pins native_card_url to the worker origin when it is resolvable", () => {
+    const ui = buildChartAppUiResourceFromOutputPubId(
+      ENV,
+      "https://mcp.example.test",
+    );
+    expect(ui.html).toContain(
+      'var EXPECTED_NATIVE_ORIGIN = "https://mcp.example.test"',
+    );
+  });
+
+  it("leaves the native placeholder (scheme-only check) when the worker origin is unknown", () => {
+    // No requestOrigin and no PUBLIC_MCP_URL: the native path is off in this
+    // configuration (nativeCardUrl resolves to undefined server-side), so the
+    // widget keeps the scheme-only behavior rather than refusing everything.
+    const ui = buildChartAppUiResourceFromOutputPubId(ENV);
+    expect(ui.html).toContain(
+      'var EXPECTED_NATIVE_ORIGIN = "__EXPECTED_NATIVE_ORIGIN__"',
     );
   });
 });

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -1148,6 +1148,26 @@ const WIDGET_HTML = `<!doctype html>
     return url + (url.indexOf("?") === -1 ? "?" : "&") + "disable_tracking=true";
   }
 
+  // The only origin the embed iframe may load. Substituted at resource-build
+  // time (see \`buildChartAppUiResourceFromOutputPubId\`) with the same
+  // \`resolvePublicBase\` origin \`buildChartUrls\` writes into \`embed_url\`, so
+  // the pin and the url cannot drift per-env. This matters more now that the
+  // iframe carries \`allow="clipboard-write"\`: the Permissions-Policy default
+  // allowlist is 'src', which follows the frame WHEREVER it navigates, and
+  // the scheme check alone would extend clipboard access to any https origin
+  // a hostile or corrupted tool result named. An unsubstituted placeholder
+  // (raw-template contexts, e.g. direct WIDGET_HTML reads in tests) keeps the
+  // scheme-only behavior rather than bricking every chart.
+  var EXPECTED_EMBED_ORIGIN = "__EXPECTED_EMBED_ORIGIN__";
+  function embedOriginOk(url) {
+    if (EXPECTED_EMBED_ORIGIN.indexOf("http") !== 0) return true;
+    try {
+      return new URL(url).origin === EXPECTED_EMBED_ORIGIN;
+    } catch (err) {
+      return false;
+    }
+  }
+
   // Rewrite \`dark_mode\` on a chart url to match the host. Leaves the url alone
   // when the host is silent, so \`auto\` survives rather than being guessed at.
   //
@@ -1858,7 +1878,10 @@ const WIDGET_HTML = `<!doctype html>
     // server-side too, but the widget is the last hop before the DOM,
     // so a hostile MCP server shipping \`javascript:\` would otherwise
     // execute in the widget origin once dropped into \`src\`.
-    var validEmbed = typeof url === "string" && /^https?:\\/\\//.test(url);
+    var validEmbed =
+      typeof url === "string" &&
+      /^https?:\\/\\//.test(url) &&
+      embedOriginOk(url);
     var validDataImage = typeof imgDataUrl === "string" && imgDataUrl.indexOf("data:image/") === 0;
     var validHttpImage = typeof imgUrl === "string" && /^https?:\\/\\//.test(imgUrl);
     // Prefer the inlined \`data:\` URI over the cross-origin URL — the
@@ -2894,7 +2917,12 @@ export function buildChartAppUiResource(
     // per-call URI overrides.
     uri: appUiResourceUri(env),
     name: APP_UI_RESOURCE_NAME,
-    html: WIDGET_HTML,
+    // Pin the embed iframe to the env's public web origin — the same value
+    // `buildChartUrls` writes into `embed_url`, so the widget's origin check
+    // and the URLs it receives cannot disagree. See EXPECTED_EMBED_ORIGIN in
+    // the bundle. `resolvePublicBase` output is a validated http(s) origin
+    // with no trailing slash, so plain string substitution is safe here.
+    html: WIDGET_HTML.replace("__EXPECTED_EMBED_ORIGIN__", webBase),
     // `frameDomains` is the host CSP's allow-list for nested iframes —
     // without the widget's parent origin in here, the host blocks
     // `<iframe src="https://tako.com/embed/...">`. Pin to exactly the

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -688,7 +688,7 @@ const WIDGET_HTML = `<!doctype html>
   class="hidden"
   scrolling="no"
   frameborder="0"
-  allow="fullscreen"
+  allow="fullscreen; clipboard-write"
   title="Tako chart"
 ></iframe>
 <a
@@ -2700,6 +2700,14 @@ export async function fetchPngDimensions(
  * host knows it. `image_url` is a server-rendered PNG, where the
  * backend can't read browser preferences, so it stays
  * `true`/`false` driven by the `darkMode` arg.
+ *
+ * `embed_url` also carries `showShare=true` — the embed page's card share
+ * control is opt-in per host (tako PR #28735) and renders nothing without
+ * it. The page still hard-suppresses the control where a share affordance
+ * would be wrong (auth-gated cards, glanceable tiles, white-label,
+ * postMessage shells, `?screenshot=true`), so this opt-in is safe to carry
+ * unconditionally. `withHostTheme` only rewrites the `dark_mode=` segment,
+ * so the param survives theme rewrites.
  */
 export function buildChartUrls(
   env: Env,
@@ -2711,7 +2719,7 @@ export function buildChartUrls(
   const imageFlag = darkMode ? "true" : "false";
   const encoded = encodeURIComponent(pubId);
   return {
-    embed_url: `${webBase}/embed/${encoded}/?dark_mode=auto`,
+    embed_url: `${webBase}/embed/${encoded}/?dark_mode=auto&showShare=true`,
     image_url: `${apiBase}/api/v1/image/${encoded}/?dark_mode=${imageFlag}`,
   };
 }

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -1149,23 +1149,47 @@ const WIDGET_HTML = `<!doctype html>
   }
 
   // The only origin the embed iframe may load. Substituted at resource-build
-  // time (see \`buildChartAppUiResourceFromOutputPubId\`) with the same
-  // \`resolvePublicBase\` origin \`buildChartUrls\` writes into \`embed_url\`, so
-  // the pin and the url cannot drift per-env. This matters more now that the
-  // iframe carries \`allow="clipboard-write"\`: the Permissions-Policy default
-  // allowlist is 'src', which follows the frame WHEREVER it navigates, and
-  // the scheme check alone would extend clipboard access to any https origin
-  // a hostile or corrupted tool result named. An unsubstituted placeholder
-  // (raw-template contexts, e.g. direct WIDGET_HTML reads in tests) keeps the
-  // scheme-only behavior rather than bricking every chart.
+  // time (see \`buildChartAppUiResourceFromOutputPubId\`) with the origin of the
+  // same \`resolvePublicBase\` value \`buildChartUrls\` writes into \`embed_url\`,
+  // so the pin and the url cannot drift per-env. This matters more now that
+  // the iframe carries \`allow="clipboard-write"\`: the Permissions-Policy
+  // default allowlist is 'src', which follows the frame WHEREVER it navigates,
+  // and the scheme check alone would extend clipboard access to any https
+  // origin a hostile or corrupted tool result named. An unsubstituted
+  // placeholder (raw-template contexts, e.g. direct WIDGET_HTML reads in
+  // tests) keeps the scheme-only behavior rather than bricking every chart.
+  //
+  // OPERATIONAL COUPLING: hosts cache this bundle BY URI and the cache is not
+  // known to invalidate on redeploy (it survives connector re-adds). So a
+  // web-origin migration (e.g. staging.trytako.com → staging.tako.com) mints
+  // new embed_urls while cached bundles keep pinning the OLD origin, and every
+  // chart silently degrades to PNG. The lever is \`WIDGET_URI_SUFFIX\`: bump it
+  // in the same deploy as any origin change, so hosts fetch a fresh bundle
+  // under a fresh URI.
   var EXPECTED_EMBED_ORIGIN = "__EXPECTED_EMBED_ORIGIN__";
-  function embedOriginOk(url) {
-    if (EXPECTED_EMBED_ORIGIN.indexOf("http") !== 0) return true;
+  function pinnedOriginOk(pin, url) {
+    if (pin.indexOf("http") !== 0) return true;
     try {
-      return new URL(url).origin === EXPECTED_EMBED_ORIGIN;
+      return new URL(url).origin === pin;
     } catch (err) {
       return false;
     }
+  }
+  function embedOriginOk(url) {
+    return pinnedOriginOk(EXPECTED_EMBED_ORIGIN, url);
+  }
+
+  // Same pin, for the native-card upgrade URL — a strictly WIDER grant than
+  // the iframe: \`upgradeToNativeCard\` fetches it and document.write()s the
+  // response into this document, where injected script runs in the widget
+  // origin. The host CSP (\`connectDomains\`) is the spec-level backstop; this
+  // is the same last-hop defense the embed pin provides. Substituted with the
+  // worker's own origin (\`resolveWidgetOrigin\`) — the origin \`nativeCardUrl\`
+  // on the server builds from — when that origin is known at resource-build
+  // time; unknown means the native path is off and the placeholder stays.
+  var EXPECTED_NATIVE_ORIGIN = "__EXPECTED_NATIVE_ORIGIN__";
+  function nativeOriginOk(url) {
+    return pinnedOriginOk(EXPECTED_NATIVE_ORIGIN, url);
   }
 
   // Rewrite \`dark_mode\` on a chart url to match the host. Leaves the url alone
@@ -1861,8 +1885,12 @@ const WIDGET_HTML = `<!doctype html>
     var probeEnabled =
       meta && typeof meta === "object" && meta.interactive_probe === true;
     // Proxied embed-page URL for the native upgrade. Absent → PNG only.
+    // Origin-pinned like the embed url, and for a stronger reason: this url
+    // gets fetched and document.write()n — see EXPECTED_NATIVE_ORIGIN.
     var nativeCardUrl =
-      meta && typeof meta === "object" && typeof meta.native_card_url === "string"
+      meta && typeof meta === "object" &&
+      typeof meta.native_card_url === "string" &&
+      nativeOriginOk(meta.native_card_url)
         ? meta.native_card_url
         : "";
     var imgNaturalW = meta && typeof meta === "object" && typeof meta.image_natural_width === "number"
@@ -2748,6 +2776,22 @@ export function buildChartUrls(
 }
 
 /**
+ * Append the card-share opt-in to an embed url that lacks it.
+ *
+ * For urls the MCP does NOT build: `cards[].embed_url` is backend passthrough
+ * (search/answer via `slimCard`, the agent verbatim), and without this the
+ * SAME top card carried the opt-in on the widget-rendered
+ * `structuredContent.embed_url` but not on the copy an agent quotes from the
+ * text — two different urls for one card. Idempotent, and a caller (or a
+ * future `showShare=false`) is left alone rather than silently overridden —
+ * same contract as the widget's `withoutTracking`.
+ */
+export function withShareOptIn(url: string): string {
+  if (url.includes("showShare=")) return url;
+  return url + (url.includes("?") ? "&" : "?") + "showShare=true";
+}
+
+/**
  * Fetch the chart PNG and return its `data:image/...;base64,...` URI
  * along with the source PNG's natural pixel dimensions. The dimensions
  * let the widget pre-size its document height (so claude.ai's outer
@@ -2917,12 +2961,26 @@ export function buildChartAppUiResource(
     // per-call URI overrides.
     uri: appUiResourceUri(env),
     name: APP_UI_RESOURCE_NAME,
-    // Pin the embed iframe to the env's public web origin — the same value
-    // `buildChartUrls` writes into `embed_url`, so the widget's origin check
-    // and the URLs it receives cannot disagree. See EXPECTED_EMBED_ORIGIN in
-    // the bundle. `resolvePublicBase` output is a validated http(s) origin
-    // with no trailing slash, so plain string substitution is safe here.
-    html: WIDGET_HTML.replace("__EXPECTED_EMBED_ORIGIN__", webBase),
+    // Pin the embed iframe to the env's public web origin — derived from the
+    // same value `buildChartUrls` writes into `embed_url`, so the widget's
+    // origin check and the URLs it receives cannot disagree. `new URL().origin`
+    // rather than the raw base: `validatePublicOrigin` tolerates a path
+    // (`https://tako.com/app` passes), and a pathed base substituted verbatim
+    // could never equal any `URL.origin`, silently degrading every chart to
+    // the PNG. The native-card pin gets the worker's own origin — the one
+    // `nativeCardUrl` builds from — when it is resolvable; otherwise the
+    // placeholder stays and the widget keeps the scheme-only check (the
+    // native path is off in that configuration anyway).
+    html: (() => {
+      const pinned = WIDGET_HTML.replace(
+        "__EXPECTED_EMBED_ORIGIN__",
+        new URL(webBase).origin,
+      );
+      const nativeOrigin = resolveWidgetOrigin(env, requestOrigin);
+      return nativeOrigin === undefined
+        ? pinned
+        : pinned.replace("__EXPECTED_NATIVE_ORIGIN__", nativeOrigin);
+    })(),
     // `frameDomains` is the host CSP's allow-list for nested iframes —
     // without the widget's parent origin in here, the host blocks
     // `<iframe src="https://tako.com/embed/...">`. Pin to exactly the

--- a/workers/src/tools/_search_results.test.ts
+++ b/workers/src/tools/_search_results.test.ts
@@ -166,6 +166,27 @@ describe("slimCardContent — drop-all mode (capRows = null)", () => {
 // card" signal (the backend's export-safe gate 403s cards without it), so
 // slimming must preserve exactly what the wire said: never fabricate a
 // descriptor on an unexportable card, never drop one from an exportable card.
+describe("slimCard — share opt-in on the passthrough embed_url", () => {
+  // cards[].embed_url is backend passthrough; without the opt-in the SAME
+  // top card carried showShare on the widget-rendered structuredContent url
+  // but not on the copy an agent quotes from the text.
+  it("appends showShare=true to a card's embed_url", () => {
+    const card: TakoCard = {
+      card_id: "c1",
+      title: "t",
+      embed_url: "https://trytako.com/embed/c1/",
+    };
+    expect(slimCard(card, null).embed_url).toBe(
+      "https://trytako.com/embed/c1/?showShare=true",
+    );
+  });
+
+  it("leaves a card without an embed_url untouched", () => {
+    const card: TakoCard = { card_id: "c1", title: "t" };
+    expect(slimCard(card, null)).not.toHaveProperty("embed_url");
+  });
+});
+
 describe("slimCard — content presence is the export-eligibility signal", () => {
   it("does not fabricate a content descriptor on a card without one (not exportable)", () => {
     const card: TakoCard = { card_id: "c1", title: "t" };

--- a/workers/src/tools/_search_results.ts
+++ b/workers/src/tools/_search_results.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
   buildChartUrls,
+  withShareOptIn,
 } from "./_chart_widget.js";
 
 // Backend ResultContent (api/ga/content_types.py) — a result's export
@@ -457,10 +458,17 @@ function orderCardKeys(card: TakoCard): TakoCard {
  */
 export const slimCard = (card: TakoCard, capRows: number | null): TakoCard => {
   const exportable = card.exportable ?? card.content != null;
+  // Share opt-in on the passthrough embed_url, so the url an agent quotes
+  // from the text matches the one the widget renders for the same card —
+  // see withShareOptIn.
+  const shared =
+    typeof card.embed_url === "string" && card.embed_url !== ""
+      ? { ...card, embed_url: withShareOptIn(card.embed_url) }
+      : card;
   const slimmed =
-    card.content == null
-      ? { ...card, exportable }
-      : { ...card, exportable, content: slimCardContent(card.content, capRows) };
+    shared.content == null
+      ? { ...shared, exportable }
+      : { ...shared, exportable, content: slimCardContent(shared.content, capRows) };
   return orderCardKeys(
     exportable ? slimmed : { ...slimmed, values_hint: valuesHint(card) },
   );

--- a/workers/src/tools/tako_agent.test.ts
+++ b/workers/src/tools/tako_agent.test.ts
@@ -23,7 +23,13 @@ describe("tako_agent", () => {
         status: "completed",
         result: {
           answer: "42",
-          cards: [],
+          cards: [
+            {
+              card_id: "agentcard",
+              title: "Agent card",
+              embed_url: "https://trytako.com/embed/agentcard/",
+            },
+          ],
           citations: [{ index: 1, title: "Source", url: "https://example.com" }],
         },
       });
@@ -43,6 +49,10 @@ describe("tako_agent", () => {
     expect(out.status).toBe("completed");
     expect(out.timed_out).toBe(false);
     expect(out.result?.answer).toBe("42");
+    // Passthrough cards pick up the share opt-in — see withShareOptIn.
+    expect(out.result?.cards[0]?.embed_url).toBe(
+      "https://trytako.com/embed/agentcard/?showShare=true",
+    );
     // The Answer Agent's unified citation registry flows through (replacing the
     // generic agent's web_results).
     expect(out.result?.citations).toHaveLength(1);

--- a/workers/src/tools/tako_agent.ts
+++ b/workers/src/tools/tako_agent.ts
@@ -28,6 +28,7 @@ import {
   AnswerAgentRun as AnswerAgentRunContract,
   AnswerAgentRunRequest,
 } from "../generated/schemas.js";
+import { withShareOptIn } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
 import {
@@ -235,6 +236,24 @@ export async function pollAgentRun(
   let pollCount = 0;
   let lastRun: AgentRun | undefined;
 
+  // Share opt-in on the passthrough card embed_urls, so the url an agent
+  // quotes into its answer matches the one every other surface serves for
+  // the same card — see withShareOptIn in _chart_widget.ts.
+  const withSharedCards = (run: AgentRun): AgentRun =>
+    run.result == null || run.result.cards.length === 0
+      ? run
+      : {
+          ...run,
+          result: {
+            ...run.result,
+            cards: run.result.cards.map((c) =>
+              typeof c.embed_url === "string" && c.embed_url !== ""
+                ? { ...c, embed_url: withShareOptIn(c.embed_url) }
+                : c,
+            ),
+          },
+        };
+
   while (true) {
     let wire: AgentRunWire;
     try {
@@ -316,11 +335,11 @@ export async function pollAgentRun(
       logWireGuardFailure("tako_agent", "output-normalise", parsed.error, wire);
       throw new Error("Tako agent run endpoint returned an unexpected shape.");
     }
-    lastRun = parsed.data;
+    lastRun = withSharedCards(parsed.data);
     pollCount += 1; // MCP requires progress to strictly increase per token.
     await ctx.sendProgress(pollCount, { message: `Agent running… (${parsed.data.status})` });
     if (parsed.data.status === "completed" || parsed.data.status === "failed") {
-      return { ...parsed.data, timed_out: false };
+      return { ...lastRun, timed_out: false };
     }
     // Budget check: stop before the next poll would land past the deadline.
     // Worst case the loop still overruns budgetMs by up to

--- a/workers/src/tools/tako_search.test.ts
+++ b/workers/src/tools/tako_search.test.ts
@@ -372,7 +372,7 @@ describe("tako_search response mapping", () => {
     expect(out.pub_id).toBe("aapl-price");
     expect(out.guidance).toBeUndefined();
     expect(out.embed_url).toBe(
-      "https://staging.trytako.com/embed/aapl-price/?dark_mode=auto",
+      "https://staging.trytako.com/embed/aapl-price/?dark_mode=auto&showShare=true",
     );
     expect(out.image_url).toBe(
       "https://staging.trytako.com/api/v1/image/aapl-price/?dark_mode=true",

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -181,6 +181,25 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     expect(renderedIframe(m)).toBe(true);
   });
 
+  it("PIN: refuses to commit the iframe to a non-Tako origin", () => {
+    // The iframe carries allow="clipboard-write" and the Permissions-Policy
+    // default allowlist ('src') follows the frame wherever it navigates. So
+    // the widget must not hand the frame — and with it, clipboard access —
+    // to whatever https origin a corrupted tool result names. Scheme checks
+    // alone pass this URL; the EXPECTED_EMBED_ORIGIN pin is what refuses it.
+    const m = mountWidget(html(), {
+      toolOutput: {
+        ...PROD_STRUCTURED_CONTENT,
+        embed_url: `https://evil.example/embed/${PUB_ID}/?dark_mode=auto`,
+      },
+    });
+    expect(renderedIframe(m)).toBe(false);
+    const src = frame(m).getAttribute("src");
+    expect(src ?? "").not.toContain("evil.example");
+    // The card still renders — it falls back to the PNG path.
+    expect(img(m).getAttribute("src")).toBe(IMAGE_URL);
+  });
+
   it("EMPTY: a chart-less toolOutput labels the card ChatGPT keeps anyway", () => {
     // The host this was reported on. ChatGPT mounts the widget from static
     // `openai/outputTemplate` registration metadata, so a zero-card search

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -22,7 +22,7 @@ import { buildChartAppUiResourceFromOutputPubId } from "../../src/tools/_chart_w
 const ENV: Env = { DJANGO_BASE_URL: "https://tako.com" };
 
 const PUB_ID = "VKd7qE8K9Ba16kMFENNQ";
-const EMBED_URL = `https://tako.com/embed/${PUB_ID}/?dark_mode=auto`;
+const EMBED_URL = `https://tako.com/embed/${PUB_ID}/?dark_mode=auto&showShare=true`;
 const IMAGE_URL = `https://tako.com/api/v1/image/${PUB_ID}/?dark_mode=true`;
 
 // Verbatim shape of prod's structuredContent (cards/web_results elided).

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -29,7 +29,8 @@ import {
 
 const ENV: Env = { DJANGO_BASE_URL: "https://staging.trytako.com" };
 
-const EMBED_URL = "https://staging.trytako.com/embed/abc123/?dark_mode=auto";
+const EMBED_URL =
+  "https://staging.trytako.com/embed/abc123/?dark_mode=auto&showShare=true";
 // What the widget must actually put in an `iframe.src`: the same embed url with
 // analytics suppressed. `withoutTracking` in `_chart_widget.ts` appends it to
 // every in-widget iframe load — OpenAI's iframe policy singles out tracking
@@ -956,6 +957,37 @@ describe("native card upgrade (executed)", () => {
     // The PNG is the committed baseline BEFORE any fetch happens.
     expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
     expect(f.calls).toEqual([]);
+    fireImageLoad(m);
+    expect(f.calls).toEqual([NATIVE_URL]);
+  });
+
+  it("PIN: refuses to fetch a native card from a foreign origin", () => {
+    // upgradeToNativeCard document.write()s the response into the widget's
+    // own document — a wider grant than the pinned iframe's clipboard-write.
+    // With the bundle built for a known worker origin, a native_card_url on
+    // any other origin must never be fetched; the PNG stays.
+    const html = buildChartAppUiResourceFromOutputPubId(
+      ENV,
+      "https://mcp.example.test",
+    ).html;
+    const m = mountWidget(html);
+    const f = stubFetch(m, () => htmlResponse(NATIVE_HTML));
+    deliverNative(m, "https://evil.example/embed-html/abc123");
+    fireImageLoad(m);
+    expect(f.calls).toEqual([]);
+    expect(widgetImg(m).getAttribute("src")).toBe(DATA_URL);
+  });
+
+  it("PIN: still fetches from the pinned worker origin", () => {
+    // Positive control for the refusal above — the pin admits the origin the
+    // server actually builds native_card_url from.
+    const html = buildChartAppUiResourceFromOutputPubId(
+      ENV,
+      "https://mcp.example.test",
+    ).html;
+    const m = mountWidget(html);
+    const f = stubFetch(m, () => htmlResponse(NATIVE_HTML));
+    deliverNative(m);
     fireImageLoad(m);
     expect(f.calls).toEqual([NATIVE_URL]);
   });


### PR DESCRIPTION
## What this does

Tako's embed page grew an opt-in share control in TakoData/tako#28735 — a trigger in the card's top-right action cluster opening a dialog with copyable embed/card links. It shipped inert: nothing renders unless the embedding URL carries `?showShare=true`, and that PR's own words were "Enabling it is one line in TakoData/tako-mcp." This is that line, plus the clipboard delegation the dialog needs.

- `buildChartUrls` now appends `&showShare=true` to `embed_url`. It is the choke point for every URL the widget renders: search/answer top-card widget fields, `tako_visualize`, the baked per-pub_id widget resource, and the probe/commit iframe. Per-card `embed_url`s inside the `cards` array (markdown listings, structured output) are backend passthrough and unchanged — only the rendered card opts in. `withHostTheme` rewrites only the `dark_mode=` segment, so the param survives theme rewrites.
- The widget's embed iframe gains `allow="fullscreen; clipboard-write"`. The share dialog copies via `navigator.clipboard.writeText`, which needs every ancestor frame to delegate `clipboard-write`; this is the one hop we own.

## What stays PNG / share-less, by design

The embed page hard-suppresses the control even when opted in — auth-gated cards (both links would 401 for a recipient), glanceable tiles, white-label embeds, `?screenshot=true` renders, and data-less postMessage shells. The native-card `document.write` path (claude.ai's interactive card) cannot show it *yet*: every gate (`isShareShown`, `getCardPubId`) and the dialog's URL builder (`canonicalOrigin`) reads `window.location`, which in that path is the widget sandbox URL, not `/embed/<id>/`. This PR already carries the opt-in on the proxy's upstream fetch — inert until a small tako-repo follow-up bakes the param, the pub_id, and the canonical origin into `json_script` islands the gates can fall back on. Once that tako PR lands, the share CONTROL lights up on claude.ai with no further change here; the copy action there depends on claude.ai's own sandbox delegating `clipboard-write` (the widget's iframe `allow` doesn't apply to the document.write path — there is no nested frame), with the dialog's select-and-copy fallback otherwise.

## Verified live

- Prod already serves the share machinery (the `card-require-auth` json_script is in the live embed HTML), so this is not gated on a backend deploy.
- Headless check on a real prod card: with `?showShare=true` a "Share this card" button renders and the dialog offers the embed and card links; without the param, zero share elements.
- End-to-end on chatgpt.com through a dev tunnel: interactive card renders with the share control; both links present and correct.
- Clipboard: ChatGPT's sandbox does not delegate `clipboard-write`, so the dialog lands on its designed fallback — the URL pre-selects and the button shows the ⌘C hint. That rejection happens at OpenAI's hop; ours no longer blocks anything.

## Tests

`buildChartUrls` gets direct unit coverage (exact `embed_url`/`image_url` shapes, param kept off the PNG url), the widget HTML is asserted to carry the `clipboard-write` delegation, and the search-tool integration expectation pins the full URL. All three vitest configs pass (37 + 3 + 4 files), typecheck clean across all four tsconfig projects.

## Test plan

- [ ] CI green
- [ ] After staging deploy: ask claude.ai (staging connector) for a chart → interactive card shows "Share this card"; dialog links open the right card
- [ ] Confirm a glanceable single-answer card still renders without the control
- [ ] Spot-check an `embed_url` from tool text output opens with the share control in a plain browser tab


