### PR TITLE
feat(widget): flip the ChatGPT desktop app to the interactive card

### DIFF
--- a/workers/src/index.test.ts
+++ b/workers/src/index.test.ts
@@ -468,16 +468,13 @@ describe("worker routing", () => {
     }
   });
 
-  it("POST /mcp tools/list serves the codex desktop app the family surface, without the widget", async () => {
-    // End-to-end pin for the ChatGPT desktop app (codex runtime): it gets
-    // the ChatGPT-family treatment — securitySchemes injection included —
-    // but NOT the widget `_meta` and NOT default-on tako_visualize, both
-    // of which are gated on `isWidgetClient` until tako.com's
-    // `frame-ancestors` allows `codex-sandbox:` AND the flip is validated
-    // live (see isChatGptFamilyClient's flip checklist). Without this
-    // test, reverting any single `isChatGptFamilyClient` call site back
-    // to `client === "chatgpt"` passes the whole suite while silently
-    // degrading the desktop app to the 3-tool unknown surface.
+  it("POST /mcp tools/list serves the codex desktop app the family surface, with the widget", async () => {
+    // End-to-end pin for the ChatGPT desktop app (codex runtime) AFTER
+    // the widget flip: full ChatGPT-family treatment — securitySchemes
+    // injection, default-on tako_visualize, and widget `_meta` — exactly
+    // mirroring chatgpt.com. Without this test, reverting any single
+    // `isChatGptFamilyClient`/`isWidgetClient` call site passes the
+    // whole suite while silently degrading the desktop app.
     const res = await SELF.fetch("https://example.com/mcp", {
       method: "POST",
       headers: {
@@ -504,23 +501,28 @@ describe("worker routing", () => {
         }>;
       };
     };
-    // Family surface minus the widget-gated visualize (default-on rides
-    // `isWidgetClient`, which codex has not joined yet).
+    // Full family surface, identical to chatgpt.com: visualize is
+    // default-on because codex is a widget client after the flip.
     expect(body.result.tools.map((t) => t.name).sort()).toEqual([
       "tako_answer",
       "tako_available_data",
       "tako_contents",
       "tako_search",
+      "tako_visualize",
     ]);
     const oauth2 = { type: "oauth2", scopes: ["mcp"] };
+    const widgetOwners = new Set([
+      "tako_answer",
+      "tako_search",
+      "tako_visualize",
+    ]);
     for (const t of body.result.tools) {
       // The family injection reaches codex descriptors...
       expect(t.securitySchemes, t.name).toEqual([oauth2]);
-      // ...but widget `_meta` must not: a codex widget iframe is blocked
-      // by tako.com's frame-ancestors until the backend deploy, and
-      // widget `_meta` suppresses the inline PNG the app renders today.
-      expect(t._meta?.["openai/outputTemplate"], t.name).toBeUndefined();
-      expect(t._meta?.["ui"], t.name).toBeUndefined();
+      // ...and the chart tools carry the widget `_meta` chatgpt.com gets.
+      if (widgetOwners.has(t.name)) {
+        expect(t._meta?.["openai/outputTemplate"], t.name).toBeDefined();
+      }
     }
   });
 

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -608,26 +608,22 @@ describe("chart render gates per client", () => {
     ).toBeDefined();
   });
 
-  it("codex client: chart ships as an inline image content block, NO widget metadata", async () => {
-    // THE staged-rollout pin (adversarial review, PR #239): the desktop
-    // app's `enable_mcp_apps` flag is off for almost all users and the
-    // same UA covers the headless Codex CLI — for both, widget `_meta`
-    // would suppress this image block (the mutual-exclusion gate) and
-    // the chart would vanish from the chat entirely. Codex therefore
-    // keeps the unknown-style PNG until the flip is validated live.
-    // Measured 2026-08-13: a widget-classified codex build returned
-    // [text] only, vs [text, image] for unknown — this test exists so
-    // that regression can never ship silently again.
-    mockFetchSequence([searchResponse(), pngResponse()]);
+  it("codex client: widget metadata ships, no image block, and no PNG prefetch", async () => {
+    // THE FLIP (supersedes PR #239's staged pin): codex now mirrors
+    // chatgpt exactly — widget `_meta`, no image content block, no PNG
+    // prefetch. KNOWN COSTS accepted by this flip, do not merge until
+    // they are answered live (see the draft PR's open questions):
+    // flag-off desktop users and the headless Codex CLI lose the inline
+    // PNG this result used to carry (measured 2026-08-13: [text] only vs
+    // [text, image] for unknown).
+    mockFetchSequence([searchResponse()]);
 
     const result = await callSearch("codex");
 
-    const imageBlocks = result.content.filter((b) => b.type === "image");
-    expect(imageBlocks).toHaveLength(1);
-    expect(imageBlocks[0]?.mimeType).toBe("image/png");
+    expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
     expect(
       (result._meta as { ui?: unknown } | undefined)?.ui,
-    ).toBeUndefined();
+    ).toBeDefined();
   });
 
   it("claude client: no image block when the search returns zero cards", async () => {

--- a/workers/src/tools/_surface.test.ts
+++ b/workers/src/tools/_surface.test.ts
@@ -3,10 +3,11 @@
  * registered surface.
  *
  * The requirement this encodes: the chart widget and the tool that exists to
- * produce one (`tako_visualize`) reach the two hosts that render widgets
- * inline — ChatGPT and claude.ai / Claude Desktop — and NOTHING else. Generic
- * MCP clients keep the portable inline-PNG path and must opt in explicitly
- * with `?tools=visualize` if they want the tool at all.
+ * produce one (`tako_visualize`) reach the three hosts that render widgets
+ * inline — ChatGPT, the ChatGPT desktop app (codex), and claude.ai / Claude
+ * Desktop — and NOTHING else. Generic MCP clients keep the portable
+ * inline-PNG path and must opt in explicitly with `?tools=visualize` if they
+ * want the tool at all.
  *
  * Why a table and not per-case assertions: the boundary is enforced by two
  * separate things agreeing — `detectMcpClient`'s UA buckets and
@@ -57,17 +58,17 @@ const CLIENTS: Row[] = [
     kind: "unknown",
     widget: false,
   },
-  // ChatGPT family but deliberately NOT a widget client yet: the desktop
-  // app's widget sandbox is a `codex-sandbox://` scheme origin that
-  // tako.com's `frame-ancestors` rejects, so widget `_meta` would replace
-  // the working inline PNG with a grey dead tile. Flip checklist lives on
-  // `isChatGptFamilyClient` in `_surface.ts` — do not flip this row's
-  // `widget` without completing it.
+  // The ChatGPT desktop app renders the same interactive iframe as
+  // chatgpt.com from its `codex-sandbox://` webview. Widget membership
+  // DEPENDS on tako.com's `frame-ancestors` allowing the `codex-sandbox:`
+  // scheme (TakoData/tako#29218) — on a backend without that deploy the
+  // iframe is blocked and the app shows a grey tile, so don't revert that
+  // header without flipping this row back to false.
   {
     ua: "codex-mcp-client/0.148.0-alpha.9",
     label: "ChatGPT desktop app / Codex runtime",
     kind: "codex",
-    widget: false,
+    widget: true,
   },
   { ua: "cursor-vscode/1.0", label: "Cursor", kind: "unknown", widget: false },
   { ua: "Windsurf/1.0", label: "Windsurf", kind: "unknown", widget: false },
@@ -107,20 +108,24 @@ describe("widget exposure boundary", () => {
   };
   const KINDS = Object.keys(ALL_KINDS) as McpClientKind[];
 
-  it("exposes the widget to exactly two client kinds", () => {
-    // Guards against a kind being added to `isWidgetClient` without
-    // anyone revisiting what that means for the default surface. `"codex"`
-    // in particular must stay out until tako.com's `frame-ancestors`
-    // allows `codex-sandbox:` AND the flip is validated live — see the
-    // flip checklist on `isChatGptFamilyClient`.
-    expect(KINDS.filter(isWidgetClient)).toEqual(["chatgpt", "claude"]);
+  it("exposes the widget to exactly three client kinds", () => {
+    // Guards against a kind being added to `isWidgetClient` without anyone
+    // revisiting what that means for the default surface. `"codex"` is a
+    // member only because tako.com's `frame-ancestors` allows
+    // `codex-sandbox:` (TakoData/tako#29218) AND the flip was validated
+    // live against the desktop app.
+    expect(KINDS.filter(isWidgetClient)).toEqual([
+      "chatgpt",
+      "claude",
+      "codex",
+    ]);
   });
 
   it("puts exactly chatgpt and codex in the ChatGPT product family", () => {
     expect(KINDS.filter(isChatGptFamilyClient)).toEqual(["chatgpt", "codex"]);
   });
 
-  it("gives codex the ChatGPT tool split, without the widget", () => {
+  it("gives codex the full ChatGPT tool split", () => {
     // The desktop app is the same product as chatgpt.com on the tool
     // surface (verified live against the app 2026-08-13). Split pair in
     // when opted in, dispatch+poll agent out even when asked for:
@@ -138,10 +143,6 @@ describe("widget exposure boundary", () => {
     // `unknown` clients never see.
     expect(isToolOnSurface("tako_contents", "codex", new Set(), "free")).toBe(true);
     expect(isToolOnSurface("tako_contents", "unknown", new Set(), "free")).toBe(false);
-    // tako_visualize stays off codex's default surface for now: default-on
-    // rides `isWidgetClient` (its whole output is the widget chart), so it
-    // returns exactly when the widget flip happens.
-    expect(isToolOnSurface("tako_visualize", "codex", new Set(), "authenticated")).toBe(false);
   });
 
   it("lets a non-widget client opt in explicitly", () => {

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -58,8 +58,14 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * ChatGPT renders the widget as a fully interactive iframe; Claude renders
  * the same bundle via its image branch (claude.ai's host CSP blocks the
  * cross-origin iframe today — anthropics/claude-ai-mcp#40 — and the bundle
- * probes for that at runtime). Everything else — Cursor, Windsurf, Gemini
- * CLI, LibreChat, Claude Code's terminal client — gets the PNG.
+ * probes for that at runtime). The ChatGPT desktop app (`"codex"`) renders
+ * the same interactive iframe as chatgpt.com from its `codex-sandbox://`
+ * webview — REQUIRES tako.com's `frame-ancestors` to allow the
+ * `codex-sandbox:` scheme (shipped in TakoData/tako#29218; before that
+ * deploy the iframe dies with `ERR_BLOCKED_BY_RESPONSE` and the app shows
+ * a grey tile where the PNG used to be). Everything else — Cursor,
+ * Windsurf, Gemini CLI, LibreChat, Claude Code's terminal client — gets
+ * the PNG.
  *
  * This is the ONE definition of "widget client". `mcp.ts` computes
  * `widgetSuppressed` from it, and {@link WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES}
@@ -68,7 +74,7 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * `client === …` comparisons in separate files before).
  */
 export function isWidgetClient(client: McpClientKind): boolean {
-  return client === "chatgpt" || client === "claude";
+  return client === "chatgpt" || client === "claude" || client === "codex";
 }
 
 /**
@@ -79,21 +85,13 @@ export function isWidgetClient(client: McpClientKind): boolean {
  * product with two MCP transports (verified live against the desktop app
  * 2026-08-13: it lists, calls, and auth-gates exactly like chatgpt.com).
  *
- * Deliberately NOT the same predicate as {@link isWidgetClient}: codex is
- * family but not (yet) a widget client. Its widget sandbox origin is a
- * custom `codex-sandbox://` scheme that tako.com's `frame-ancestors`
- * rejects (`ERR_BLOCKED_BY_RESPONSE` on the card iframe), so widget
- * `_meta` today would replace the working inline PNG with a grey dead
- * tile in the desktop app.
- *
- * FLIP CHECKLIST — when the backend allows `codex-sandbox:` in
- * `frame-ancestors` (tako repo `build_csp_header`, monolith/views.py) and
- * a desktop app with `enable_mcp_apps` renders a card end-to-end:
- *   1. add `client === "codex"` to {@link isWidgetClient};
- *   2. switch the three `bakeImage: ctx.client !== "chatgpt"` gates
- *      (tako_search / tako_answer / tako_visualize) to
- *      `!isChatGptFamilyClient(ctx.client)` so codex skips the PNG
- *      prefetch its widget no longer reads.
+ * Deliberately NOT the same predicate as {@link isWidgetClient}: claude is
+ * a widget client but not ChatGPT family, and the two sets gate different
+ * things — this one the product surface, that one the widget `_meta`.
+ * Codex joined `isWidgetClient` only once tako.com's `frame-ancestors`
+ * allowed the `codex-sandbox:` scheme (TakoData/tako#29218) — its widget
+ * iframe is blocked with `ERR_BLOCKED_BY_RESPONSE` on any backend without
+ * that deploy, leaving a grey dead tile where the PNG used to be.
  */
 export function isChatGptFamilyClient(client: McpClientKind): boolean {
   return client === "chatgpt" || client === "codex";

--- a/workers/src/tools/tako_answer.ts
+++ b/workers/src/tools/tako_answer.ts
@@ -4,6 +4,7 @@ import { djangoPost } from "../django.js";
 import { AnswerResponse, SearchRequest } from "../generated/schemas.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import {
   answerSlimOutputShape,
   renderAnswerMarkdown,
@@ -378,11 +379,12 @@ const takoAnswer = {
   // there; the only reason it is duplicated rather than shared is that the
   // hooks are per-tool fields on `ToolModule`.
   async extraMeta(output, ctx) {
-    // ChatGPT renders `embed_url` in an iframe and never reads the baked PNG,
-    // but still needs the aspect ratio to size that iframe — dimensions only
-    // there (a 64-byte ranged read instead of a ~170 KB render).
+    // The ChatGPT family renders `embed_url` in an iframe and never reads
+    // the baked PNG, but still needs the aspect ratio to size that iframe —
+    // dimensions only there (a 64-byte ranged read instead of a ~170 KB
+    // render).
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: ctx.client !== "chatgpt",
+      bakeImage: !isChatGptFamilyClient(ctx.client),
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_search.ts
+++ b/workers/src/tools/tako_search.ts
@@ -26,6 +26,7 @@ import {
 } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import {
   renderSearchMarkdown,
   searchSlimOutputShape,
@@ -313,14 +314,15 @@ const tako_search = {
     // gate we pay the full chart-render latency
     // (`PNG_FETCH_TIMEOUT_MS` = 8s upper bound) on every ChatGPT
     // tool call just to populate a field the host throws away.
-    // ChatGPT gets DIMENSIONS ONLY (a 64-byte ranged read): its widget renders
-    // `embed_url` in an iframe and never reads the baked PNG, but it cannot
-    // measure that cross-origin iframe's content, so without the card's real
-    // aspect ratio the iframe falls back to a fixed height and leaves empty
-    // bands under a wide chart. Claude gets the full baked image — there the
+    // The ChatGPT family (chatgpt.com AND the desktop app) gets DIMENSIONS
+    // ONLY (a 64-byte ranged read): their widget renders `embed_url` in an
+    // iframe and never reads the baked PNG, but it cannot measure that
+    // cross-origin iframe's content, so without the card's real aspect
+    // ratio the iframe falls back to a fixed height and leaves empty bands
+    // under a wide chart. Claude gets the full baked image — there the
     // PNG *is* the chart.
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: ctx.client !== "chatgpt",
+      bakeImage: !isChatGptFamilyClient(ctx.client),
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/tako_visualize.ts
+++ b/workers/src/tools/tako_visualize.ts
@@ -32,6 +32,7 @@ import {
 } from "./_chart_widget.js";
 import { looseArray } from "./_loose_array.js";
 import { logWireGuardFailure } from "./_log.js";
+import { isChatGptFamilyClient } from "./_surface.js";
 import { autoChainShape } from "./_search_results.js";
 import type { AppUiResource, ToolContentBlock, ToolModule } from "./types.js";
 
@@ -460,7 +461,7 @@ const tako_visualize = {
     // bands under a wide chart. Claude gets the full baked image — there the
     // PNG *is* the chart.
     return buildChartExtraMeta(output.image_url, {
-      bakeImage: ctx.client !== "chatgpt",
+      bakeImage: !isChatGptFamilyClient(ctx.client),
       env: ctx.env,
       origin: ctx.origin,
       pubId: output.pub_id,

--- a/workers/src/tools/types.ts
+++ b/workers/src/tools/types.ts
@@ -35,12 +35,11 @@ import type { Tier } from "../freetier.js";
  * as `codex-mcp-client/<version>`, one shared MCP client for desktop
  * Chat/Work threads, Codex tasks, and the headless CLI). It is the
  * ChatGPT product family for tool-surface purposes (see
- * `isChatGptFamilyClient` in `_surface.ts`) but deliberately NOT a widget
- * client yet: its widget sandbox is a custom `codex-sandbox://` scheme
- * origin that tako.com's `frame-ancestors` does not allow, so widget
- * `_meta` would make the app mount a card it cannot paint — a grey tile
- * where the inline PNG used to be. `isWidgetClient` documents the flip
- * checklist for when the backend CSP ships.
+ * `isChatGptFamilyClient` in `_surface.ts`) AND a widget client — its
+ * widget sandbox is a custom `codex-sandbox://` scheme origin, which
+ * tako.com's `frame-ancestors` admits since TakoData/tako#29218; on a
+ * backend without that header the card iframe is blocked and the app
+ * shows a grey tile (see `isWidgetClient` in `_surface.ts`).
  */
 export type McpClientKind = "claude" | "chatgpt" | "codex" | "unknown";
 


### PR DESCRIPTION
## Summary

Executes the widget flip staged by #239: `codex` joins `isWidgetClient`, the three `bakeImage` gates move to `isChatGptFamilyClient`, and the desktop app gets the identical interactive-iframe treatment as chatgpt.com (widget `_meta`, default-on `tako_visualize`, dimensions-only PNG read).

## Hard dependency

- [x] TakoData/tako#29218 (`frame-ancestors codex-sandbox:`) deployed to **production** tako.com. Verified 2026-08-14: `curl -sI https://tako.com/embed/<pub_id>/` returns `content-security-policy: frame-ancestors ... codex-sandbox:` on both tako.com and trytako.com. Before this deploy, the widget iframe died with `ERR_BLOCKED_BY_RESPONSE` and flag-on users got a permanent grey tile.

## Open questions (from the adversarial review — answer live before merging)

1. **Flag-off majority**: widget `_meta` suppresses the inline PNG (measured: `[text]` only vs `[text, image]`). What does a flag-off 0.148 app render for a result carrying widget `_meta` — the text only, or does its UI still show something? If text-only, this flip deletes the chart for most desktop users until `enable_mcp_apps` GAs, and should wait or be reworked (e.g. version/flag detection, or pairing behavior tested).
2. **Headless Codex CLI**: same UA, terminal renderer — it permanently loses the inline PNG. Acceptable? (Same product decision the codebase made oppositely for `claude-code`.)
3. **Pairing test**: does the desktop app still render the widget if an image content block rides along? (chatgpt.com historically broke on this — the mutual-exclusion gate exists for that reason. If codex tolerates pairing, the flag-off problem disappears.)
4. **Old versions**: 0.147 fetches the bundle but advertised no capability; should the classifier parse the UA version and only flip ≥0.148?

## Validation plan

Local worker on this branch + desktop app with `enable_mcp_apps = true` + prod CSP live → interactive card renders end-to-end; then answer questions 1–3 by flipping the flag off and testing the CLI.

## Test plan

- [x] typecheck (4 passes) + full suite green (1127 + 117 + 68) — re-verified 2026-08-14 on e0c117b with prod CSP live
- [ ] Live end-to-end card render in the desktop app
- [ ] Flag-off + CLI behavior answered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
