### PR TITLE
fix(registry): stop the codex parity gate from blocking a widget rollback

### DIFF
--- a/workers/scripts/gen-registry.ts
+++ b/workers/scripts/gen-registry.ts
@@ -30,6 +30,7 @@ import {
 import {
   isToolOnSurface,
   toolAnnotationsForClient,
+  WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES,
 } from "../src/tools/_surface.js";
 import type { ToolAnnotations, ToolModule } from "../src/tools/types.js";
 
@@ -293,28 +294,41 @@ export function assertChatgptSubmissionParity(
   // The submission covers the ChatGPT PRODUCT, and the product has two MCP
   // transports: chatgpt.com's connector AND the desktop app (detected as
   // "codex"). Every surface equality above is asserted against "chatgpt"
-  // only, so without this block a revert of codex's family/widget
-  // membership (e.g. dropping it from `isChatGptFamilyClient`) would leave
-  // `registry:check` green while the desktop app lists a DIFFERENT tool set
-  // than the submission declares — review finding on PR #239. Equality of
-  // the two members' surfaces at both tiers is exactly "the family shares
-  // one surface", which is the premise the submission rests on.
+  // only, so without this block a revert of codex's FAMILY membership
+  // (dropping it from `isChatGptFamilyClient`) would leave `registry:check`
+  // green while the desktop app lists a DIFFERENT tool set than the
+  // submission declares — review finding on PR #239.
+  //
+  // Deliberately compared MODULO the widget-default-on names: this check
+  // runs as a DEPLOY GATE (workers-deploy.yml), and the widget flip's only
+  // rollback lever is removing `codex` from `isWidgetClient` (there is no
+  // widget kill switch in `Env`). That one-line revert drops the
+  // default-on `tako_visualize` from codex while chatgpt keeps it — a raw
+  // surface equality here would fail the gate and BLOCK the rollback
+  // deploy, telling the operator to undo their rollback (round-3 review
+  // finding on PR #239). So the gate asserts only what the FAMILY
+  // predicate feeds; codex's widget membership is pinned in the test
+  // suites instead (_surface.test.ts membership table, index.test.ts,
+  // mcp.test.ts), which fail loudly without holding a deploy hostage.
   for (const tier of ["authenticated", "free"] as const) {
-    const chatgptSurface = tools
-      .filter((t) => isToolOnSurface(t.name, "chatgpt", noOptIns, tier))
-      .map((t) => t.name)
-      .sort();
-    const codexSurface = tools
-      .filter((t) => isToolOnSurface(t.name, "codex", noOptIns, tier))
-      .map((t) => t.name)
-      .sort();
+    const familySurface = (client: "chatgpt" | "codex"): string[] =>
+      tools
+        .filter(
+          (t) =>
+            !WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES.has(t.name) &&
+            isToolOnSurface(t.name, client, noOptIns, tier),
+        )
+        .map((t) => t.name)
+        .sort();
+    const chatgptSurface = familySurface("chatgpt");
+    const codexSurface = familySurface("codex");
     if (JSON.stringify(codexSurface) !== JSON.stringify(chatgptSurface)) {
       problems.push(
         `codex (ChatGPT desktop app) ${tier} surface [${codexSurface.join(
           ", ",
         )}] diverges from chatgpt's [${chatgptSurface.join(
           ", ",
-        )}] — the submission describes the ChatGPT product, which includes the desktop app; restore family membership in workers/src/tools/_surface.ts`,
+        )}] (widget-default-on names excluded) — the submission describes the ChatGPT product, which includes the desktop app; restore family membership in workers/src/tools/_surface.ts`,
       );
     }
   }

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -593,38 +593,47 @@ describe("chart render gates per client", () => {
     ).toBeUndefined();
   });
 
-  it("chatgpt client: widget metadata ships, no image block, and no PNG prefetch", async () => {
-    // Exactly ONE response queued: the v3 search. ChatGPT keeps the
-    // interactive widget (which loads `embed_url` itself), so neither
-    // the image-content-block fetch nor `extraMeta`'s PNG prefetch may
-    // fire — `mockFetchSequence` throws loudly on any second call.
-    mockFetchSequence([searchResponse()]);
+  it.each(["chatgpt", "codex"] as const)(
+    "%s client: widget metadata ships, no image block, dimensions-only PNG read",
+    async (client) => {
+      // Codex mirrors chatgpt exactly since the flip (PR #240): widget
+      // `_meta`, no image content block, and a RANGED dimensions read
+      // instead of the full PNG bake. ACCEPTED-COST RECORD (validated
+      // live 2026-08-14, PR #239 body): a flag-off desktop app and the
+      // headless Codex CLI share this UA and lose the inline PNG this
+      // result used to carry (measured 2026-08-13: [text] only vs
+      // [text, image] for unknown).
+      //
+      // The earlier shape of this test queued ONE response and relied on
+      // `mockFetchSequence`'s queue-exhaustion throw to pin "no PNG
+      // prefetch" — but the top card carries an `image_url`, so
+      // `extraMeta` DOES fetch (the ranged `fetchPngDimensions`), and the
+      // throw was swallowed by that helper's catch and again by mcp.ts's
+      // `extraMeta` catch: a revert to the full-bake path stayed green
+      // (round-3 review finding on PR #239). Now the second fetch is
+      // queued and asserted: exactly two calls, and the PNG one carries a
+      // Range header — a full `fetchImageDataUrlAndDims` bake reads the
+      // whole body and sends none.
+      const fetchMock = mockFetchSequence([
+        searchResponse(),
+        new Response(new Uint8Array(64), {
+          status: 206,
+          headers: { "content-type": "image/png" },
+        }),
+      ]);
 
-    const result = await callSearch("chatgpt");
+      const result = await callSearch(client);
 
-    expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
-    expect(
-      (result._meta as { ui?: unknown } | undefined)?.ui,
-    ).toBeDefined();
-  });
-
-  it("codex client: widget metadata ships, no image block, and no PNG prefetch", async () => {
-    // THE FLIP (supersedes PR #239's staged pin): codex now mirrors
-    // chatgpt exactly — widget `_meta`, no image content block, no PNG
-    // prefetch. KNOWN COSTS accepted by this flip, do not merge until
-    // they are answered live (see the draft PR's open questions):
-    // flag-off desktop users and the headless Codex CLI lose the inline
-    // PNG this result used to carry (measured 2026-08-13: [text] only vs
-    // [text, image] for unknown).
-    mockFetchSequence([searchResponse()]);
-
-    const result = await callSearch("codex");
-
-    expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
-    expect(
-      (result._meta as { ui?: unknown } | undefined)?.ui,
-    ).toBeDefined();
-  });
+      expect(result.content.filter((b) => b.type === "image")).toHaveLength(0);
+      expect(
+        (result._meta as { ui?: unknown } | undefined)?.ui,
+      ).toBeDefined();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const pngRequest = new Request(...(fetchMock.mock.calls[1] as [RequestInfo, RequestInit?]));
+      expect(pngRequest.url).toContain("/api/v1/image/");
+      expect(pngRequest.headers.get("range")).not.toBeNull();
+    },
+  );
 
   it("claude client: no image block when the search returns zero cards", async () => {
     // Empty result → no top card → no image_url → `extraMeta`'s PNG

--- a/workers/src/tools/_surface.ts
+++ b/workers/src/tools/_surface.ts
@@ -72,6 +72,21 @@ export const CHATGPT_EXCLUDED_TOOL_NAMES: ReadonlySet<string> = new Set([
  * below keys off it too, so the tool that ships a widget and the clients that
  * receive widget metadata cannot drift apart (they were two hand-maintained
  * `client === …` comparisons in separate files before).
+ *
+ * ACCEPTED COST of `"codex"` membership: one UA covers the desktop app,
+ * Codex tasks, AND the headless Codex CLI, so the CLI — a terminal that
+ * renders no widget — pays the default-on `tako_visualize` schema
+ * (~3.5k tokens, the largest descriptor on the surface) in every session,
+ * the exact cost {@link WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES} spares Claude
+ * Code by bucketing it `unknown`. A carve-out has no per-REQUEST signal:
+ * the UA is shared, and the one real discriminator — the widget-capable
+ * app advertises `io.modelcontextprotocol/ui` in `initialize` — appears
+ * only there, while this Worker computes surfaces statelessly on every
+ * request. Distinguishing the CLI therefore means persisting per-session
+ * capability state, a follow-up-shaped change, not a predicate edit here.
+ * The trade favors the desktop app deliberately — it is where codex
+ * traffic comes from — and is recorded on PR #239 alongside the CLI's
+ * lost inline PNG (round-3 review finding).
  */
 export function isWidgetClient(client: McpClientKind): boolean {
   return client === "chatgpt" || client === "claude" || client === "codex";


### PR DESCRIPTION
## Summary

Addresses all four round-3 (post-merge) review findings on #239. One is a real operational defect on code live in production; the other three ride along as small hardening/doc fixes in the same files.

**The necessary fix — rollback blocker (gen-registry.ts)**: the codex↔chatgpt surface-parity assertion added in #239's round-2 ran as a deploy gate (`registry:check` in `workers-deploy.yml`) and compared raw surfaces, which `isWidgetClient` also feeds. The widget flip's only rollback lever is removing `codex` from `isWidgetClient` (there is no widget kill switch in `Env`) — and that one-line revert made the gate fail and instruct the operator to undo the rollback, blocking the rollback deploy exactly when it's needed. The comparison now excludes `WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES`, so the deploy gate asserts only family-driven parity; widget membership stays pinned in the test suites (`_surface.test.ts` membership table, index/mcp tests), which fail loudly without holding a deploy hostage.

**Ride-alongs**:
- **mcp.test.ts**: the chatgpt/codex search pins titled "no PNG prefetch" pinned nothing — the queue-exhaustion throw they relied on is swallowed by `fetchPngDimensions` and the `extraMeta` catch, so a full-bake revert stayed green. Now parametrized over both family members with the ranged read asserted (`toHaveBeenCalledTimes(2)` + Range header on the PNG request), matching the answer/visualize pins.
- **mcp.test.ts**: stale "do not merge until answered live" comment rewritten as the accepted-cost record it now is (the live validation happened; #239's body records the costs).
- **_surface.ts**: `isWidgetClient` now documents the accepted CLI cost of codex membership (the ~3.5k-token default-on `tako_visualize` schema in every terminal session) and why a carve-out requires per-session capability state rather than a predicate edit — the one real discriminator (`io.modelcontextprotocol/ui`) appears only in `initialize`, and surfaces are computed statelessly per request.

## Verification

- [x] typecheck (4 passes); suites 1144 + 120 + 68 green; `registry:check` + `schemas:check` green
- [x] **Rollback simulation**: with codex temporarily removed from `isWidgetClient`, `registry:check` passes (rollback deploy unblocked); with codex removed from `isChatGptFamilyClient`, it fails with the named remediation (family drift still caught)
- [x] Full-bake revert simulation is what the new range assertion encodes: a second queued 206 response + Range-header assertion fails on `fetchImageDataUrlAndDims`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
