### PR TITLE
feat(mcp): recognize the ChatGPT desktop app (codex client) as ChatGPT family

### DIFF
--- a/workers/scripts/gen-registry.ts
+++ b/workers/scripts/gen-registry.ts
@@ -290,6 +290,35 @@ export function assertChatgptSubmissionParity(
     }
   }
 
+  // The submission covers the ChatGPT PRODUCT, and the product has two MCP
+  // transports: chatgpt.com's connector AND the desktop app (detected as
+  // "codex"). Every surface equality above is asserted against "chatgpt"
+  // only, so without this block a revert of codex's family/widget
+  // membership (e.g. dropping it from `isChatGptFamilyClient`) would leave
+  // `registry:check` green while the desktop app lists a DIFFERENT tool set
+  // than the submission declares — review finding on PR #239. Equality of
+  // the two members' surfaces at both tiers is exactly "the family shares
+  // one surface", which is the premise the submission rests on.
+  for (const tier of ["authenticated", "free"] as const) {
+    const chatgptSurface = tools
+      .filter((t) => isToolOnSurface(t.name, "chatgpt", noOptIns, tier))
+      .map((t) => t.name)
+      .sort();
+    const codexSurface = tools
+      .filter((t) => isToolOnSurface(t.name, "codex", noOptIns, tier))
+      .map((t) => t.name)
+      .sort();
+    if (JSON.stringify(codexSurface) !== JSON.stringify(chatgptSurface)) {
+      problems.push(
+        `codex (ChatGPT desktop app) ${tier} surface [${codexSurface.join(
+          ", ",
+        )}] diverges from chatgpt's [${chatgptSurface.join(
+          ", ",
+        )}] — the submission describes the ChatGPT product, which includes the desktop app; restore family membership in workers/src/tools/_surface.ts`,
+      );
+    }
+  }
+
   const HINT_KEYS = ["readOnlyHint", "openWorldHint", "destructiveHint"] as const;
   for (const [name, resolved] of expected) {
     const declared = declaredTools[name];

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -468,16 +468,13 @@ describe("worker routing", () => {
     }
   });
 
-  it("POST /mcp tools/list serves the codex desktop app the family surface, without the widget", async () => {
-    // End-to-end pin for the ChatGPT desktop app (codex runtime): it gets
-    // the ChatGPT-family treatment — securitySchemes injection included —
-    // but NOT the widget `_meta` and NOT default-on tako_visualize, both
-    // of which are gated on `isWidgetClient` until tako.com's
-    // `frame-ancestors` allows `codex-sandbox:` AND the flip is validated
-    // live (see isChatGptFamilyClient's flip checklist). Without this
-    // test, reverting any single `isChatGptFamilyClient` call site back
-    // to `client === "chatgpt"` passes the whole suite while silently
-    // degrading the desktop app to the 3-tool unknown surface.
+  it("POST /mcp tools/list serves the codex desktop app the family surface, with the widget", async () => {
+    // End-to-end pin for the ChatGPT desktop app (codex runtime) AFTER
+    // the widget flip: full ChatGPT-family treatment — securitySchemes
+    // injection, default-on tako_visualize, and widget `_meta` — exactly
+    // mirroring chatgpt.com. Without this test, reverting any single
+    // `isChatGptFamilyClient`/`isWidgetClient` call site passes the
+    // whole suite while silently degrading the desktop app.
     const res = await SELF.fetch("https://example.com/mcp", {
       method: "POST",
       headers: {
@@ -504,23 +501,28 @@ describe("worker routing", () => {
         }>;
       };
     };
-    // Family surface minus the widget-gated visualize (default-on rides
-    // `isWidgetClient`, which codex has not joined yet).
+    // Full family surface, identical to chatgpt.com: visualize is
+    // default-on because codex is a widget client after the flip.
     expect(body.result.tools.map((t) => t.name).sort()).toEqual([
       "tako_answer",
       "tako_available_data",
       "tako_contents",
       "tako_search",
+      "tako_visualize",
     ]);
     const oauth2 = { type: "oauth2", scopes: ["mcp"] };
+    const widgetOwners = new Set([
+      "tako_answer",
+      "tako_search",
+      "tako_visualize",
+    ]);
     for (const t of body.result.tools) {
       // The family injection reaches codex descriptors...
       expect(t.securitySchemes, t.name).toEqual([oauth2]);
-      // ...but widget `_meta` must not: a codex widget iframe is blocked
-      // by tako.com's frame-ancestors until the backend deploy, and
-      // widget `_meta` suppresses the inline PNG the app renders today.
-      expect(t._meta?.["openai/outputTemplate"], t.name).toBeUndefined();
-      expect(t._meta?.["ui"], t.name).toBeUndefined();
+      // ...and the chart tools carry the widget `_meta` chatgpt.com gets.
+      if (widgetOwners.has(t.name)) {
+        expect(t._meta?.["openai/outputTemplate"], t.name).toBeDefined();
+      }
     }
   });
 

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -374,9 +374,9 @@ describe("worker routing", () => {
       expect(t._meta?.["com.tako/securitySchemes"]).toEqual([
         { type: "oauth2", scopes: ["mcp"] },
       ]);
-      // The top-level `securitySchemes` field is a ChatGPT-only
+      // The top-level `securitySchemes` field is a ChatGPT-family
       // compatibility injection (`withChatGptToolSecuritySchemes`) — this
-      // request has no User-Agent, so non-ChatGPT descriptors must NOT
+      // request has no User-Agent, so non-family descriptors must NOT
       // carry it.
       expect(
         (t as { securitySchemes?: unknown }).securitySchemes,
@@ -418,8 +418,9 @@ describe("worker routing", () => {
     // ChatGPT's Apps SDK reads `securitySchemes` at the descriptor TOP
     // LEVEL (developers.openai.com/apps-sdk/build/auth). The MCP SDK
     // drops unknown descriptor fields, so `handleMcpRequest` injects the
-    // field into the buffered response for ChatGPT clients only
-    // (`withChatGptToolSecuritySchemes`).
+    // field into the buffered response for ChatGPT-family clients only
+    // (`withChatGptToolSecuritySchemes` — chatgpt.com and the desktop
+    // app's codex runtime).
     const res = await SELF.fetch("https://example.com/mcp", {
       method: "POST",
       headers: {
@@ -464,6 +465,62 @@ describe("worker routing", () => {
     const oauth2 = { type: "oauth2", scopes: ["mcp"] };
     for (const t of body.result.tools) {
       expect(t.securitySchemes, t.name).toEqual([oauth2]);
+    }
+  });
+
+  it("POST /mcp tools/list serves the codex desktop app the family surface, without the widget", async () => {
+    // End-to-end pin for the ChatGPT desktop app (codex runtime): it gets
+    // the ChatGPT-family treatment — securitySchemes injection included —
+    // but NOT the widget `_meta` and NOT default-on tako_visualize, both
+    // of which are gated on `isWidgetClient` until tako.com's
+    // `frame-ancestors` allows `codex-sandbox:` AND the flip is validated
+    // live (see isChatGptFamilyClient's flip checklist). Without this
+    // test, reverting any single `isChatGptFamilyClient` call site back
+    // to `client === "chatgpt"` passes the whole suite while silently
+    // degrading the desktop app to the 3-tool unknown surface.
+    const res = await SELF.fetch("https://example.com/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: AUTH_HEADER,
+        "user-agent": "codex-mcp-client/0.148.0-alpha.9",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: {
+        tools: Array<{
+          name: string;
+          _meta?: Record<string, unknown>;
+          securitySchemes?: Array<{ type: string; scopes?: string[] }>;
+        }>;
+      };
+    };
+    // Family surface minus the widget-gated visualize (default-on rides
+    // `isWidgetClient`, which codex has not joined yet).
+    expect(body.result.tools.map((t) => t.name).sort()).toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_contents",
+      "tako_search",
+    ]);
+    const oauth2 = { type: "oauth2", scopes: ["mcp"] };
+    for (const t of body.result.tools) {
+      // The family injection reaches codex descriptors...
+      expect(t.securitySchemes, t.name).toEqual([oauth2]);
+      // ...but widget `_meta` must not: a codex widget iframe is blocked
+      // by tako.com's frame-ancestors until the backend deploy, and
+      // widget `_meta` suppresses the inline PNG the app renders today.
+      expect(t._meta?.["openai/outputTemplate"], t.name).toBeUndefined();
+      expect(t._meta?.["ui"], t.name).toBeUndefined();
     }
   });
 

--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { Env } from "./env.js";
 import worker from "./index.js";
@@ -524,6 +524,77 @@ describe("worker routing", () => {
         expect(t._meta?.["openai/outputTemplate"], t.name).toBeDefined();
       }
     }
+  });
+
+  it("POST /mcp tools/list keeps the anonymous codex listing on the family surface, not unknown's", async () => {
+    // The authenticated codex pin above cannot distinguish "codex resolved
+    // as ChatGPT family" from "codex fell to `unknown`" by names alone on
+    // the free tier's opposite failure: an ANONYMOUS `unknown` listing is
+    // the three free-tier tools, while an anonymous FAMILY listing keeps
+    // the auth-gated submitted tools visible for the link-account
+    // affordance (`CHATGPT_ANONYMOUS_DISCOVERABLE_TOOL_NAMES`). So this is
+    // the request shape where a `detectMcpClient` regression for the
+    // desktop app is VISIBLE as a listing diff — pin it. (Review finding
+    // on PR #239: the authenticated assertion alone also matched the
+    // authenticated no-UA surface.)
+    //
+    // The suite's worker env deliberately leaves the free-tier bindings
+    // unset so every other test exercises the fail-closed 401, and `SELF`'s
+    // bindings can't be changed per-test — so this dispatches the handler
+    // directly with an env where all three free-tier bindings exist
+    // (key + both limiters; freetier.ts activates only on the full set).
+    const allow: RateLimit = { limit: async () => ({ success: true }) };
+    const freeTierEnv: Env = {
+      ...(env as Env),
+      FREE_TIER_API_KEY: "free-tier-test-key",
+      FREE_TIER_RATE_LIMITER: allow,
+      FREE_TIER_GLOBAL_RATE_LIMITER: allow,
+    };
+    const listTools = async (userAgent?: string) => {
+      const res = await worker.fetch(
+        new Request("https://example.com/mcp", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            accept: "application/json, text/event-stream",
+            // No authorization header: tier resolves to "free".
+            ...(userAgent === undefined ? {} : { "user-agent": userAgent }),
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list",
+            params: {},
+          }),
+        }),
+        freeTierEnv,
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        result: { tools: Array<{ name: string }> };
+      };
+      return body.result.tools.map((t) => t.name).sort();
+    };
+
+    // Anonymous desktop app: full family listing — the free-tier trio plus
+    // the two auth-gated tools that must stay listed pre-link so the host
+    // can offer sign-in from the descriptor.
+    expect(await listTools("codex-mcp-client/0.148.0-alpha.9")).toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_contents",
+      "tako_search",
+      "tako_visualize",
+    ]);
+    // Same request with an unrecognized UA: the anonymous surface shrinks
+    // to the free-tier trio. This contrast is what makes the codex
+    // assertion above meaningful — the two listings differ, so a
+    // classifier miss fails here instead of degrading silently.
+    expect(await listTools("some-unknown-agent/1.0")).toEqual([
+      "tako_answer",
+      "tako_available_data",
+      "tako_search",
+    ]);
   });
 
   it("POST /mcp tools/list declares the chart widget _meta for claude clients", async () => {

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -52,6 +52,16 @@ describe("detectMcpClient", () => {
     expect(detectMcpClient("")).toBe("unknown");
     expect(detectMcpClient("curl/8.4.0")).toBe("unknown");
   });
+
+  it("maps the ChatGPT desktop app's runtime to codex", () => {
+    // The merged desktop app (Chat/Work threads, Codex tasks, and the
+    // headless CLI) all connect through one client — verified live
+    // 2026-08-13 on 0.147.0-alpha.6.6 and 0.148.0-alpha.9.
+    expect(detectMcpClient("codex-mcp-client/0.148.0-alpha.9")).toBe("codex");
+    // The codex check must beat the broad `openai` substring match, so a
+    // future OpenAI-branded rename keeps codex-specific widget handling.
+    expect(detectMcpClient("openai-codex/1.0")).toBe("codex");
+  });
 });
 
 describe("toolAnnotationsForClient", () => {

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -1130,12 +1130,12 @@ describe("withChatGptToolSecuritySchemes", () => {
     const res = new Response("event: message\ndata: {}\n\n", {
       headers: { "content-type": "text/event-stream" },
     });
-    expect(await withChatGptToolSecuritySchemes(res, "authenticated")).toBe(res);
+    expect(await withChatGptToolSecuritySchemes(res, "authenticated", "chatgpt")).toBe(res);
   });
 
   it("returns the original response when the body is not valid JSON (body stays readable)", async () => {
     const res = new Response("{not json", { headers: JSON_CT });
-    const out = await withChatGptToolSecuritySchemes(res, "authenticated");
+    const out = await withChatGptToolSecuritySchemes(res, "authenticated", "chatgpt");
     expect(out).toBe(res);
     // The adapter reads a clone — the original body must not be consumed.
     await expect(out.text()).resolves.toBe("{not json");
@@ -1146,7 +1146,7 @@ describe("withChatGptToolSecuritySchemes", () => {
       JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }),
       { headers: JSON_CT },
     );
-    expect(await withChatGptToolSecuritySchemes(res, "authenticated")).toBe(res);
+    expect(await withChatGptToolSecuritySchemes(res, "authenticated", "chatgpt")).toBe(res);
   });
 
   it("rewrites tools/list, drops the stale content-length, and keeps status", async () => {
@@ -1159,7 +1159,7 @@ describe("withChatGptToolSecuritySchemes", () => {
       status: 200,
       headers: { ...JSON_CT, "content-length": String(body.length) },
     });
-    const out = await withChatGptToolSecuritySchemes(res, "free");
+    const out = await withChatGptToolSecuritySchemes(res, "free", "chatgpt");
     expect(out).not.toBe(res);
     expect(out.status).toBe(200);
     expect(out.headers.get("content-length")).toBeNull();
@@ -1180,7 +1180,7 @@ describe("withChatGptToolSecuritySchemes", () => {
       result: { tools: [{ name: "tako_search" }] },
     });
     const res = new Response(body, { headers: JSON_CT });
-    const out = await withChatGptToolSecuritySchemes(res, "authenticated");
+    const out = await withChatGptToolSecuritySchemes(res, "authenticated", "chatgpt");
     const json = (await out.json()) as {
       result: { tools: Array<{ securitySchemes?: unknown }> };
     };

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -608,26 +608,22 @@ describe("chart render gates per client", () => {
     ).toBeDefined();
   });
 
-  it("codex client: chart ships as an inline image content block, NO widget metadata", async () => {
-    // THE staged-rollout pin (adversarial review, PR #239): the desktop
-    // app's `enable_mcp_apps` flag is off for almost all users and the
-    // same UA covers the headless Codex CLI — for both, widget `_meta`
-    // would suppress this image block (the mutual-exclusion gate) and
-    // the chart would vanish from the chat entirely. Codex therefore
-    // keeps the unknown-style PNG until the flip is validated live.
-    // Measured 2026-08-13: a widget-classified codex build returned
-    // [text] only, vs [text, image] for unknown — this test exists so
-    // that regression can never ship silently again.
-    mockFetchSequence([searchResponse(), pngResponse()]);
+  it("codex client: widget metadata ships, no image block, and no PNG prefetch", async () => {
+    // THE FLIP (supersedes PR #239's staged pin): codex now mirrors
+    // chatgpt exactly — widget `_meta`, no image content block, no PNG
+    // prefetch. KNOWN COSTS accepted by this flip, do not merge until
+    // they are answered live (see the draft PR's open questions):
+    // flag-off desktop users and the headless Codex CLI lose the inline
+    // PNG this result used to carry (measured 2026-08-13: [text] only vs
+    // [text, image] for unknown).
+    mockFetchSequence([searchResponse()]);
 
     const result = await callSearch("codex");
 
-    const imageBlocks = result.content.filter((b) => b.type === "image");
-    expect(imageBlocks).toHaveLength(1);
-    expect(imageBlocks[0]?.mimeType).toBe("image/png");
+    expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
     expect(
       (result._meta as { ui?: unknown } | undefined)?.ui,
-    ).toBeUndefined();
+    ).toBeDefined();
   });
 
   it("claude client: no image block when the search returns zero cards", async () => {

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -608,6 +608,28 @@ describe("chart render gates per client", () => {
     ).toBeDefined();
   });
 
+  it("codex client: chart ships as an inline image content block, NO widget metadata", async () => {
+    // THE staged-rollout pin (adversarial review, PR #239): the desktop
+    // app's `enable_mcp_apps` flag is off for almost all users and the
+    // same UA covers the headless Codex CLI — for both, widget `_meta`
+    // would suppress this image block (the mutual-exclusion gate) and
+    // the chart would vanish from the chat entirely. Codex therefore
+    // keeps the unknown-style PNG until the flip is validated live.
+    // Measured 2026-08-13: a widget-classified codex build returned
+    // [text] only, vs [text, image] for unknown — this test exists so
+    // that regression can never ship silently again.
+    mockFetchSequence([searchResponse(), pngResponse()]);
+
+    const result = await callSearch("codex");
+
+    const imageBlocks = result.content.filter((b) => b.type === "image");
+    expect(imageBlocks).toHaveLength(1);
+    expect(imageBlocks[0]?.mimeType).toBe("image/png");
+    expect(
+      (result._meta as { ui?: unknown } | undefined)?.ui,
+    ).toBeUndefined();
+  });
+
   it("claude client: no image block when the search returns zero cards", async () => {
     // Empty result → no top card → no image_url → `extraMeta`'s PNG
     // prefetch must not fire (queue holds only the search response; an
@@ -1035,26 +1057,34 @@ describe("auth challenges (ChatGPT link-account flow)", () => {
     expect(result._meta?.["mcp/www_authenticate"]).toBeUndefined();
   });
 
-  it("a Django 401 on ChatGPT attaches the reauth challenge to the mapped error", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => jsonResponse(401, { detail: "Invalid API key." })),
-    );
-    const result = await callTool(
-      { client: "chatgpt", requestOrigin: "https://mcp.example.com" },
-      "tako_search",
-      { query: "US GDP" },
-    );
-    expect(result.isError).toBe(true);
-    const challenges = result._meta?.["mcp/www_authenticate"] as string[];
-    expect(challenges).toHaveLength(1);
-    expect(challenges[0]).toContain('error="invalid_token"');
-    expect(challenges[0]).toContain("error_description=");
-    // The existing structured error detail is preserved alongside.
-    expect(
-      (result._meta?.["tako/error"] as { kind?: string } | undefined)?.kind,
-    ).toBe("unauthorized");
-  });
+  it.each(["chatgpt", "codex"] as const)(
+    "a Django 401 on %s attaches the reauth challenge to the mapped error",
+    async (client) => {
+      // Parameterized over the ChatGPT family: the desktop app's
+      // link-account re-auth flow keys on the same
+      // `_meta["mcp/www_authenticate"]` field (isChatGptFamilyClient gate
+      // in registerTool). A revert of that gate to `=== "chatgpt"` would
+      // pass a chatgpt-only version of this test.
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => jsonResponse(401, { detail: "Invalid API key." })),
+      );
+      const result = await callTool(
+        { client, requestOrigin: "https://mcp.example.com" },
+        "tako_search",
+        { query: "US GDP" },
+      );
+      expect(result.isError).toBe(true);
+      const challenges = result._meta?.["mcp/www_authenticate"] as string[];
+      expect(challenges).toHaveLength(1);
+      expect(challenges[0]).toContain('error="invalid_token"');
+      expect(challenges[0]).toContain("error_description=");
+      // The existing structured error detail is preserved alongside.
+      expect(
+        (result._meta?.["tako/error"] as { kind?: string } | undefined)?.kind,
+      ).toBe("unauthorized");
+    },
+  );
 
   it("a Django 401 on the FREE tier does not claim the caller's session expired", async () => {
     // On free tier the rejected credential is the SHARED free-tier key,

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -1738,8 +1738,11 @@ export async function withChatGptToolSecuritySchemes(
   // but it made codex traffic log as chatgpt — hiding codex adoption and
   // codex UA drift from `wrangler tail` — and would silently misroute the
   // day the two family members diverge in `securitySchemesForTool`.
-  // Defaulted for existing tests; production passes the detected kind.
-  client: McpClientKind = "chatgpt",
+  // REQUIRED (no `= "chatgpt"` default): the schemes body is byte-identical
+  // for the two family members today, so nothing asserts this argument —
+  // a default would let a revert to a hardcoded kind pass the whole suite
+  // while silently flattening the log line's client dimension.
+  client: McpClientKind,
 ): Promise<Response> {
   try {
     const contentType = response.headers.get("content-type") ?? "";

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -52,6 +52,7 @@ import {
   wwwAuthenticate,
 } from "./tools/_security.js";
 import {
+  annotationClientFamily,
   isChatGptFamilyClient,
   isToolOnSurface,
   isWidgetClient,
@@ -231,9 +232,16 @@ const JSON_SCHEMA_VALIDATOR = new CfWorkerJsonSchemaValidator();
  * image branch, since claude.ai's host-side CSP ignores declared
  * `frameDomains` and the widget's runtime `window.openai` check falls
  * back to the static image there) while unknown clients fall back to
- * the inline PNG `image` content block, and routing ChatGPT through
- * the agent split pair (its Apps SDK doesn't reset tool-call timeouts
- * on progress notifications).
+ * the inline PNG `image` content block, and routing the ChatGPT FAMILY
+ * (chatgpt.com and the desktop app's codex runtime — see
+ * `isChatGptFamilyClient`) through the agent split pair (the Apps SDK
+ * doesn't reset tool-call timeouts on progress notifications).
+ *
+ * INVARIANT: the detected kind is presentation/routing metadata only —
+ * it must NEVER feed an authorization decision. The UA is
+ * caller-controlled; execution gating keys on tier/token (see the
+ * free-tier dispatch gate in `registerTool`), so a spoofed UA can widen
+ * what a connection SEES, never what it can EXECUTE.
  *
  * The match is intentionally loose: we don't care about exact UA
  * strings, just whether the request smells like one of the major
@@ -696,8 +704,15 @@ function registerTool(
   // self-identifying its host — empirically unreliable, since the
   // model has no first-class signal beyond the description text
   // itself.
+  // Resolved through `annotationClientFamily` (not the raw kind) so a
+  // `chatgpt:` override reaches the whole ChatGPT family — the desktop app
+  // (`"codex"`) must see the same descriptions as chatgpt.com, the same way
+  // it already resolves the same annotations. Reading `options.client`
+  // directly here would silently exempt codex from the first
+  // `descriptionByClient` override any tool adds.
   const description =
-    tool.descriptionByClient?.[options.client] ?? tool.description;
+    tool.descriptionByClient?.[annotationClientFamily(options.client)] ??
+    tool.description;
   const config: Record<string, unknown> = {
     title: tool.annotations.title,
     description,
@@ -1575,9 +1590,10 @@ export async function handleMcpRequest(
     const url = new URL(request.url);
     const requestOrigin = url.origin;
     // Detect calling client from User-Agent so we can route the chart
-    // widget to ChatGPT and Claude (unknown clients fall back to the
-    // inline PNG) and route ChatGPT through the agent split pair. See
-    // `detectMcpClient` for the matching rules.
+    // widget to widget clients (see `isWidgetClient`; unknown clients
+    // fall back to the inline PNG) and route the ChatGPT family — both
+    // chatgpt.com and the desktop app — through the agent split pair.
+    // See `detectMcpClient` for the matching rules.
     const userAgent = request.headers.get("user-agent");
     const client = detectMcpClient(userAgent);
     // Log the RAW User-Agent next to the kind it resolved to, once per
@@ -1657,7 +1673,7 @@ export async function handleMcpRequest(
       // (`"codex"`) reads the same field for its connector link-account
       // flow. Every other client gets the SDK's response untouched.
       return isChatGptFamilyClient(client)
-        ? await withChatGptToolSecuritySchemes(response, tier)
+        ? await withChatGptToolSecuritySchemes(response, tier, client)
         : response;
     } finally {
       // TODO(Phase 2): revisit this unconditional close.
@@ -1715,24 +1731,33 @@ export async function handleMcpRequest(
 export async function withChatGptToolSecuritySchemes(
   response: Response,
   tier: Tier,
+  // The DETECTED client, threaded through so the scheme derivation and the
+  // log line below carry the real kind. Hardcoding "chatgpt" here was
+  // functionally identical (the caller already gates on the ChatGPT
+  // family, and `securitySchemesForTool` branches on the same predicate)
+  // but it made codex traffic log as chatgpt — hiding codex adoption and
+  // codex UA drift from `wrangler tail` — and would silently misroute the
+  // day the two family members diverge in `securitySchemesForTool`.
+  // Defaulted for existing tests; production passes the detected kind.
+  client: McpClientKind = "chatgpt",
 ): Promise<Response> {
   try {
     const contentType = response.headers.get("content-type") ?? "";
     if (!contentType.includes("application/json")) return response;
     const body = (await response.clone().json()) as unknown;
     const transformed = withToolSecuritySchemes(body, {
-      client: "chatgpt",
+      client,
       tier,
     });
     if (transformed === body) return response;
     // Positive rollout/observability signal: this line appearing in
-    // `wrangler tail` proves the UA resolved to chatgpt AND the
-    // injection ran. Its ABSENCE while ChatGPT sign-in misbehaves points
-    // straight at `detectMcpClient` (e.g. a connector UA change) —
+    // `wrangler tail` proves the UA resolved to a ChatGPT-family client
+    // AND the injection ran. Its ABSENCE while ChatGPT sign-in misbehaves
+    // points straight at `detectMcpClient` (e.g. a connector UA change) —
     // without it, a UA miss is indistinguishable from "ChatGPT changed
     // something" (review finding on PR #183).
     console.log(
-      `[mcp] tools/list securitySchemes injected client=chatgpt tier=${tier}`,
+      `[mcp] tools/list securitySchemes injected client=${client} tier=${tier}`,
     );
     const headers = new Headers(response.headers);
     // The rewritten body has a different byte length; let the runtime

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -52,6 +52,7 @@ import {
   wwwAuthenticate,
 } from "./tools/_security.js";
 import {
+  isChatGptFamilyClient,
   isToolOnSurface,
   isWidgetClient,
   toolAnnotationsForClient,
@@ -273,6 +274,16 @@ export function detectMcpClient(userAgent: string | null): McpClientKind {
   // pinned. If it sends `Claude-User` it is indistinguishable from
   // claude.ai here and gets widget `_meta` it cannot render.
   if (ua.includes("claude") || ua.includes("anthropic")) return "claude";
+  // The merged ChatGPT desktop app's runtime — one MCP client for desktop
+  // Chat/Work threads, Codex tasks, and the headless CLI — sends
+  // `codex-mcp-client/<version>` (verified live 2026-08-13 against
+  // 0.147.0-alpha.6.6 and 0.148.0-alpha.9; the name is pinned in
+  // openai/codex `codex-rs/rmcp-client/src/utils.rs`). Must run BEFORE the
+  // ChatGPT block: today's UA contains neither `chatgpt` nor `openai`, but
+  // an OpenAI-branded rename (e.g. `openai-codex/…`) would otherwise be
+  // swallowed by the `openai` substring match and lose the codex-specific
+  // widget handling.
+  if (ua.includes("codex")) return "codex";
   // ChatGPT's Apps SDK connector typically advertises `ChatGPT-User`,
   // `openai-mcp`, or similar in UA. OpenAI's published crawler/agent UAs
   // (`GPTBot`, `OAI-SearchBot`) contain neither substring, so match them
@@ -476,7 +487,8 @@ export function createMcpServer(
       tier,
       origin: options.requestOrigin,
       widgetSuppressedForTool:
-        client === "chatgpt" && CHATGPT_NO_WIDGET_TOOL_NAMES.has(tool.name),
+        isChatGptFamilyClient(client) &&
+        CHATGPT_NO_WIDGET_TOOL_NAMES.has(tool.name),
       registeredResourceUris,
       registeredTemplateNames,
     });
@@ -1121,7 +1133,7 @@ function registerTool(
           // — and funneling anonymous users into (working) sign-in would
           // mask a shared-key outage as a per-user auth failure.
           if (
-            options.client === "chatgpt" &&
+            isChatGptFamilyClient(options.client) &&
             options.tier === "authenticated" &&
             err instanceof DjangoUnauthorizedError
           ) {
@@ -1638,12 +1650,13 @@ export async function handleMcpRequest(
     try {
       const response = await transport.handleRequest(request);
       await logSdkValidationRejections(requestForLogging, response);
-      // ChatGPT-only compatibility adapter: rewrite the buffered
+      // ChatGPT-family compatibility adapter: rewrite the buffered
       // `tools/list` response to carry the top-level `securitySchemes`
-      // field its Apps SDK reads (the MCP SDK cannot serialize unknown
-      // descriptor fields — see `tools/_security.ts`). Every other
-      // client gets the SDK's response untouched.
-      return client === "chatgpt"
+      // field the Apps SDK reads (the MCP SDK cannot serialize unknown
+      // descriptor fields — see `tools/_security.ts`). The desktop app
+      // (`"codex"`) reads the same field for its connector link-account
+      // flow. Every other client gets the SDK's response untouched.
+      return isChatGptFamilyClient(client)
         ? await withChatGptToolSecuritySchemes(response, tier)
         : response;
     } finally {

--- a/workers/src/tools/_optional.ts
+++ b/workers/src/tools/_optional.ts
@@ -16,8 +16,9 @@
  *
  * `agent` spans all three agent tool files: the single-call `tako_agent`
  * (Claude / unknown clients) and the `tako_agent_start` / `tako_agent_wait`
- * split pair (ChatGPT). The alias enables the *feature*; the per-client
- * filters in `_surface.ts` (`CHATGPT_ONLY_TOOL_NAMES` / `CHATGPT_EXCLUDED_TOOL_NAMES`)
+ * split pair (the ChatGPT family — chatgpt.com and the desktop app's codex
+ * runtime). The alias enables the *feature*; the per-client filters in
+ * `_surface.ts` (`CHATGPT_ONLY_TOOL_NAMES` / `CHATGPT_EXCLUDED_TOOL_NAMES`)
  * then narrow to the correct variant for the calling client. Users never need
  * to know the split exists — they enable `agent` and get the right tool.
  *
@@ -25,7 +26,7 @@
  * tools are useful but rarely needed, so they are kept off the default
  * surface to save per-session context. They compose freely, e.g.
  * `?tools=visualize,credits`. Exception: `tako_visualize` stays on the
- * default surface for ChatGPT clients (it powers the chart widget) — see
+ * default surface for widget clients (it powers the chart widget) — see
  * `WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES` in `_surface.ts`.
  *
  * `graph` enables the three low-level graph primitives (search / related /

--- a/workers/src/tools/_security.test.ts
+++ b/workers/src/tools/_security.test.ts
@@ -11,12 +11,18 @@ describe("securitySchemesForTool", () => {
   const OAUTH2 = { type: "oauth2", scopes: ["mcp"] };
   const ANON_CHATGPT = { client: "chatgpt", tier: "free" } as const;
 
-  it("advertises noauth + oauth2 for the free tools on an ANONYMOUS ChatGPT listing", () => {
-    for (const name of ["tako_search", "tako_answer", "tako_available_data"]) {
-      expect(securitySchemesForTool(name, ANON_CHATGPT)).toEqual([
-        { type: "noauth" },
-        OAUTH2,
-      ]);
+  it("advertises noauth + oauth2 for the free tools on an ANONYMOUS ChatGPT-family listing", () => {
+    // Parameterized over the family: the desktop app (codex) reads the
+    // same Apps SDK metadata as chatgpt.com. A revert of the
+    // isChatGptFamilyClient call in securitySchemesForTool would pass a
+    // chatgpt-only version of this test.
+    for (const client of ["chatgpt", "codex"] as const) {
+      for (const name of ["tako_search", "tako_answer", "tako_available_data"]) {
+        expect(securitySchemesForTool(name, { client, tier: "free" })).toEqual([
+          { type: "noauth" },
+          OAUTH2,
+        ]);
+      }
     }
   });
 
@@ -42,7 +48,9 @@ describe("securitySchemesForTool", () => {
     }
   });
 
-  it("keeps non-ChatGPT clients on the pre-existing oauth2-only constant", () => {
+  it("keeps non-family clients on the pre-existing oauth2-only constant", () => {
+    // codex is deliberately NOT in this loop — it is ChatGPT family and
+    // takes the noauth+oauth2 branch above.
     for (const client of ["claude", "unknown"] as const) {
       for (const tier of ["free", "authenticated"] as const) {
         expect(securitySchemesForTool("tako_search", { client, tier })).toEqual([

--- a/workers/src/tools/_security.ts
+++ b/workers/src/tools/_security.ts
@@ -18,7 +18,8 @@
  * fixed key list from its config and the `tools/list` handler rebuilds each
  * descriptor from fixed fields, so unknown top-level fields are dropped
  * (verified against 1.29.0 and 1.30.0). `mcp.ts` therefore injects the
- * field into the already-buffered JSON response for ChatGPT clients via
+ * field into the already-buffered JSON response for ChatGPT-FAMILY
+ * clients (chatgpt.com and the desktop app's codex runtime) via
  * {@link withToolSecuritySchemes} — a post-serialization adapter, not an
  * SDK fork.
  *

--- a/workers/src/tools/_security.ts
+++ b/workers/src/tools/_security.ts
@@ -26,6 +26,7 @@
  * `gen-registry.ts` (it is NOT a `ToolModule`).
  */
 import { FREE_TIER_TOOL_NAMES, type Tier } from "../freetier.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import type { McpClientKind } from "./types.js";
 
 /** OAuth scope every Worker-issued access token carries — see `oauth/`. */
@@ -78,7 +79,7 @@ export function securitySchemesForTool(
     type: "oauth2",
     scopes: [OAUTH_TOOL_SCOPE],
   };
-  return ctx.client === "chatgpt" &&
+  return isChatGptFamilyClient(ctx.client) &&
     ctx.tier === "free" &&
     FREE_TIER_TOOL_NAMES.has(name)
     ? [{ type: "noauth" }, oauth2]

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -3,10 +3,11 @@
  * registered surface.
  *
  * The requirement this encodes: the chart widget and the tool that exists to
- * produce one (`tako_visualize`) reach the two hosts that render widgets
- * inline — ChatGPT and claude.ai / Claude Desktop — and NOTHING else. Generic
- * MCP clients keep the portable inline-PNG path and must opt in explicitly
- * with `?tools=visualize` if they want the tool at all.
+ * produce one (`tako_visualize`) reach the three hosts that render widgets
+ * inline — ChatGPT, the ChatGPT desktop app (codex), and claude.ai / Claude
+ * Desktop — and NOTHING else. Generic MCP clients keep the portable
+ * inline-PNG path and must opt in explicitly with `?tools=visualize` if they
+ * want the tool at all.
  *
  * Why a table and not per-case assertions: the boundary is enforced by two
  * separate things agreeing — `detectMcpClient`'s UA buckets and
@@ -57,17 +58,17 @@ const CLIENTS: Row[] = [
     kind: "unknown",
     widget: false,
   },
-  // ChatGPT family but deliberately NOT a widget client yet: the desktop
-  // app's widget sandbox is a `codex-sandbox://` scheme origin that
-  // tako.com's `frame-ancestors` rejects, so widget `_meta` would replace
-  // the working inline PNG with a grey dead tile. Flip checklist lives on
-  // `isChatGptFamilyClient` in `_surface.ts` — do not flip this row's
-  // `widget` without completing it.
+  // The ChatGPT desktop app renders the same interactive iframe as
+  // chatgpt.com from its `codex-sandbox://` webview. Widget membership
+  // DEPENDS on tako.com's `frame-ancestors` allowing the `codex-sandbox:`
+  // scheme (TakoData/tako#29218) — on a backend without that deploy the
+  // iframe is blocked and the app shows a grey tile, so don't revert that
+  // header without flipping this row back to false.
   {
     ua: "codex-mcp-client/0.148.0-alpha.9",
     label: "ChatGPT desktop app / Codex runtime",
     kind: "codex",
-    widget: false,
+    widget: true,
   },
   { ua: "cursor-vscode/1.0", label: "Cursor", kind: "unknown", widget: false },
   { ua: "Windsurf/1.0", label: "Windsurf", kind: "unknown", widget: false },
@@ -95,14 +96,13 @@ describe("widget exposure boundary", () => {
     });
   }
 
-  it("exposes the widget to exactly two client kinds", () => {
-    // Guards against a third kind being added to `isWidgetClient` without
-    // anyone revisiting what that means for the default surface. `"codex"`
-    // in particular must stay out until tako.com's `frame-ancestors`
-    // allows `codex-sandbox:` — see the flip checklist on
-    // `isChatGptFamilyClient`.
+  it("exposes the widget to exactly three client kinds", () => {
+    // Guards against a kind being added to `isWidgetClient` without anyone
+    // revisiting what that means for the default surface. `"codex"` is a
+    // member only because tako.com's `frame-ancestors` allows
+    // `codex-sandbox:` (TakoData/tako#29218).
     const kinds: McpClientKind[] = ["chatgpt", "claude", "codex", "unknown"];
-    expect(kinds.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
+    expect(kinds.filter(isWidgetClient)).toEqual(["chatgpt", "claude", "codex"]);
   });
 
   it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
@@ -110,7 +110,7 @@ describe("widget exposure boundary", () => {
     expect(kinds.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
   });
 
-  it("gives codex the ChatGPT tool split, without the widget", () => {
+  it("gives codex the full ChatGPT tool split", () => {
     // The desktop app is the same product as chatgpt.com on the tool
     // surface (verified live against the app 2026-08-13). Split pair in
     // when opted in, dispatch+poll agent out even when asked for:
@@ -128,10 +128,6 @@ describe("widget exposure boundary", () => {
     // `unknown` clients never see.
     expect(isToolOnSurface("tako_contents", "codex", new Set(), "free")).toBe(true);
     expect(isToolOnSurface("tako_contents", "unknown", new Set(), "free")).toBe(false);
-    // tako_visualize stays off codex's default surface for now: default-on
-    // rides `isWidgetClient` (its whole output is the widget chart), so it
-    // returns exactly when the widget flip happens.
-    expect(isToolOnSurface("tako_visualize", "codex", new Set(), "authenticated")).toBe(false);
   });
 
   it("lets a non-widget client opt in explicitly", () => {

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -96,34 +96,40 @@ describe("widget exposure boundary", () => {
     });
   }
 
-  // `Record<McpClientKind, true>` makes this list provably exhaustive: a
-  // fifth kind added to the union in types.ts fails COMPILATION here until
-  // someone decides its widget/family membership — the review found the
-  // previous hand-listed arrays let a new kind silently skip these guards.
-  const ALL_KINDS: Record<McpClientKind, true> = {
-    chatgpt: true,
-    claude: true,
-    codex: true,
-    unknown: true,
+  // A per-kind expected-membership TABLE, not a filtered list: a fifth kind
+  // added to the union in types.ts fails COMPILATION here until someone
+  // writes down BOTH of its memberships — with the previous
+  // `.filter(...).toEqual([...])` shape, satisfying the compiler only took
+  // `newkind: true` in a fixture and the new kind landed silently on the
+  // unknown surface (review finding on PR #239). Per-kind assertions are
+  // also insertion-order independent, so reordering this literal can't
+  // fail without a behavior change.
+  //
+  // The memberships gate different things and genuinely diverge (claude):
+  // `widget` = receives widget `_meta` + default-on `tako_visualize`;
+  // `family` = the ChatGPT product surface (agent split, anonymous
+  // discoverable listing, securitySchemes injection). `codex` is a widget
+  // member only because tako.com's `frame-ancestors` allows
+  // `codex-sandbox:` (TakoData/tako#29218) AND the flip was validated live
+  // against the desktop app.
+  const EXPECTED_MEMBERSHIP: Record<
+    McpClientKind,
+    { widget: boolean; family: boolean }
+  > = {
+    chatgpt: { widget: true, family: true },
+    claude: { widget: true, family: false },
+    codex: { widget: true, family: true },
+    unknown: { widget: false, family: false },
   };
-  const KINDS = Object.keys(ALL_KINDS) as McpClientKind[];
 
-  it("exposes the widget to exactly three client kinds", () => {
-    // Guards against a kind being added to `isWidgetClient` without anyone
-    // revisiting what that means for the default surface. `"codex"` is a
-    // member only because tako.com's `frame-ancestors` allows
-    // `codex-sandbox:` (TakoData/tako#29218) AND the flip was validated
-    // live against the desktop app.
-    expect(KINDS.filter(isWidgetClient)).toEqual([
-      "chatgpt",
-      "claude",
-      "codex",
-    ]);
-  });
-
-  it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
-    expect(KINDS.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
-  });
+  for (const [kind, expected] of Object.entries(EXPECTED_MEMBERSHIP) as Array<
+    [McpClientKind, { widget: boolean; family: boolean }]
+  >) {
+    it(`membership table: ${kind} widget=${expected.widget} family=${expected.family}`, () => {
+      expect(isWidgetClient(kind)).toBe(expected.widget);
+      expect(isChatGptFamilyClient(kind)).toBe(expected.family);
+    });
+  }
 
   it("gives codex the full ChatGPT tool split", () => {
     // The desktop app is the same product as chatgpt.com on the tool

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -17,7 +17,11 @@
 import { describe, expect, it } from "vitest";
 
 import { detectMcpClient } from "../mcp.js";
-import { isToolOnSurface, isWidgetClient } from "./_surface.js";
+import {
+  isChatGptFamilyClient,
+  isToolOnSurface,
+  isWidgetClient,
+} from "./_surface.js";
 import type { McpClientKind } from "./types.js";
 
 interface Row {
@@ -53,6 +57,18 @@ const CLIENTS: Row[] = [
     kind: "unknown",
     widget: false,
   },
+  // ChatGPT family but deliberately NOT a widget client yet: the desktop
+  // app's widget sandbox is a `codex-sandbox://` scheme origin that
+  // tako.com's `frame-ancestors` rejects, so widget `_meta` would replace
+  // the working inline PNG with a grey dead tile. Flip checklist lives on
+  // `isChatGptFamilyClient` in `_surface.ts` — do not flip this row's
+  // `widget` without completing it.
+  {
+    ua: "codex-mcp-client/0.148.0-alpha.9",
+    label: "ChatGPT desktop app / Codex runtime",
+    kind: "codex",
+    widget: false,
+  },
   { ua: "cursor-vscode/1.0", label: "Cursor", kind: "unknown", widget: false },
   { ua: "Windsurf/1.0", label: "Windsurf", kind: "unknown", widget: false },
   { ua: "python-httpx/0.27.0", label: "generic HTTP client", kind: "unknown", widget: false },
@@ -81,9 +97,41 @@ describe("widget exposure boundary", () => {
 
   it("exposes the widget to exactly two client kinds", () => {
     // Guards against a third kind being added to `isWidgetClient` without
-    // anyone revisiting what that means for the default surface.
-    const kinds: McpClientKind[] = ["chatgpt", "claude", "unknown"];
+    // anyone revisiting what that means for the default surface. `"codex"`
+    // in particular must stay out until tako.com's `frame-ancestors`
+    // allows `codex-sandbox:` — see the flip checklist on
+    // `isChatGptFamilyClient`.
+    const kinds: McpClientKind[] = ["chatgpt", "claude", "codex", "unknown"];
     expect(kinds.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
+  });
+
+  it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
+    const kinds: McpClientKind[] = ["chatgpt", "claude", "codex", "unknown"];
+    expect(kinds.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
+  });
+
+  it("gives codex the ChatGPT tool split, without the widget", () => {
+    // The desktop app is the same product as chatgpt.com on the tool
+    // surface (verified live against the app 2026-08-13). Split pair in
+    // when opted in, dispatch+poll agent out even when asked for:
+    expect(
+      isToolOnSurface("tako_agent_start", "codex", new Set(["tako_agent_start"]), "authenticated"),
+    ).toBe(true);
+    expect(
+      isToolOnSurface("tako_agent_start", "unknown", new Set(["tako_agent_start"]), "authenticated"),
+    ).toBe(false);
+    expect(
+      isToolOnSurface("tako_agent", "codex", new Set(["tako_agent"]), "authenticated"),
+    ).toBe(false);
+    // Anonymous family listing keeps the auth-gated submitted tool visible
+    // so the host can offer link-account from the descriptor — a surface
+    // `unknown` clients never see.
+    expect(isToolOnSurface("tako_contents", "codex", new Set(), "free")).toBe(true);
+    expect(isToolOnSurface("tako_contents", "unknown", new Set(), "free")).toBe(false);
+    // tako_visualize stays off codex's default surface for now: default-on
+    // rides `isWidgetClient` (its whole output is the widget chart), so it
+    // returns exactly when the widget flip happens.
+    expect(isToolOnSurface("tako_visualize", "codex", new Set(), "authenticated")).toBe(false);
   });
 
   it("lets a non-widget client opt in explicitly", () => {

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -95,19 +95,29 @@ describe("widget exposure boundary", () => {
     });
   }
 
+  // `Record<McpClientKind, true>` makes this list provably exhaustive: a
+  // fifth kind added to the union in types.ts fails COMPILATION here until
+  // someone decides its widget/family membership — the review found the
+  // previous hand-listed arrays let a new kind silently skip these guards.
+  const ALL_KINDS: Record<McpClientKind, true> = {
+    chatgpt: true,
+    claude: true,
+    codex: true,
+    unknown: true,
+  };
+  const KINDS = Object.keys(ALL_KINDS) as McpClientKind[];
+
   it("exposes the widget to exactly two client kinds", () => {
-    // Guards against a third kind being added to `isWidgetClient` without
+    // Guards against a kind being added to `isWidgetClient` without
     // anyone revisiting what that means for the default surface. `"codex"`
     // in particular must stay out until tako.com's `frame-ancestors`
-    // allows `codex-sandbox:` — see the flip checklist on
-    // `isChatGptFamilyClient`.
-    const kinds: McpClientKind[] = ["chatgpt", "claude", "codex", "unknown"];
-    expect(kinds.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
+    // allows `codex-sandbox:` AND the flip is validated live — see the
+    // flip checklist on `isChatGptFamilyClient`.
+    expect(KINDS.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
   });
 
   it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
-    const kinds: McpClientKind[] = ["chatgpt", "claude", "codex", "unknown"];
-    expect(kinds.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
+    expect(KINDS.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
   });
 
   it("gives codex the ChatGPT tool split, without the widget", () => {

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -3,11 +3,10 @@
  * registered surface.
  *
  * The requirement this encodes: the chart widget and the tool that exists to
- * produce one (`tako_visualize`) reach the three hosts that render widgets
- * inline — ChatGPT, the ChatGPT desktop app (codex), and claude.ai / Claude
- * Desktop — and NOTHING else. Generic MCP clients keep the portable
- * inline-PNG path and must opt in explicitly with `?tools=visualize` if they
- * want the tool at all.
+ * produce one (`tako_visualize`) reach the two hosts that render widgets
+ * inline — ChatGPT and claude.ai / Claude Desktop — and NOTHING else. Generic
+ * MCP clients keep the portable inline-PNG path and must opt in explicitly
+ * with `?tools=visualize` if they want the tool at all.
  *
  * Why a table and not per-case assertions: the boundary is enforced by two
  * separate things agreeing — `detectMcpClient`'s UA buckets and
@@ -58,17 +57,17 @@ const CLIENTS: Row[] = [
     kind: "unknown",
     widget: false,
   },
-  // The ChatGPT desktop app renders the same interactive iframe as
-  // chatgpt.com from its `codex-sandbox://` webview. Widget membership
-  // DEPENDS on tako.com's `frame-ancestors` allowing the `codex-sandbox:`
-  // scheme (TakoData/tako#29218) — on a backend without that deploy the
-  // iframe is blocked and the app shows a grey tile, so don't revert that
-  // header without flipping this row back to false.
+  // ChatGPT family but deliberately NOT a widget client yet: the desktop
+  // app's widget sandbox is a `codex-sandbox://` scheme origin that
+  // tako.com's `frame-ancestors` rejects, so widget `_meta` would replace
+  // the working inline PNG with a grey dead tile. Flip checklist lives on
+  // `isChatGptFamilyClient` in `_surface.ts` — do not flip this row's
+  // `widget` without completing it.
   {
     ua: "codex-mcp-client/0.148.0-alpha.9",
     label: "ChatGPT desktop app / Codex runtime",
     kind: "codex",
-    widget: true,
+    widget: false,
   },
   { ua: "cursor-vscode/1.0", label: "Cursor", kind: "unknown", widget: false },
   { ua: "Windsurf/1.0", label: "Windsurf", kind: "unknown", widget: false },
@@ -96,13 +95,14 @@ describe("widget exposure boundary", () => {
     });
   }
 
-  it("exposes the widget to exactly three client kinds", () => {
-    // Guards against a kind being added to `isWidgetClient` without anyone
-    // revisiting what that means for the default surface. `"codex"` is a
-    // member only because tako.com's `frame-ancestors` allows
-    // `codex-sandbox:` (TakoData/tako#29218).
+  it("exposes the widget to exactly two client kinds", () => {
+    // Guards against a third kind being added to `isWidgetClient` without
+    // anyone revisiting what that means for the default surface. `"codex"`
+    // in particular must stay out until tako.com's `frame-ancestors`
+    // allows `codex-sandbox:` — see the flip checklist on
+    // `isChatGptFamilyClient`.
     const kinds: McpClientKind[] = ["chatgpt", "claude", "codex", "unknown"];
-    expect(kinds.filter(isWidgetClient)).toEqual(["chatgpt", "claude", "codex"]);
+    expect(kinds.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
   });
 
   it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
@@ -110,7 +110,7 @@ describe("widget exposure boundary", () => {
     expect(kinds.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
   });
 
-  it("gives codex the full ChatGPT tool split", () => {
+  it("gives codex the ChatGPT tool split, without the widget", () => {
     // The desktop app is the same product as chatgpt.com on the tool
     // surface (verified live against the app 2026-08-13). Split pair in
     // when opted in, dispatch+poll agent out even when asked for:
@@ -128,6 +128,10 @@ describe("widget exposure boundary", () => {
     // `unknown` clients never see.
     expect(isToolOnSurface("tako_contents", "codex", new Set(), "free")).toBe(true);
     expect(isToolOnSurface("tako_contents", "unknown", new Set(), "free")).toBe(false);
+    // tako_visualize stays off codex's default surface for now: default-on
+    // rides `isWidgetClient` (its whole output is the widget chart), so it
+    // returns exactly when the widget flip happens.
+    expect(isToolOnSurface("tako_visualize", "codex", new Set(), "authenticated")).toBe(false);
   });
 
   it("lets a non-widget client opt in explicitly", () => {

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -3,10 +3,11 @@
  * registered surface.
  *
  * The requirement this encodes: the chart widget and the tool that exists to
- * produce one (`tako_visualize`) reach the two hosts that render widgets
- * inline — ChatGPT and claude.ai / Claude Desktop — and NOTHING else. Generic
- * MCP clients keep the portable inline-PNG path and must opt in explicitly
- * with `?tools=visualize` if they want the tool at all.
+ * produce one (`tako_visualize`) reach the three hosts that render widgets
+ * inline — ChatGPT, the ChatGPT desktop app (codex), and claude.ai / Claude
+ * Desktop — and NOTHING else. Generic MCP clients keep the portable
+ * inline-PNG path and must opt in explicitly with `?tools=visualize` if they
+ * want the tool at all.
  *
  * Why a table and not per-case assertions: the boundary is enforced by two
  * separate things agreeing — `detectMcpClient`'s UA buckets and
@@ -57,17 +58,17 @@ const CLIENTS: Row[] = [
     kind: "unknown",
     widget: false,
   },
-  // ChatGPT family but deliberately NOT a widget client yet: the desktop
-  // app's widget sandbox is a `codex-sandbox://` scheme origin that
-  // tako.com's `frame-ancestors` rejects, so widget `_meta` would replace
-  // the working inline PNG with a grey dead tile. Flip checklist lives on
-  // `isChatGptFamilyClient` in `_surface.ts` — do not flip this row's
-  // `widget` without completing it.
+  // The ChatGPT desktop app renders the same interactive iframe as
+  // chatgpt.com from its `codex-sandbox://` webview. Widget membership
+  // DEPENDS on tako.com's `frame-ancestors` allowing the `codex-sandbox:`
+  // scheme (TakoData/tako#29218) — on a backend without that deploy the
+  // iframe is blocked and the app shows a grey tile, so don't revert that
+  // header without flipping this row back to false.
   {
     ua: "codex-mcp-client/0.148.0-alpha.9",
     label: "ChatGPT desktop app / Codex runtime",
     kind: "codex",
-    widget: false,
+    widget: true,
   },
   { ua: "cursor-vscode/1.0", label: "Cursor", kind: "unknown", widget: false },
   { ua: "Windsurf/1.0", label: "Windsurf", kind: "unknown", widget: false },
@@ -107,20 +108,24 @@ describe("widget exposure boundary", () => {
   };
   const KINDS = Object.keys(ALL_KINDS) as McpClientKind[];
 
-  it("exposes the widget to exactly two client kinds", () => {
-    // Guards against a kind being added to `isWidgetClient` without
-    // anyone revisiting what that means for the default surface. `"codex"`
-    // in particular must stay out until tako.com's `frame-ancestors`
-    // allows `codex-sandbox:` AND the flip is validated live — see the
-    // flip checklist on `isChatGptFamilyClient`.
-    expect(KINDS.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
+  it("exposes the widget to exactly three client kinds", () => {
+    // Guards against a kind being added to `isWidgetClient` without anyone
+    // revisiting what that means for the default surface. `"codex"` is a
+    // member only because tako.com's `frame-ancestors` allows
+    // `codex-sandbox:` (TakoData/tako#29218) AND the flip was validated
+    // live against the desktop app.
+    expect(KINDS.filter(isWidgetClient)).toEqual([
+      "chatgpt",
+      "claude",
+      "codex",
+    ]);
   });
 
   it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
     expect(KINDS.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
   });
 
-  it("gives codex the ChatGPT tool split, without the widget", () => {
+  it("gives codex the full ChatGPT tool split", () => {
     // The desktop app is the same product as chatgpt.com on the tool
     // surface (verified live against the app 2026-08-13). Split pair in
     // when opted in, dispatch+poll agent out even when asked for:
@@ -138,10 +143,6 @@ describe("widget exposure boundary", () => {
     // `unknown` clients never see.
     expect(isToolOnSurface("tako_contents", "codex", new Set(), "free")).toBe(true);
     expect(isToolOnSurface("tako_contents", "unknown", new Set(), "free")).toBe(false);
-    // tako_visualize stays off codex's default surface for now: default-on
-    // rides `isWidgetClient` (its whole output is the widget chart), so it
-    // returns exactly when the widget flip happens.
-    expect(isToolOnSurface("tako_visualize", "codex", new Set(), "authenticated")).toBe(false);
   });
 
   it("lets a non-widget client opt in explicitly", () => {

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -72,6 +72,34 @@ export function isWidgetClient(client: McpClientKind): boolean {
 }
 
 /**
+ * The ChatGPT PRODUCT family: chatgpt.com's connector AND the merged
+ * ChatGPT desktop app (`"codex"`). These share the tool surface — the
+ * split agent pair, the anonymous discoverable set, `securitySchemes`
+ * injection, the Apps-SDK reauth challenge — because they are the same
+ * product with two MCP transports (verified live against the desktop app
+ * 2026-08-13: it lists, calls, and auth-gates exactly like chatgpt.com).
+ *
+ * Deliberately NOT the same predicate as {@link isWidgetClient}: codex is
+ * family but not (yet) a widget client. Its widget sandbox origin is a
+ * custom `codex-sandbox://` scheme that tako.com's `frame-ancestors`
+ * rejects (`ERR_BLOCKED_BY_RESPONSE` on the card iframe), so widget
+ * `_meta` today would replace the working inline PNG with a grey dead
+ * tile in the desktop app.
+ *
+ * FLIP CHECKLIST — when the backend allows `codex-sandbox:` in
+ * `frame-ancestors` (tako repo `build_csp_header`, monolith/views.py) and
+ * a desktop app with `enable_mcp_apps` renders a card end-to-end:
+ *   1. add `client === "codex"` to {@link isWidgetClient};
+ *   2. switch the three `bakeImage: ctx.client !== "chatgpt"` gates
+ *      (tako_search / tako_answer / tako_visualize) to
+ *      `!isChatGptFamilyClient(ctx.client)` so codex skips the PNG
+ *      prefetch its widget no longer reads.
+ */
+export function isChatGptFamilyClient(client: McpClientKind): boolean {
+  return client === "chatgpt" || client === "codex";
+}
+
+/**
  * Optional tools that stay on the DEFAULT surface for widget clients
  * ({@link isWidgetClient}).
  *
@@ -167,7 +195,7 @@ export function isToolOnSurface(
     tier === "free" &&
     !FREE_TIER_TOOL_NAMES.has(name) &&
     !(
-      client === "chatgpt" &&
+      isChatGptFamilyClient(client) &&
       CHATGPT_ANONYMOUS_DISCOVERABLE_TOOL_NAMES.has(name)
     )
   ) {
@@ -180,8 +208,12 @@ export function isToolOnSurface(
   ) {
     return false;
   }
-  if (CHATGPT_ONLY_TOOL_NAMES.has(name) && client !== "chatgpt") return false;
-  if (CHATGPT_EXCLUDED_TOOL_NAMES.has(name) && client === "chatgpt") return false;
+  if (CHATGPT_ONLY_TOOL_NAMES.has(name) && !isChatGptFamilyClient(client)) {
+    return false;
+  }
+  if (CHATGPT_EXCLUDED_TOOL_NAMES.has(name) && isChatGptFamilyClient(client)) {
+    return false;
+  }
   return true;
 }
 

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -228,7 +228,9 @@ export function isToolOnSurface(
  * Apps-review labels to a generic third-party MCP client merely
  * understates `openWorldHint` on retrieval — cosmetic, and reversible.
  */
-export function annotationClientFamily(client: McpClientKind): McpClientKind {
+export function annotationClientFamily(
+  client: McpClientKind,
+): "claude" | "chatgpt" {
   return client === "claude" ? "claude" : "chatgpt";
 }
 

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -58,8 +58,14 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * ChatGPT renders the widget as a fully interactive iframe; Claude renders
  * the same bundle via its image branch (claude.ai's host CSP blocks the
  * cross-origin iframe today — anthropics/claude-ai-mcp#40 — and the bundle
- * probes for that at runtime). Everything else — Cursor, Windsurf, Gemini
- * CLI, LibreChat, Claude Code's terminal client — gets the PNG.
+ * probes for that at runtime). The ChatGPT desktop app (`"codex"`) renders
+ * the same interactive iframe as chatgpt.com from its `codex-sandbox://`
+ * webview — REQUIRES tako.com's `frame-ancestors` to allow the
+ * `codex-sandbox:` scheme (shipped in TakoData/tako#29218; before that
+ * deploy the iframe dies with `ERR_BLOCKED_BY_RESPONSE` and the app shows
+ * a grey tile where the PNG used to be). Everything else — Cursor,
+ * Windsurf, Gemini CLI, LibreChat, Claude Code's terminal client — gets
+ * the PNG.
  *
  * This is the ONE definition of "widget client". `mcp.ts` computes
  * `widgetSuppressed` from it, and {@link WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES}
@@ -68,7 +74,7 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * `client === …` comparisons in separate files before).
  */
 export function isWidgetClient(client: McpClientKind): boolean {
-  return client === "chatgpt" || client === "claude";
+  return client === "chatgpt" || client === "claude" || client === "codex";
 }
 
 /**
@@ -79,21 +85,13 @@ export function isWidgetClient(client: McpClientKind): boolean {
  * product with two MCP transports (verified live against the desktop app
  * 2026-08-13: it lists, calls, and auth-gates exactly like chatgpt.com).
  *
- * Deliberately NOT the same predicate as {@link isWidgetClient}: codex is
- * family but not (yet) a widget client. Its widget sandbox origin is a
- * custom `codex-sandbox://` scheme that tako.com's `frame-ancestors`
- * rejects (`ERR_BLOCKED_BY_RESPONSE` on the card iframe), so widget
- * `_meta` today would replace the working inline PNG with a grey dead
- * tile in the desktop app.
- *
- * FLIP CHECKLIST — when the backend allows `codex-sandbox:` in
- * `frame-ancestors` (tako repo `build_csp_header`, monolith/views.py) and
- * a desktop app with `enable_mcp_apps` renders a card end-to-end:
- *   1. add `client === "codex"` to {@link isWidgetClient};
- *   2. switch the three `bakeImage: ctx.client !== "chatgpt"` gates
- *      (tako_search / tako_answer / tako_visualize) to
- *      `!isChatGptFamilyClient(ctx.client)` so codex skips the PNG
- *      prefetch its widget no longer reads.
+ * Deliberately NOT the same predicate as {@link isWidgetClient}: claude is
+ * a widget client but not ChatGPT family, and the two sets gate different
+ * things — this one the product surface, that one the widget `_meta`.
+ * Codex joined `isWidgetClient` only once tako.com's `frame-ancestors`
+ * allowed the `codex-sandbox:` scheme (TakoData/tako#29218) — its widget
+ * iframe is blocked with `ERR_BLOCKED_BY_RESPONSE` on any backend without
+ * that deploy, leaving a grey dead tile where the PNG used to be.
  */
 export function isChatGptFamilyClient(client: McpClientKind): boolean {
   return client === "chatgpt" || client === "codex";

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -58,14 +58,8 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * ChatGPT renders the widget as a fully interactive iframe; Claude renders
  * the same bundle via its image branch (claude.ai's host CSP blocks the
  * cross-origin iframe today — anthropics/claude-ai-mcp#40 — and the bundle
- * probes for that at runtime). The ChatGPT desktop app (`"codex"`) renders
- * the same interactive iframe as chatgpt.com from its `codex-sandbox://`
- * webview — REQUIRES tako.com's `frame-ancestors` to allow the
- * `codex-sandbox:` scheme (shipped in TakoData/tako#29218; before that
- * deploy the iframe dies with `ERR_BLOCKED_BY_RESPONSE` and the app shows
- * a grey tile where the PNG used to be). Everything else — Cursor,
- * Windsurf, Gemini CLI, LibreChat, Claude Code's terminal client — gets
- * the PNG.
+ * probes for that at runtime). Everything else — Cursor, Windsurf, Gemini
+ * CLI, LibreChat, Claude Code's terminal client — gets the PNG.
  *
  * This is the ONE definition of "widget client". `mcp.ts` computes
  * `widgetSuppressed` from it, and {@link WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES}
@@ -74,7 +68,7 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * `client === …` comparisons in separate files before).
  */
 export function isWidgetClient(client: McpClientKind): boolean {
-  return client === "chatgpt" || client === "claude" || client === "codex";
+  return client === "chatgpt" || client === "claude";
 }
 
 /**
@@ -85,13 +79,21 @@ export function isWidgetClient(client: McpClientKind): boolean {
  * product with two MCP transports (verified live against the desktop app
  * 2026-08-13: it lists, calls, and auth-gates exactly like chatgpt.com).
  *
- * Deliberately NOT the same predicate as {@link isWidgetClient}: claude is
- * a widget client but not ChatGPT family, and the two sets gate different
- * things — this one the product surface, that one the widget `_meta`.
- * Codex joined `isWidgetClient` only once tako.com's `frame-ancestors`
- * allowed the `codex-sandbox:` scheme (TakoData/tako#29218) — its widget
- * iframe is blocked with `ERR_BLOCKED_BY_RESPONSE` on any backend without
- * that deploy, leaving a grey dead tile where the PNG used to be.
+ * Deliberately NOT the same predicate as {@link isWidgetClient}: codex is
+ * family but not (yet) a widget client. Its widget sandbox origin is a
+ * custom `codex-sandbox://` scheme that tako.com's `frame-ancestors`
+ * rejects (`ERR_BLOCKED_BY_RESPONSE` on the card iframe), so widget
+ * `_meta` today would replace the working inline PNG with a grey dead
+ * tile in the desktop app.
+ *
+ * FLIP CHECKLIST — when the backend allows `codex-sandbox:` in
+ * `frame-ancestors` (tako repo `build_csp_header`, monolith/views.py) and
+ * a desktop app with `enable_mcp_apps` renders a card end-to-end:
+ *   1. add `client === "codex"` to {@link isWidgetClient};
+ *   2. switch the three `bakeImage: ctx.client !== "chatgpt"` gates
+ *      (tako_search / tako_answer / tako_visualize) to
+ *      `!isChatGptFamilyClient(ctx.client)` so codex skips the PNG
+ *      prefetch its widget no longer reads.
  */
 export function isChatGptFamilyClient(client: McpClientKind): boolean {
   return client === "chatgpt" || client === "codex";

--- a/workers/src/tools/tako_answer.test.ts
+++ b/workers/src/tools/tako_answer.test.ts
@@ -266,33 +266,40 @@ describe("tako_answer renders a chart, exactly like tako_search", () => {
     expect(typeof takoAnswer.extraContentBlocks).toBe("function");
   });
 
-  it("sends ChatGPT dimensions only, never the whole PNG", async () => {
-    // `bakeImage: ctx.client !== "chatgpt"` is justified as "a 64-byte ranged
-    // read instead of a ~170 KB render". Inverted, every ChatGPT answer call
-    // pays the full PNG_FETCH_TIMEOUT_MS budget for a payload that host
-    // discards — and nothing caught that, here or in search.
-    const seen: { url: string; range: string | null }[] = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation((async (
-      input: RequestInfo | URL,
-      init?: RequestInit,
-    ) => {
-      const req = new Request(input as RequestInfo, init);
-      seen.push({ url: req.url, range: req.headers.get("range") });
-      // 8 bytes of PNG signature + IHDR length so the dimension parser has
-      // something to chew on; the assertion is about the REQUEST.
-      return new Response(new Uint8Array(64), {
-        status: 206,
-        headers: { "content-type": "image/png" },
-      });
-    }) as typeof fetch);
+  it.each(["chatgpt", "codex"] as const)(
+    "sends %s dimensions only, never the whole PNG",
+    async (client) => {
+      // `bakeImage: !isChatGptFamilyClient(ctx.client)` is justified as "a
+      // 64-byte ranged read instead of a ~170 KB render". Inverted, every
+      // family answer call pays the full PNG_FETCH_TIMEOUT_MS budget for a
+      // payload that host discards — and nothing caught that, here or in
+      // search. Both family members are pinned because the gate is one of
+      // the three named in the staged-rollout checklist (search, answer,
+      // visualize): a per-tool revert to `client !== "chatgpt"` would strip
+      // the desktop app's dimensions path while the suite stayed green.
+      const seen: { url: string; range: string | null }[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation((async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const req = new Request(input as RequestInfo, init);
+        seen.push({ url: req.url, range: req.headers.get("range") });
+        // 8 bytes of PNG signature + IHDR length so the dimension parser has
+        // something to chew on; the assertion is about the REQUEST.
+        return new Response(new Uint8Array(64), {
+          status: 206,
+          headers: { "content-type": "image/png" },
+        });
+      }) as typeof fetch);
 
-    await takoAnswer.extraMeta!(
-      { image_url: "https://x.test/api/v1/image/abc/", pub_id: "abc" } as never,
-      { ...CTX, client: "chatgpt" } as never,
-    );
-    expect(seen).toHaveLength(1);
-    expect(seen[0]!.range).not.toBeNull();
-  });
+      await takoAnswer.extraMeta!(
+        { image_url: "https://x.test/api/v1/image/abc/", pub_id: "abc" } as never,
+        { ...CTX, client } as never,
+      );
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.range).not.toBeNull();
+    },
+  );
 
   it("returns no content block when there is no chart", async () => {
     // `fetchPngContentBlock(undefined)` would fetch the string "undefined".

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -4,6 +4,7 @@ import { djangoPost } from "../django.js";
 import { AnswerResponse, SearchRequest } from "../generated/schemas.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import {
   answerSlimOutputShape,
   renderAnswerMarkdown,
@@ -378,11 +379,12 @@ const takoAnswer = {
   // there; the only reason it is duplicated rather than shared is that the
   // hooks are per-tool fields on `ToolModule`.
   async extraMeta(output, ctx) {
-    // ChatGPT renders `embed_url` in an iframe and never reads the baked PNG,
-    // but still needs the aspect ratio to size that iframe — dimensions only
-    // there (a 64-byte ranged read instead of a ~170 KB render).
+    // The ChatGPT family renders `embed_url` in an iframe and never reads
+    // the baked PNG, but still needs the aspect ratio to size that iframe —
+    // dimensions only there (a 64-byte ranged read instead of a ~170 KB
+    // render).
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: ctx.client !== "chatgpt",
+      bakeImage: !isChatGptFamilyClient(ctx.client),
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -4,7 +4,6 @@ import { djangoPost } from "../django.js";
 import { AnswerResponse, SearchRequest } from "../generated/schemas.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
-import { isChatGptFamilyClient } from "./_surface.js";
 import {
   answerSlimOutputShape,
   renderAnswerMarkdown,
@@ -379,12 +378,11 @@ const takoAnswer = {
   // there; the only reason it is duplicated rather than shared is that the
   // hooks are per-tool fields on `ToolModule`.
   async extraMeta(output, ctx) {
-    // The ChatGPT family renders `embed_url` in an iframe and never reads
-    // the baked PNG, but still needs the aspect ratio to size that iframe —
-    // dimensions only there (a 64-byte ranged read instead of a ~170 KB
-    // render).
+    // ChatGPT renders `embed_url` in an iframe and never reads the baked PNG,
+    // but still needs the aspect ratio to size that iframe — dimensions only
+    // there (a 64-byte ranged read instead of a ~170 KB render).
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: !isChatGptFamilyClient(ctx.client),
+      bakeImage: ctx.client !== "chatgpt",
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -26,7 +26,6 @@ import {
 } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
-import { isChatGptFamilyClient } from "./_surface.js";
 import {
   renderSearchMarkdown,
   searchSlimOutputShape,
@@ -314,15 +313,14 @@ const tako_search = {
     // gate we pay the full chart-render latency
     // (`PNG_FETCH_TIMEOUT_MS` = 8s upper bound) on every ChatGPT
     // tool call just to populate a field the host throws away.
-    // The ChatGPT family (chatgpt.com AND the desktop app) gets DIMENSIONS
-    // ONLY (a 64-byte ranged read): their widget renders `embed_url` in an
-    // iframe and never reads the baked PNG, but it cannot measure that
-    // cross-origin iframe's content, so without the card's real aspect
-    // ratio the iframe falls back to a fixed height and leaves empty bands
-    // under a wide chart. Claude gets the full baked image — there the
+    // ChatGPT gets DIMENSIONS ONLY (a 64-byte ranged read): its widget renders
+    // `embed_url` in an iframe and never reads the baked PNG, but it cannot
+    // measure that cross-origin iframe's content, so without the card's real
+    // aspect ratio the iframe falls back to a fixed height and leaves empty
+    // bands under a wide chart. Claude gets the full baked image — there the
     // PNG *is* the chart.
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: !isChatGptFamilyClient(ctx.client),
+      bakeImage: ctx.client !== "chatgpt",
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -26,6 +26,7 @@ import {
 } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import {
   renderSearchMarkdown,
   searchSlimOutputShape,
@@ -313,14 +314,15 @@ const tako_search = {
     // gate we pay the full chart-render latency
     // (`PNG_FETCH_TIMEOUT_MS` = 8s upper bound) on every ChatGPT
     // tool call just to populate a field the host throws away.
-    // ChatGPT gets DIMENSIONS ONLY (a 64-byte ranged read): its widget renders
-    // `embed_url` in an iframe and never reads the baked PNG, but it cannot
-    // measure that cross-origin iframe's content, so without the card's real
-    // aspect ratio the iframe falls back to a fixed height and leaves empty
-    // bands under a wide chart. Claude gets the full baked image — there the
+    // The ChatGPT family (chatgpt.com AND the desktop app) gets DIMENSIONS
+    // ONLY (a 64-byte ranged read): their widget renders `embed_url` in an
+    // iframe and never reads the baked PNG, but it cannot measure that
+    // cross-origin iframe's content, so without the card's real aspect
+    // ratio the iframe falls back to a fixed height and leaves empty bands
+    // under a wide chart. Claude gets the full baked image — there the
     // PNG *is* the chart.
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: ctx.client !== "chatgpt",
+      bakeImage: !isChatGptFamilyClient(ctx.client),
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_visualize.test.ts
+++ b/workers/src/tools/tako_visualize.test.ts
@@ -357,6 +357,45 @@ describe("tako_visualize input schema", () => {
 
 // --- Contract guard tests (A7) ---
 
+describe("tako_visualize chart prefetch, exactly like tako_search", () => {
+  it.each(["chatgpt", "codex"] as const)(
+    "sends %s dimensions only, never the whole PNG",
+    async (client) => {
+      // Third of the three `bakeImage: !isChatGptFamilyClient(ctx.client)`
+      // gates named in the staged-rollout checklist (search, answer,
+      // visualize). Search's gate is pinned in mcp.test.ts and answer's in
+      // tako_answer.test.ts; without this one, a per-tool revert here
+      // would bake the full PNG into every desktop-app visualize call —
+      // paying the render latency for a payload the widget discards —
+      // while the suite stayed green.
+      const seen: { url: string; range: string | null }[] = [];
+      vi.spyOn(globalThis, "fetch").mockImplementation((async (
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ) => {
+        const req = new Request(input as RequestInfo, init);
+        seen.push({ url: req.url, range: req.headers.get("range") });
+        // 8 bytes of PNG signature + IHDR length so the dimension parser
+        // has something to chew on; the assertion is about the REQUEST.
+        return new Response(new Uint8Array(64), {
+          status: 206,
+          headers: { "content-type": "image/png" },
+        });
+      }) as typeof fetch);
+
+      await takoVisualize.extraMeta!(
+        {
+          image_url: "https://x.test/api/v1/image/card_abc123/",
+          pub_id: "card_abc123",
+        } as never,
+        { ...CTX, client } as never,
+      );
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.range).not.toBeNull();
+    },
+  );
+});
+
 // Representative thin_viz/create response that the backend returns
 // (a full card dump; ThinVizCard documents only the populated subset).
 const KNOWLEDGE_CARD_WIRE = {

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -32,6 +32,7 @@ import {
 } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import { autoChainShape } from "./_search_results.js";
 import type { AppUiResource, ToolContentBlock, ToolModule } from "./types.js";
 
@@ -460,7 +461,7 @@ const tako_visualize = {
     // bands under a wide chart. Claude gets the full baked image — there the
     // PNG *is* the chart.
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: ctx.client !== "chatgpt",
+      bakeImage: !isChatGptFamilyClient(ctx.client),
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -32,7 +32,6 @@ import {
 } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
-import { isChatGptFamilyClient } from "./_surface.js";
 import { autoChainShape } from "./_search_results.js";
 import type { AppUiResource, ToolContentBlock, ToolModule } from "./types.js";
 
@@ -461,7 +460,7 @@ const tako_visualize = {
     // bands under a wide chart. Claude gets the full baked image — there the
     // PNG *is* the chart.
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: !isChatGptFamilyClient(ctx.client),
+      bakeImage: ctx.client !== "chatgpt",
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -318,17 +318,25 @@ export interface ToolModule<
    */
   description: string;
   /**
-   * Optional per-client description overrides. The Worker selects the
-   * entry matching the request's detected `McpClientKind` and falls
-   * back to {@link description} when no entry exists. Use this when a
-   * tool's instructions diverge meaningfully by host (e.g. claude.ai
-   * auto-renders charts inline with server-side escalation while
-   * ChatGPT must redirect to the Tako agent on empty results) —
-   * sending each model only the directive it can act on is more
-   * reliable than asking it to self-identify and filter from a single
-   * description with conditional clauses.
+   * Optional per-client description overrides, resolved by ANNOTATION
+   * FAMILY, not raw detected kind: `claude` clients read the `claude`
+   * entry; everything else — chatgpt, codex, AND `unknown` — reads the
+   * `chatgpt` entry (see `annotationClientFamily` in `_surface.ts` for
+   * why `unknown` resolves chatgpt: an OpenAI reviewer or crawler whose
+   * UA the classifier misses must never see text that contradicts
+   * `chatgpt-app-submission.json`). Falls back to {@link description}
+   * when no entry exists. Use this when a tool's instructions diverge
+   * meaningfully by host (e.g. claude.ai auto-renders charts inline
+   * with server-side escalation while ChatGPT must redirect to the Tako
+   * agent on empty results) — sending each model only the directive it
+   * can act on is more reliable than asking it to self-identify and
+   * filter from a single description with conditional clauses.
+   *
+   * The key type is the two FAMILY names, not `McpClientKind`: a
+   * `codex:`/`unknown:` entry could never be resolved, so allowing the
+   * keys would only create dead config that still typechecks.
    */
-  descriptionByClient?: Partial<Record<McpClientKind, string>>;
+  descriptionByClient?: Partial<Record<"claude" | "chatgpt", string>>;
   inputSchema: InputSchema;
   outputSchema?: z.ZodType<Output>;
   annotations: ToolAnnotations;
@@ -364,7 +372,7 @@ export interface ToolModule<
    * false everywhere.
    */
   annotationsByClient?: Partial<
-    Record<McpClientKind, Partial<ToolAnnotations>>
+    Record<"claude" | "chatgpt", Partial<ToolAnnotations>>
   >;
   handler: (input: z.infer<InputSchema>, ctx: ToolContext) => Promise<Output>;
   /**
@@ -452,13 +460,13 @@ export interface ToolModule<
 export interface AnyToolModule {
   name: string;
   description: string;
-  descriptionByClient?: Partial<Record<McpClientKind, string>>;
+  descriptionByClient?: Partial<Record<"claude" | "chatgpt", string>>;
   inputSchema: z.ZodObject<z.ZodRawShape>;
   outputSchema?: z.ZodType<unknown>;
   annotations: ToolAnnotations;
   /** Per-client annotation overrides — see {@link ToolModule.annotationsByClient}. */
   annotationsByClient?: Partial<
-    Record<McpClientKind, Partial<ToolAnnotations>>
+    Record<"claude" | "chatgpt", Partial<ToolAnnotations>>
   >;
   handler: (input: unknown, ctx: ToolContext) => Promise<unknown>;
   renderText?: (output: unknown, ctx: ToolContext) => string;

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -88,7 +88,8 @@ export interface ToolContext {
    * `embed_url` directly and never reads the baked-in image), and
    * `mcp.ts` uses it to gate which tools each host sees — the
    * `tako_agent_start` / `tako_agent_wait` pair is registered only
-   * when `client === "chatgpt"`.
+   * for the ChatGPT family (`isChatGptFamilyClient`: chatgpt.com and
+   * the desktop app's codex runtime).
    *
    * NB: this is a server-instance-level value (set from User-Agent
    * detection at server creation), NOT a per-request flag. Don't

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -35,12 +35,11 @@ import type { Tier } from "../freetier.js";
  * as `codex-mcp-client/<version>`, one shared MCP client for desktop
  * Chat/Work threads, Codex tasks, and the headless CLI). It is the
  * ChatGPT product family for tool-surface purposes (see
- * `isChatGptFamilyClient` in `_surface.ts`) but deliberately NOT a widget
- * client yet: its widget sandbox is a custom `codex-sandbox://` scheme
- * origin that tako.com's `frame-ancestors` does not allow, so widget
- * `_meta` would make the app mount a card it cannot paint — a grey tile
- * where the inline PNG used to be. `isWidgetClient` documents the flip
- * checklist for when the backend CSP ships.
+ * `isChatGptFamilyClient` in `_surface.ts`) AND a widget client — its
+ * widget sandbox is a custom `codex-sandbox://` scheme origin, which
+ * tako.com's `frame-ancestors` admits since TakoData/tako#29218; on a
+ * backend without that header the card iframe is blocked and the app
+ * shows a grey tile (see `isWidgetClient` in `_surface.ts`).
  */
 export type McpClientKind = "claude" | "chatgpt" | "codex" | "unknown";
 

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -35,11 +35,12 @@ import type { Tier } from "../freetier.js";
  * as `codex-mcp-client/<version>`, one shared MCP client for desktop
  * Chat/Work threads, Codex tasks, and the headless CLI). It is the
  * ChatGPT product family for tool-surface purposes (see
- * `isChatGptFamilyClient` in `_surface.ts`) AND a widget client — its
- * widget sandbox is a custom `codex-sandbox://` scheme origin, which
- * tako.com's `frame-ancestors` admits since TakoData/tako#29218; on a
- * backend without that header the card iframe is blocked and the app
- * shows a grey tile (see `isWidgetClient` in `_surface.ts`).
+ * `isChatGptFamilyClient` in `_surface.ts`) but deliberately NOT a widget
+ * client yet: its widget sandbox is a custom `codex-sandbox://` scheme
+ * origin that tako.com's `frame-ancestors` does not allow, so widget
+ * `_meta` would make the app mount a card it cannot paint — a grey tile
+ * where the inline PNG used to be. `isWidgetClient` documents the flip
+ * checklist for when the backend CSP ships.
  */
 export type McpClientKind = "claude" | "chatgpt" | "codex" | "unknown";
 

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -30,8 +30,19 @@ import type { Tier } from "../freetier.js";
  * honor `notifications/progress` for timeout extension). Detection is
  * best-effort by UA substring match — when we can't classify,
  * `"unknown"` keeps the default (PNG) behavior.
+ *
+ * `"codex"` is the merged ChatGPT desktop app (its Codex runtime connects
+ * as `codex-mcp-client/<version>`, one shared MCP client for desktop
+ * Chat/Work threads, Codex tasks, and the headless CLI). It is the
+ * ChatGPT product family for tool-surface purposes (see
+ * `isChatGptFamilyClient` in `_surface.ts`) but deliberately NOT a widget
+ * client yet: its widget sandbox is a custom `codex-sandbox://` scheme
+ * origin that tako.com's `frame-ancestors` does not allow, so widget
+ * `_meta` would make the app mount a card it cannot paint — a grey tile
+ * where the inline PNG used to be. `isWidgetClient` documents the flip
+ * checklist for when the backend CSP ships.
  */
-export type McpClientKind = "claude" | "chatgpt" | "unknown";
+export type McpClientKind = "claude" | "chatgpt" | "codex" | "unknown";
 
 /**
  * Execution context handed to every tool `handler`. Built in `mcp.ts` once


### PR DESCRIPTION
## Summary

The merged ChatGPT desktop app connects through its Codex runtime as `codex-mcp-client/<version>` and fell to the `unknown` client surface: 3 free-tier tools, no `securitySchemes`, no reauth flow. This PR makes the desktop app a first-class **ChatGPT-family** client AND (since #240 merged into this branch) flips it to the same interactive chart widget as chatgpt.com:

- New `"codex"` client kind (`detectMcpClient`) + `isChatGptFamilyClient` predicate
- Codex gets the ChatGPT product surface: split agent pair, anonymous discoverable listing, `securitySchemes` injection (with the real client threaded through to the rollout log), the Apps-SDK reauth challenge, and family-routed `descriptionByClient`
- **Widget flip (#240)**: codex joins `isWidgetClient` — widget `_meta` on the three chart tools, default-on `tako_visualize`, dimensions-only PNG read (`bakeImage` gated on the family). Its hard dependency, TakoData/tako#29218's `frame-ancestors codex-sandbox:`, is verified live on production tako.com (2026-08-14).

## History: the flip was staged, then landed

A full pre-landing review measured the flip build live: a widget-classified codex tool call returns `[text]` only (widget `_meta` and image blocks are mutually exclusive), so the flip originally shipped as a separate draft (#240) gated on the production CSP deploy. That deploy is live and #240 merged into this branch on 2026-08-14 after local end-to-end verification (see the verification comment below).

**Known, accepted costs** (tracked as follow-ups): a flag-off (`enable_mcp_apps = false`) desktop app and the headless Codex CLI share this UA and lose the inline PNG for widget-classified calls. The CLI's `notifications/progress` handling (which decides whether the agent split is right for it) has not been measured — follow-up filed from the round-2 review.

## Review

**Round 1** (pre-landing, 3 specialists + adversarial passes): security clean — UA spoofing widens only what a connection *sees*, never what it can *execute* (tier-keyed dispatch gate verified); 5 revert-resistance gaps closed; 12 stale comments fixed.

**Round 2** (robertabbott, all 8 comments addressed in `ac133b1`): `client` param on the schemes adapter now required; `descriptionByClient`/`annotationsByClient` key types narrowed to the two annotation families (dead `codex:`/`unknown:` keys are now compile errors, docstring fixed); `assertChatgptSubmissionParity` asserts the codex surface equals chatgpt's at both tiers; codex `bakeImage` pins added for answer + visualize; anonymous codex `tools/list` pinned against unknown's free-tier trio; widget/family membership is a per-kind expected table.

## Safety

Mergeable and deployable now — the CSP dependency is live on production. Non-codex clients: no behavior change today (`descriptionByClient` overrides would also reach `unknown` clients by design — documented submission-consistency asymmetry — but no tool defines one yet). Codex: gains the full family surface + interactive widget; the flag-off/CLI PNG trade-off above is the one regression, accepted deliberately.

## Test plan

- [x] `npm run typecheck` (all four passes)
- [x] `npm test` — 1144 + 120 + 68, all green (post-rebase onto main at 0.20.0, post round-2 review)
- [x] `registry:check` / `schemas:check` green (now includes the codex↔chatgpt surface-parity assertion)
- [x] Live validation against the desktop app (0.147 + 0.148): list/call/schemes/reauth surfaces verified
- [x] Local worker verified as `codex-mcp-client`: initialize + `tools/list` serve the 5-tool family surface with widget `_meta` on the three chart tools
- [x] Production CSP verified: `curl -sI https://tako.com/embed/<pub_id>/` carries `frame-ancestors … codex-sandbox:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
