### PR TITLE
fix(widget): reveal the ChatGPT committed iframe only when the embed has painted

### DIFF
--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -479,7 +479,11 @@ describe("freeTierLimitResponse", () => {
     const body = (await res.json()) as {
       jsonrpc: string;
       id: number;
-      result: { content: Array<{ type: string; text: string }>; isError: boolean };
+      result: {
+        content: Array<{ type: string; text: string }>;
+        isError: boolean;
+        _meta: Record<string, unknown>;
+      };
     };
     expect(body.jsonrpc).toBe("2.0");
     expect(body.id).toBe(4);
@@ -487,6 +491,12 @@ describe("freeTierLimitResponse", () => {
     expect(body.result.content).toEqual([
       { type: "text", text: FREE_TIER_LIMIT_MESSAGE },
     ]);
+    // The failed-call discriminant every other error result carries. The
+    // chart widget keys its labelled empty state on it — without this the
+    // most common anonymous-ChatGPT failure left an unlabelled blank box.
+    expect(body.result._meta).toEqual({
+      "tako/error": { kind: "rate_limited" },
+    });
   });
 
   it("without a request id: degrades to the legacy 429 with Retry-After", async () => {
@@ -510,13 +520,23 @@ describe("freeTierGlobalLimitResponse", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       id: string;
-      result: { content: Array<{ type: string; text: string }>; isError: boolean };
+      result: {
+        content: Array<{ type: string; text: string }>;
+        isError: boolean;
+        _meta: Record<string, unknown>;
+      };
     };
     expect(body.id).toBe("req-3");
     expect(body.result.isError).toBe(true);
     expect(body.result.content).toEqual([
       { type: "text", text: FREE_TIER_GLOBAL_LIMIT_MESSAGE },
     ]);
+    // Same discriminant as the per-IP bucket, kind mirroring the 429
+    // branch's data.kind — distinct spellings on purpose (see the
+    // function's comment on topology visibility).
+    expect(body.result._meta).toEqual({
+      "tako/error": { kind: "global_rate_limited" },
+    });
   });
 
   it("without an id: a 429 JSON-RPC error with the capacity message and Retry-After", async () => {

--- a/workers/src/freetier.ts
+++ b/workers/src/freetier.ts
@@ -394,6 +394,13 @@ export function freeTierLimitResponse(requestId: JsonRpcRequestId): Response {
       id: requestId,
       result: {
         content: [{ type: "text", text: FREE_TIER_LIMIT_MESSAGE }],
+        // Same discriminant every other failed tool result carries
+        // (djangoErrorToToolResult, freeTierCreditsToolResult, …), same
+        // spelling as the 429 branch's `data.kind` above. The chart widget
+        // keys its labelled empty state on this: rate limiting is the most
+        // common anonymous-ChatGPT failure, and without the marker it was
+        // the one failure that still left an unlabelled blank box.
+        _meta: { "tako/error": { kind: "rate_limited" } },
         isError: true,
       },
     }),
@@ -462,6 +469,10 @@ export function freeTierGlobalLimitResponse(
       id: requestId,
       result: {
         content: [{ type: "text", text: FREE_TIER_GLOBAL_LIMIT_MESSAGE }],
+        // See freeTierLimitResponse: the widget's failed-call label keys on
+        // this. Kind mirrors the 429 branch's `data.kind`, distinct from the
+        // per-IP bucket on purpose (comment above).
+        _meta: { "tako/error": { kind: "global_rate_limited" } },
         isError: true,
       },
     }),

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -2254,6 +2254,63 @@ const WIDGET_HTML = `<!doctype html>
     return "cards" in o || "answer" in o || "web_results" in o;
   }
 
+  // Does this object say the CALL ITSELF failed? Two spellings, both
+  // positive claims rather than inferences: the MCP envelope's
+  // \`isError: true\`, and the server's own \`_meta["tako/error"]\`
+  // discriminant (attached to every mapped upstream failure — Django
+  // errors, free-tier capacity; see \`djangoErrorToToolResult\` in mcp.ts).
+  // Either is the affirmative knowledge the no-data watchdog lacks: a
+  // failed call and a late delivery stop being indistinguishable the
+  // moment one of these is visible.
+  function isErrorSignal(o) {
+    if (!o || typeof o !== "object") return false;
+    if (o.isError === true) return true;
+    var direct = o["tako/error"];
+    if (direct && typeof direct === "object") return true;
+    var meta = o._meta;
+    if (meta && typeof meta === "object") {
+      var nested = meta["tako/error"];
+      if (nested && typeof nested === "object") return true;
+    }
+    return false;
+  }
+
+  // The failed-call signal across ChatGPT's envelope spellings — same
+  // best-first probing (and the same reason) as \`pickMetaFromOpenAi\`:
+  // \`toolResponseMetadata\` "preserves the full MCP result envelope,
+  // including hidden \`_meta\`", but the envelope's internal shape is
+  // ChatGPT's, not the spec's.
+  function trmHasError(trm) {
+    if (!trm || typeof trm !== "object") return false;
+    return (
+      isErrorSignal(trm) ||
+      isErrorSignal(trm.mcp_tool_result) ||
+      isErrorSignal(trm.call_tool_result)
+    );
+  }
+  function pickErrorFromOpenAi() {
+    var w = window;
+    if (!w || !w.openai || typeof w.openai !== "object") return false;
+    return trmHasError(w.openai.toolResponseMetadata);
+  }
+
+  // Label-and-collapse for a KNOWN-failed call. The same collapse the
+  // no-chart guard uses, with failure copy: hosts that keep the box anyway
+  // (ChatGPT pins its mount height and ignores shrinks) then show an
+  // intentional labelled state instead of a blank card that reads as a
+  // display failure. The label makes no claim about WHY — the host renders
+  // the error text itself, right next to this box.
+  //
+  // Every call site checks the payload channels FIRST: a result that can
+  // paint must never be pre-empted by leftover error metadata in a lesser
+  // channel, and within one call a chart and \`isError\` never coexist.
+  function collapseFailed() {
+    if (rendered) return;
+    empty.textContent = "No chart: the call failed.";
+    collapse(true);
+    log("failed call, collapsed widget with label");
+  }
+
   // Best-first over ordered candidates, plus the widget-state mirror as the
   // last thing tried. Truthiness is NOT the selector: ChatGPT's stripped
   // reload payload (\`{width, height}\`) is a perfectly truthy object, so a
@@ -2369,16 +2426,30 @@ const WIDGET_HTML = `<!doctype html>
   // ChatGPT populates the global at unpredictable times. Cost: one
   // property read every 250 ms.
   if (!render(pickPayload(null), pickMetaFromOpenAi())) {
-    var attempts = 0;
-    var handle = setInterval(function () {
-      attempts += 1;
-      // Re-read the meta each tick, not once before the loop: the payload and
-      // its \`_meta\` can land on different ticks, and pinning a stale
-      // \`undefined\` here would reintroduce the exact bug this fixes.
-      if (render(pickPayload(null), pickMetaFromOpenAi()) || attempts >= 40) {
-        clearInterval(handle);
-      }
-    }, 250);
+    // Payload first, error second — see \`collapseFailed\`. An \`isError\`
+    // result never grows a payload later, so acting on it synchronously
+    // spares the user the 10 s of blank box the watchdog would allow.
+    if (pickErrorFromOpenAi()) {
+      collapseFailed();
+    } else {
+      var attempts = 0;
+      var handle = setInterval(function () {
+        attempts += 1;
+        // Re-read the meta each tick, not once before the loop: the payload and
+        // its \`_meta\` can land on different ticks, and pinning a stale
+        // \`undefined\` here would reintroduce the exact bug this fixes.
+        if (render(pickPayload(null), pickMetaFromOpenAi())) {
+          clearInterval(handle);
+          return;
+        }
+        if (pickErrorFromOpenAi()) {
+          collapseFailed();
+          clearInterval(handle);
+          return;
+        }
+        if (attempts >= 40) clearInterval(handle);
+      }, 250);
+    }
   }
 
   // No-data watchdog. If nothing renderable has arrived by the time the
@@ -2433,7 +2504,17 @@ const WIDGET_HTML = `<!doctype html>
     // covers both hosts' timing.
     var eventMeta =
       globals && hasWidgetMeta(globals._meta) ? globals._meta : undefined;
-    render(pickPayload(globals), eventMeta || pickMetaFromOpenAi());
+    if (render(pickPayload(globals), eventMeta || pickMetaFromOpenAi())) return;
+    // Nothing renderable on any channel — but the event may be the delivery
+    // of a FAILED call (the host populated \`toolResponseMetadata\` and fired
+    // the event with no useful detail, the same timing PATH 3 has for
+    // success). Check the event's own globals and the live snapshot.
+    if (
+      (globals && trmHasError(globals.toolResponseMetadata)) ||
+      pickErrorFromOpenAi()
+    ) {
+      collapseFailed();
+    }
   };
   EVENT_NAMES.forEach(function (name) {
     window.addEventListener(name, handler);
@@ -2511,7 +2592,11 @@ const WIDGET_HTML = `<!doctype html>
     // but a second release must not be able to replay the same payload.
     heldToolResult = null;
     log("released held tool-result", { why: why, theme: mcpHostTheme });
-    render(held.structuredContent, held._meta);
+    if (!render(held.structuredContent, held._meta) && isErrorSignal(held)) {
+      // The held first result can be a FAILED call too — same treatment as
+      // the direct-delivery branch above.
+      collapseFailed();
+    }
   }
 
   function sendInitRequest() {
@@ -2668,7 +2753,12 @@ const WIDGET_HTML = `<!doctype html>
       // Per the MCP Apps spec §"Wire protocol — Host → View
       // notification", \`params._meta\` is part of the tool-result
       // notification.
-      render(params.structuredContent, params._meta);
+      if (!render(params.structuredContent, params._meta) && isErrorSignal(params)) {
+        // A failed call: \`isError\` results carry no \`structuredContent\`, so
+        // render() had nothing to paint — but the params themselves say why.
+        // Label now instead of leaving the box to the silent watchdog.
+        collapseFailed();
+      }
       return;
     }
     if (msg.type === "tako-embed-height" && embedOrigin && event.origin === embedOrigin) {

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -683,9 +683,11 @@ const WIDGET_HTML = `<!doctype html>
      between widget mount and chart data arrival on hosts with slow
      postMessage delivery (~200 ms on claude.ai); ChatGPT's
      window.openai.toolOutput is synchronous so no visible flash.
-     The chart-rendering paths (iframe / img.load / iframe-fallback)
-     un-hide the relevant element AND notifyHeight(actual height) in
-     lockstep, so the widget grows naturally on success. -->
+     The img.load and iframe-fallback paths un-hide the relevant element
+     AND notifyHeight(actual height) in lockstep; the committed-iframe
+     path defers both to its reveal (\`revealCommittedFrame\` /
+     tako-embed-height — the frame stays veiled until the embed proves it
+     painted), so the widget still only grows when there are pixels. -->
 <div id="tako-placeholder" class="hidden">Loading chart…</div>
 <!-- Shown only by \`collapse()\`, i.e. only once we know there is no chart to
      draw. Never a loading state: on a host that honours the shrink this sits
@@ -755,9 +757,10 @@ const WIDGET_HTML = `<!doctype html>
 
   // Height for the embed iframe, derived from the CARD's real aspect ratio.
   //
-  // A cross-origin iframe never sizes itself to its content, and the Tako embed
-  // page does not report its height, so this height is the only thing deciding
-  // the box. It used to be \`structuredContent.height\` — a flat 720 — against a
+  // A cross-origin iframe never sizes itself to its content, so until the
+  // embed's own \`tako-embed-height\` report arrives (it DOES emit one now —
+  // see \`embedReportedHeight\`, which outranks this everywhere) this height
+  // is the only thing deciding the box. It used to be \`structuredContent.height\` — a flat 720 — against a
   // chat column around 700 px wide. That is a near-square frame holding a card
   // whose real aspect is 2.18:1 for a plain chart, so the card painted ~320 px
   // tall and left ~400 px of empty background beneath it. Ranked/list cards run
@@ -1473,6 +1476,28 @@ const WIDGET_HTML = `<!doctype html>
     }
     function onLoad() {
       if (settled) return;
+      // Stray-load guard. \`#tako-embed\` is parser-inserted with no \`src\`,
+      // so the browser queues a \`load\` for its initial about:blank
+      // document. On the synchronous \`toolOutput\` path — ChatGPT's primary
+      // one — render() commits the src and this listener attaches in the
+      // same parse task, so that stray event is delivered NEXT tick, long
+      // before the embed responds. Unguarded it would settle the watchdog
+      // (no CSP downgrade, no timeout, no PNG fallback for the rest of the
+      // widget's life) and reveal the veiled frame at full height around
+      // nothing — both halves of the bug this file exists to prevent.
+      //
+      // about:blank is the ONE document this frame can host that is
+      // same-origin-readable; the real embed is cross-origin, where
+      // \`contentDocument\` reads null (or throws on stricter engines). So a
+      // readable document still sitting on about:blank identifies the
+      // stray exactly, with no timing heuristics.
+      try {
+        var straydoc = frame.contentDocument;
+        if (straydoc && straydoc.location && straydoc.location.href === "about:blank") {
+          log("ignored stray about:blank load");
+          return;
+        }
+      } catch (e) { /* cross-origin read — the genuine embed load */ }
       cleanup();
       log("committed iframe loaded", { src: url });
       // Reveal-on-load: the embed has rendered, so it is finally safe to
@@ -1992,10 +2017,14 @@ const WIDGET_HTML = `<!doctype html>
         if (frame.classList.contains("hidden")) return;
         if (!frame.classList.contains("veiled")) return;
         frame.classList.remove("veiled");
-        // The embed's own report is AUTHORITATIVE (see embedReportedHeight):
-        // if it arrived first, the handler already sized the frame and told
-        // the host — re-notifying \`committedHeight\` here would hand the
-        // host a stale number.
+        // Defensive, and believed UNREACHABLE under current wiring: the
+        // only writer of \`embedReportedHeight\` also settles the watchdog,
+        // whose cleanup removes the \`load\` listener — so handshake-first
+        // never reaches this function, and load-first sets the flag only
+        // after this returns. Kept anyway as a one-line invariant (the
+        // embed's own report is authoritative; never notify a stale
+        // aspect estimate over it) so a future rewiring of the settle
+        // path cannot silently regress the height contract.
         if (embedReportedHeight) return;
         // Re-fit at reveal time: the resize listener stands down while
         // the frame is veiled, and the column may have laid out (or
@@ -2257,8 +2286,9 @@ const WIDGET_HTML = `<!doctype html>
   // Does this object say the CALL ITSELF failed? Two spellings, both
   // positive claims rather than inferences: the MCP envelope's
   // \`isError: true\`, and the server's own \`_meta["tako/error"]\`
-  // discriminant (attached to every mapped upstream failure — Django
-  // errors, free-tier capacity; see \`djangoErrorToToolResult\` in mcp.ts).
+  // discriminant (attached to every server-built failure — Django errors,
+  // free-tier credits/capacity, and both free-tier rate limiters; see
+  // \`djangoErrorToToolResult\` in mcp.ts and \`freetier.ts\`).
   // Either is the affirmative knowledge the no-data watchdog lacks: a
   // failed call and a late delivery stop being indistinguishable the
   // moment one of these is visible.
@@ -2291,8 +2321,29 @@ const WIDGET_HTML = `<!doctype html>
   function pickErrorFromOpenAi() {
     var w = window;
     if (!w || !w.openai || typeof w.openai !== "object") return false;
-    return trmHasError(w.openai.toolResponseMetadata);
+    // Both envelope carriers \`pickMetaFromOpenAi\` probes:
+    // \`toolResponseMetadata\`, and \`openai.widget\` — the spelling dev-mode
+    // custom connectors actually populate. Dropping the latter would send a
+    // failed call on such a host to the silent watchdog collapse even
+    // though its \`tako/error\` was sitting right there.
+    return (
+      trmHasError(w.openai.toolResponseMetadata) ||
+      trmHasError(w.openai.widget)
+    );
   }
+
+  // Failed-call signal seen on a SNIFFED ChatGPT channel (globals event or
+  // the \`window.openai\` snapshot). Deliberately NOT acted on immediately:
+  // whether ChatGPT populates \`toolResponseMetadata\` under \`isError\` — and
+  // with what staleness — is not provable from outside the host, and the
+  // poll below exists precisely because payload and \`_meta\` can land on
+  // different ticks. So the sighting is only recorded here, the poll keeps
+  // running so a late payload always wins, and the no-data watchdog turns
+  // the sighting into the LABELLED collapse at its exit. Contrast the
+  // MCP-Apps \`ui/notifications/tool-result\` path, which acts on
+  // \`isError\` immediately: there the host has delivered THE result for
+  // this call, so there is nothing left to wait for.
+  var errorSeen = false;
 
   // Label-and-collapse for a KNOWN-failed call. The same collapse the
   // no-chart guard uses, with failure copy: hosts that keep the box anyway
@@ -2426,30 +2477,25 @@ const WIDGET_HTML = `<!doctype html>
   // ChatGPT populates the global at unpredictable times. Cost: one
   // property read every 250 ms.
   if (!render(pickPayload(null), pickMetaFromOpenAi())) {
-    // Payload first, error second — see \`collapseFailed\`. An \`isError\`
-    // result never grows a payload later, so acting on it synchronously
-    // spares the user the 10 s of blank box the watchdog would allow.
-    if (pickErrorFromOpenAi()) {
-      collapseFailed();
-    } else {
-      var attempts = 0;
-      var handle = setInterval(function () {
-        attempts += 1;
-        // Re-read the meta each tick, not once before the loop: the payload and
-        // its \`_meta\` can land on different ticks, and pinning a stale
-        // \`undefined\` here would reintroduce the exact bug this fixes.
-        if (render(pickPayload(null), pickMetaFromOpenAi())) {
-          clearInterval(handle);
-          return;
-        }
-        if (pickErrorFromOpenAi()) {
-          collapseFailed();
-          clearInterval(handle);
-          return;
-        }
-        if (attempts >= 40) clearInterval(handle);
-      }, 250);
-    }
+    // Payload first, error second — see \`collapseFailed\`. The error
+    // sighting is only RECORDED (see \`errorSeen\`): the poll always runs
+    // its full window so a payload landing on a later tick still wins,
+    // and the watchdog below turns the sighting into the labelled
+    // collapse at exit.
+    if (pickErrorFromOpenAi()) errorSeen = true;
+    var attempts = 0;
+    var handle = setInterval(function () {
+      attempts += 1;
+      // Re-read the meta each tick, not once before the loop: the payload and
+      // its \`_meta\` can land on different ticks, and pinning a stale
+      // \`undefined\` here would reintroduce the exact bug this fixes.
+      if (render(pickPayload(null), pickMetaFromOpenAi())) {
+        clearInterval(handle);
+        return;
+      }
+      if (pickErrorFromOpenAi()) errorSeen = true;
+      if (attempts >= 40) clearInterval(handle);
+    }, 250);
   }
 
   // No-data watchdog. If nothing renderable has arrived by the time the
@@ -2468,12 +2514,20 @@ const WIDGET_HTML = `<!doctype html>
   // any chart has painted, and the 10 s bound matches the polling window so it
   // cannot race a slow-but-arriving delivery.
   //
-  // Collapsed WITHOUT the label, deliberately: from in here a failed call and a
-  // delivery that is merely late look identical, so "No chart for this result"
-  // would be an affirmative claim that is wrong in the second case. See
-  // \`collapse()\`.
+  // Labelled or blank, decided HERE and only here for the ChatGPT
+  // channels: when an error signal was sighted during the window
+  // (\`errorSeen\`, re-checked once more at exit for a sighting that landed
+  // after the poll's last tick), the failure is a fact and the collapse
+  // says so. Otherwise blank, deliberately: "nothing arrived in 10 s"
+  // covers a failed call and a merely late delivery alike, and "No chart
+  // for this result" would be an affirmative claim that is wrong in the
+  // second case. See \`collapse()\`.
   setTimeout(function () {
     if (rendered) return;
+    if (errorSeen || pickErrorFromOpenAi()) {
+      collapseFailed();
+      return;
+    }
     collapse(false);
     log("no data arrived, collapsed widget");
   }, 10000);
@@ -2508,12 +2562,13 @@ const WIDGET_HTML = `<!doctype html>
     // Nothing renderable on any channel — but the event may be the delivery
     // of a FAILED call (the host populated \`toolResponseMetadata\` and fired
     // the event with no useful detail, the same timing PATH 3 has for
-    // success). Check the event's own globals and the live snapshot.
+    // success). Sighted, not acted on — see \`errorSeen\`: the watchdog
+    // labels at exit, so a payload arriving on a later event still wins.
     if (
       (globals && trmHasError(globals.toolResponseMetadata)) ||
       pickErrorFromOpenAi()
     ) {
-      collapseFailed();
+      errorSeen = true;
     }
   };
   EVENT_NAMES.forEach(function (name) {
@@ -2636,11 +2691,12 @@ const WIDGET_HTML = `<!doctype html>
   // uses the \`window.openai\` path further up.
   //
   // Also handles a \`tako-embed-height\` resize message from the inner
-  // embed iframe, gated to that iframe's origin. The Tako web app does
-  // not emit it yet — when it ships, the widget will start
-  // self-correcting chart heights without a worker redeploy. Sanity
-  // bounds (positive integer < 4000 px) keep a hostile or buggy embed
-  // from blowing the iframe up to nonsensical sizes.
+  // embed iframe, gated to that iframe's origin AND sender window. The
+  // Tako web app emits it now (measured live — see \`embedReportedHeight\`),
+  // so this is a live channel: it self-corrects chart heights, reveals a
+  // veiled committed frame, and settles the committed-iframe watchdog.
+  // Sanity bounds (positive integer < 4000 px) keep a hostile or buggy
+  // embed from blowing the iframe up to nonsensical sizes.
   window.addEventListener("message", function (event) {
     var msg = event.data;
     if (!msg || typeof msg !== "object") return;

--- a/workers/src/tools/_chart_widget.ts
+++ b/workers/src/tools/_chart_widget.ts
@@ -661,6 +661,15 @@ const WIDGET_HTML = `<!doctype html>
     #tako-empty { color: #b4b8bd; }
   }
   .hidden { display: none !important; }
+  /* The committed iframe's awaiting-load state. Height 0 — NOT
+     display:none — so the frame keeps a real layout box at the real
+     column width while invisible. Under display:none the embed page
+     boots against a 0-width viewport: media queries resolve to a
+     stacked mobile layout, and a \`tako-embed-height\` measured there
+     is wrong in a way ChatGPT's pin-the-max-height quirk would make
+     permanent. \`!important\` so the class outranks the inline height
+     \`setFrameHeight\` stages at commit time. */
+  .veiled { height: 0 !important; min-height: 0 !important; }
 </style>
 </head>
 <body>
@@ -1346,10 +1355,10 @@ const WIDGET_HTML = `<!doctype html>
       // document the embed endpoint returns — including a Tako 404/5xx
       // error page. On a host whose CSP allows \`frame-src\`, an embed-page
       // outage would swap the known-good PNG for an error page. Accepted
-      // for now: the only positive signal from the cross-origin embed is
-      // the \`tako-embed-height\` message, which the Tako web app does not
-      // emit yet (see the handler comment near the bottom). Once it does,
-      // gate \`succeed()\` on that message instead of the bare \`load\`.
+      // for now: the positive signal from the cross-origin embed is the
+      // \`tako-embed-height\` message, which the Tako web app DOES emit now
+      // (measured — see \`embedReportedHeight\`); gating \`succeed()\` on it
+      // instead of the bare \`load\` remains the follow-up.
       if (probeNavigated) succeed();
     }
     document.addEventListener("securitypolicyviolation", onViolation);
@@ -1367,23 +1376,35 @@ const WIDGET_HTML = `<!doctype html>
   // One watchdog per widget lifetime, same reasoning as \`probeStarted\`.
   var watchStarted = false;
 
-  // Watch an iframe we have ALREADY shown the user, and downgrade to the PNG
-  // if it never loads. Used only on the \`window.openai\` path, which commits
-  // to the iframe up front instead of probing behind a PNG.
+  // Settles the live committed-iframe watchdog, when one is armed. Set by
+  // \`watchCommittedIframe\`, called by the \`tako-embed-height\` handler: an
+  // accepted handshake message proves the embed is RUNNING, which is a
+  // strictly stronger signal than \`load\` — \`load\` waits on every
+  // subresource, so a stalled font could otherwise let the timeout
+  // downgrade a chart the user is already looking at.
+  var settleCommittedWatch = null;
+
+  // Watch the committed (initially veiled) embed iframe and downgrade to
+  // the PNG if it never loads. Used only on the \`window.openai\` path,
+  // which commits to the iframe up front instead of probing behind a PNG.
   //
-  // Settle signals, mirroring the probe's:
-  //  - \`load\` on the frame → the embed rendered; stand down.
+  // Settle signals:
+  //  - \`load\` on the frame → the embed rendered; stand down AND reveal it
+  //    (\`opts.onLoaded\` — the frame stays veiled until one of the settle
+  //    signals proves there are pixels to show).
+  //  - an accepted \`tako-embed-height\` message → the embed is running;
+  //    the handler reveals and settles via \`settleCommittedWatch\`.
   //  - \`securitypolicyviolation\` for \`frame-src\` → definitive host block.
   //  - no \`load\` within the timeout → covers suppressed violation events,
   //    network stalls, and an embed endpoint that never finishes.
   //
-  // Same KNOWN GAP as the probe, in the opposite direction: \`load\` fires for
-  // any document the endpoint returns, so a Tako error page counts as a
-  // successful load and keeps the iframe. Closing that needs a positive
-  // signal from the embed page itself (the \`tako-embed-height\` message it
-  // does not emit yet), at which point BOTH this and \`onLoad\` in the probe
-  // should gate on it instead.
-  function watchCommittedIframe(url, imageOpts) {
+  // Same KNOWN GAP as the probe, in the opposite direction: \`load\` fires
+  // for any document the endpoint returns, so a Tako error page counts as
+  // a successful load and keeps the iframe. The \`tako-embed-height\`
+  // message (now measured live — see \`embedReportedHeight\`) is the
+  // positive signal that could close it; gating \`succeed()\`/\`onLoad\` on
+  // it remains the follow-up.
+  function watchCommittedIframe(url, opts) {
     if (watchStarted) return;
     watchStarted = true;
     var settled = false;
@@ -1394,6 +1415,11 @@ const WIDGET_HTML = `<!doctype html>
       document.removeEventListener("securitypolicyviolation", onViolation);
       frame.removeEventListener("load", onLoad);
     }
+    settleCommittedWatch = function () {
+      if (settled) return;
+      cleanup();
+      log("committed iframe settled via embed handshake", { src: url });
+    };
     function downgrade(reason) {
       if (settled) return;
       cleanup();
@@ -1401,6 +1427,7 @@ const WIDGET_HTML = `<!doctype html>
       // cannot appear on top of the PNG, and stop honoring its height
       // messages.
       embedOrigin = null;
+      frame.classList.remove("veiled");
       frame.classList.add("hidden");
       frame.src = "about:blank";
       log("iframe never loaded, falling back to image", { reason: reason });
@@ -1408,10 +1435,10 @@ const WIDGET_HTML = `<!doctype html>
       // so \`image_data_url\` is absent there — but \`image_url\` is present in
       // structuredContent, which is what makes this path work). Surface the
       // click-through rather than a silent empty frame.
-      if (imageOpts.imageSrc === null) {
+      if (opts.imageSrc === null) {
         placeholder.innerHTML = "";
         placeholder.classList.remove("hidden");
-        if (imageOpts.validEmbed) {
+        if (opts.validEmbed) {
           var anchor = document.createElement("a");
           anchor.href = url;
           anchor.target = "_blank";
@@ -1428,11 +1455,11 @@ const WIDGET_HTML = `<!doctype html>
       }
       paintImage({
         embedUrl: url,
-        imageSrc: imageOpts.imageSrc,
-        validEmbed: imageOpts.validEmbed,
-        height: imageOpts.height,
-        isDataUrl: imageOpts.isDataUrl,
-        imageUrl: imageOpts.imageUrl,
+        imageSrc: opts.imageSrc,
+        validEmbed: opts.validEmbed,
+        height: opts.height,
+        isDataUrl: opts.isDataUrl,
+        imageUrl: opts.imageUrl,
         // The iframe just failed. Do not go looking for it again.
         allowProbe: false,
       });
@@ -1448,6 +1475,10 @@ const WIDGET_HTML = `<!doctype html>
       if (settled) return;
       cleanup();
       log("committed iframe loaded", { src: url });
+      // Reveal-on-load: the embed has rendered, so it is finally safe to
+      // give the card its height. Wired through the watchdog because it is
+      // the one place already listening for the event.
+      if (typeof opts.onLoaded === "function") opts.onLoaded();
     }
     document.addEventListener("securitypolicyviolation", onViolation);
     frame.addEventListener("load", onLoad);
@@ -1939,7 +1970,42 @@ const WIDGET_HTML = `<!doctype html>
       var fitted = aspectHeight(imgNaturalW, imgNaturalH);
       committedHeight = fitted !== null ? fitted : h;
       setFrameHeight(committedHeight);
+      // Committed but VEILED, not revealed. The src was committed one line
+      // up, so the cross-origin embed page is still loading — showing the
+      // frame now (and notifying the full height, as the tail used to)
+      // expands the host's card around an empty frame for however long
+      // tako.com/embed takes to paint, which reads as a broken blank box.
+      // The reveal instead rides the same \`load\` event the watchdog below
+      // already listens for, so the expansion and the pixels arrive
+      // together. Veiled (height 0, layout box live — see the \`.veiled\`
+      // rule) rather than \`hidden\` (display:none) so the embed boots at
+      // the REAL column width; under display:none it would lay out at a
+      // 0-width viewport and could report a degenerate height that
+      // ChatGPT's pin-the-max quirk makes permanent. Failure paths are
+      // untouched: a CSP violation or the watchdog timeout still downgrade
+      // to the PNG, which reveals itself on \`img.load\`.
       frame.classList.remove("hidden");
+      frame.classList.add("veiled");
+      var revealCommittedFrame = function () {
+        // Idempotent — the embed-height handler may have revealed first —
+        // and a downgraded (hidden) frame must never be resurrected.
+        if (frame.classList.contains("hidden")) return;
+        if (!frame.classList.contains("veiled")) return;
+        frame.classList.remove("veiled");
+        // The embed's own report is AUTHORITATIVE (see embedReportedHeight):
+        // if it arrived first, the handler already sized the frame and told
+        // the host — re-notifying \`committedHeight\` here would hand the
+        // host a stale number.
+        if (embedReportedHeight) return;
+        // Re-fit at reveal time: the resize listener stands down while
+        // the frame is veiled, and the column may have laid out (or
+        // changed) between commit and load.
+        var next = aspectHeight(imgNaturalW, imgNaturalH);
+        if (next !== null) committedHeight = next;
+        setFrameHeight(committedHeight);
+        notifyHeight(committedHeight);
+        log("committed iframe revealed", { height: committedHeight });
+      };
       // Reflow on column changes (host sidebar toggle, window resize, mobile
       // rotation). Without this the frame keeps its mount-time height and the
       // empty band comes back at the new width. Skipped once a downgrade has
@@ -1955,7 +2021,11 @@ const WIDGET_HTML = `<!doctype html>
       // failure this block exists to prevent, reached by a different route.
       // \`aspectHeight\` already declines per-event, so let it.
       window.addEventListener("resize", function () {
+        // Stands down while the frame is hidden (downgraded) OR still
+        // veiled awaiting its \`load\` reveal — revealCommittedFrame re-fits
+        // for the veiled window, so nothing is lost.
         if (frame.classList.contains("hidden")) return;
+        if (frame.classList.contains("veiled")) return;
         // The embed's own report outranks anything derived from the PNG — see
         // \`embedReportedHeight\`. The comment above always claimed this listener
         // stood down "after an embed-reported height has taken over", but no
@@ -1992,6 +2062,7 @@ const WIDGET_HTML = `<!doctype html>
         height: h,
         isDataUrl: validDataImage,
         imageUrl: imgUrl,
+        onLoaded: revealCommittedFrame,
       });
     } else if (validImage) {
       return paintImage({
@@ -2037,12 +2108,18 @@ const WIDGET_HTML = `<!doctype html>
     placeholder.classList.add("hidden");
     rendered = true;
     var finalHeight = committedHeight !== null ? committedHeight : h;
-    notifyHeight(finalHeight);
+    // The committed-iframe branch defers the host height notification to
+    // \`revealCommittedFrame\` — announcing the full chart height here is
+    // what used to expand the card around a still-loading embed. The
+    // no-image \`validEmbed\` fallback keeps the immediate notify: it has
+    // no watchdog wired to reveal it later.
+    if (!useIframe) notifyHeight(finalHeight);
     log("rendered", {
       mode: useIframe ? "iframe" : "iframe-fallback",
       src: url,
       height: finalHeight,
       fitted: committedHeight !== null,
+      revealDeferred: useIframe,
     });
     return true;
   }
@@ -2595,6 +2672,13 @@ const WIDGET_HTML = `<!doctype html>
       return;
     }
     if (msg.type === "tako-embed-height" && embedOrigin && event.origin === embedOrigin) {
+      // Source pin, on top of the origin gate: only the widget's OWN embed
+      // iframe may drive resize/reveal. Origin alone would also admit any
+      // other browsing context running on the pinned Tako origin that can
+      // reach this window through the frame tree (e.g. a second widget's
+      // embed traversing \`top.frames\`), and this branch now controls
+      // visibility, not just size.
+      if (event.source !== frame.contentWindow) return;
       var h = msg.height;
       if (typeof h !== "number" || !isFinite(h) || h <= 0 || h > 4000) return;
       var n = Math.round(h);
@@ -2603,6 +2687,19 @@ const WIDGET_HTML = `<!doctype html>
       // the pre-latch value and could re-derive over what we just set.
       embedReportedHeight = true;
       setFrameHeight(n);
+      // The message can only come from the running embed page, so it is an
+      // even stronger "it rendered" signal than the frame's \`load\`:
+      //  - a committed frame still awaiting its load-reveal must unveil
+      //    now, or the notify below expands the host card around an
+      //    invisible frame;
+      //  - the watchdog must stand down, or a stalled subresource holding
+      //    \`load\` past the timeout would downgrade a chart the user is
+      //    already looking at.
+      // Deliberately does NOT touch the \`hidden\` class: a downgraded frame
+      // is unreachable here anyway (\`downgrade()\` nulls \`embedOrigin\`
+      // before hiding), and this branch should hold no un-hide power.
+      frame.classList.remove("veiled");
+      if (typeof settleCommittedWatch === "function") settleCommittedWatch();
       notifyHeight(n);
       log("resized via embed handshake", { height: n });
     }

--- a/workers/test/widget/chatgpt-diagnostic.test.ts
+++ b/workers/test/widget/chatgpt-diagnostic.test.ts
@@ -153,6 +153,16 @@ function committedHeight(m: Mounted): number {
   return Number.parseInt(frame(m).style.height, 10);
 }
 
+/**
+ * Fire the committed iframe's `load` event as if the embed page painted —
+ * the widget reveals (unhides) the frame only then, so the host card
+ * expands with pixels in it rather than seconds before.
+ */
+function fireFrameLoad(m: Mounted): void {
+  const WidgetEvent = (m.widgetWin as unknown as { Event: typeof Event }).Event;
+  frame(m).dispatchEvent(new WidgetEvent("load"));
+}
+
 afterEach(() => {
   for (const dom of mounted.splice(0)) dom.window.close();
 });
@@ -163,6 +173,11 @@ describe("ChatGPT chart chain — link by link", () => {
     expect(frame(m).getAttribute("src")).toBe(
       `${EMBED_URL}&disable_tracking=true`,
     );
+    // Veiled (height 0, layout box live) until the embed page loads —
+    // reveal-on-load — then fully visible.
+    expect(frame(m).classList.contains("veiled")).toBe(true);
+    fireFrameLoad(m);
+    expect(frame(m).classList.contains("veiled")).toBe(false);
     expect(frame(m).classList.contains("hidden")).toBe(false);
   });
 
@@ -213,6 +228,7 @@ describe("ChatGPT chart chain — link by link", () => {
     // `render()` is guarded, so this lands on exactly the old behaviour rather
     // than throwing on a missing field.
     const m = mountWidget({ toolOutput: STRUCTURED_CONTENT });
+    fireFrameLoad(m);
     expect(frame(m).classList.contains("hidden")).toBe(false);
     expect(committedHeight(m)).toBe(STRUCTURED_CONTENT.height);
   });
@@ -257,7 +273,8 @@ describe("ChatGPT chart chain — link by link", () => {
     expect(committedHeight(m)).toBe(Math.round(720 * CARD_ASPECT)); // estimate
 
     // The embed page reports its true content height. Origin must match the
-    // embed url — the handler ignores messages from anywhere else.
+    // embed url AND the sender must be the widget's own embed iframe — the
+    // handler ignores messages from anywhere else.
     const WidgetMessageEvent = (
       m.widgetWin as unknown as { MessageEvent: typeof MessageEvent }
     ).MessageEvent;
@@ -265,6 +282,7 @@ describe("ChatGPT chart chain — link by link", () => {
       new WidgetMessageEvent("message", {
         data: { type: "tako-embed-height", height: 732 },
         origin: "https://tako.com",
+        source: frame(m).contentWindow as unknown as MessageEventSource,
       }),
     );
     expect(committedHeight(m)).toBe(732);

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -13,7 +13,7 @@
  * and all.
  */
 import { JSDOM, VirtualConsole } from "jsdom";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Env } from "../../src/env.js";
 import { buildChartAppUiResourceFromOutputPubId } from "../../src/tools/_chart_widget.js";
@@ -282,32 +282,76 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     // area. An `isError` result carries no `structuredContent`, ChatGPT mounts
     // the widget from static registration metadata anyway, holds it at its
     // default height, and ignores shrink notifications — so the no-data
-    // watchdog's unlabelled collapse reads as a broken card for ten seconds
-    // and a blank one forever after. But a failed call is not unknowable:
-    // every mapped upstream failure carries `_meta["tako/error"]`, and
-    // `toolResponseMetadata` preserves the result envelope for the widget.
-    // Reading it turns the blank into the same intentional labelled state a
-    // zero-card search already gets — synchronously, not after 10 s.
-    const heights: number[] = [];
-    const m = mountWidget(html(), {
-      toolOutput: null,
-      toolResponseMetadata: {
-        _meta: {
-          "tako/error": { kind: "timeout", path: "/api/v3/search/", method: "POST" },
+    // watchdog's unlabelled collapse reads as a broken card. But a failed
+    // call is not unknowable: every server-built failure carries
+    // `_meta["tako/error"]`, and `toolResponseMetadata` preserves the result
+    // envelope for the widget.
+    //
+    // The label lands at the WATCHDOG's exit, not synchronously: the sniffed
+    // ChatGPT channels are not provably fresh, so an error sighting is only
+    // recorded (`errorSeen`) while the poll runs its full window — a payload
+    // landing on a later tick must still win (test below). The watchdog then
+    // turns the sighting into the labelled collapse.
+    vi.useFakeTimers();
+    try {
+      const heights: number[] = [];
+      const m = mountWidget(html(), {
+        toolOutput: null,
+        toolResponseMetadata: {
+          _meta: {
+            "tako/error": { kind: "timeout", path: "/api/v3/search/", method: "POST" },
+          },
         },
-      },
-      theme: "light",
-      notifyIntrinsicHeight: (h: number) => heights.push(h),
-    });
-    const empty = m.widgetWin.document.getElementById(
-      "tako-empty",
-    ) as HTMLElement;
-    expect(empty.classList.contains("hidden")).toBe(false);
-    expect(empty.textContent).toMatch(/failed/i);
-    expect(renderedIframe(m)).toBe(false);
-    // Same contract as the zero-card empty state: the mount-time floor, then
-    // the collapse. Labelling a box the host kept is not a request for one.
-    expect(heights).toEqual([1, 0]);
+        theme: "light",
+        notifyIntrinsicHeight: (h: number) => heights.push(h),
+      });
+      const empty = m.widgetWin.document.getElementById(
+        "tako-empty",
+      ) as HTMLElement;
+      // Sighted but not yet acted on — the payload window is still open.
+      expect(empty.classList.contains("hidden")).toBe(true);
+      vi.advanceTimersByTime(10_000);
+      expect(empty.classList.contains("hidden")).toBe(false);
+      expect(empty.textContent).toMatch(/failed/i);
+      expect(renderedIframe(m)).toBe(false);
+      // Same contract as the zero-card empty state: the mount-time floor,
+      // then the collapse. Labelling a box the host kept is not a request
+      // for one.
+      expect(heights).toEqual([1, 0]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ERROR: a payload landing after an error sighting still renders", () => {
+    // The redesign's reason to exist. An early `tako/error` read at boot
+    // must not be terminal: whether ChatGPT populates `toolResponseMetadata`
+    // under `isError` — and with what staleness — is not provable from the
+    // jsdom harness, and payload and `_meta` are known to land on different
+    // ticks. So a chart arriving mid-window wins over the sighting, and the
+    // watchdog then no-ops.
+    vi.useFakeTimers();
+    try {
+      const openai: Record<string, unknown> = {
+        toolResponseMetadata: {
+          _meta: { "tako/error": { kind: "timeout" } },
+        },
+      };
+      const m = mountWidget(html(), openai);
+      const empty = m.widgetWin.document.getElementById(
+        "tako-empty",
+      ) as HTMLElement;
+      expect(empty.classList.contains("hidden")).toBe(true);
+      // The payload lands two ticks later.
+      openai.toolOutput = PROD_STRUCTURED_CONTENT;
+      vi.advanceTimersByTime(500);
+      expect(renderedIframe(m)).toBe(true);
+      // And the watchdog must not label over a rendered chart.
+      vi.advanceTimersByTime(10_000);
+      expect(empty.classList.contains("hidden")).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ERROR: the envelope's own isError flag is enough (SDK-wrapped errors)", () => {
@@ -315,38 +359,53 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     // them in a generic error result WITHOUT `_meta["tako/error"]`. The
     // envelope's `isError: true` is the one signal those still carry, on
     // whichever spelling ChatGPT's envelope uses.
-    const m = mountWidget(html(), {
-      toolOutput: null,
-      toolResponseMetadata: {
-        mcp_tool_result: {
-          isError: true,
-          content: [{ type: "text", text: "Tako search endpoint returned an unexpected shape." }],
+    vi.useFakeTimers();
+    try {
+      const m = mountWidget(html(), {
+        toolOutput: null,
+        toolResponseMetadata: {
+          mcp_tool_result: {
+            isError: true,
+            content: [{ type: "text", text: "Tako search endpoint returned an unexpected shape." }],
+          },
         },
-      },
-    });
-    const empty = m.widgetWin.document.getElementById(
-      "tako-empty",
-    ) as HTMLElement;
-    expect(empty.classList.contains("hidden")).toBe(false);
-    expect(empty.textContent).toMatch(/failed/i);
+      });
+      const empty = m.widgetWin.document.getElementById(
+        "tako-empty",
+      ) as HTMLElement;
+      vi.advanceTimersByTime(10_000);
+      expect(empty.classList.contains("hidden")).toBe(false);
+      expect(empty.textContent).toMatch(/failed/i);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ERROR: a late-arriving error on the event path labels too", () => {
     // Same failure, delivered the way PATH 3 delivers success: the host
     // populates `toolResponseMetadata` after mount and fires the globals
-    // event with no useful detail.
-    const openai: Record<string, unknown> = {};
-    const m = mountWidget(html(), openai);
-    const empty = m.widgetWin.document.getElementById(
-      "tako-empty",
-    ) as HTMLElement;
-    expect(empty.classList.contains("hidden")).toBe(true);
-    openai.toolResponseMetadata = {
-      _meta: { "tako/error": { kind: "http", status: 502 } },
-    };
-    fireSetGlobals(m, undefined, "openai:set_globals");
-    expect(empty.classList.contains("hidden")).toBe(false);
-    expect(empty.textContent).toMatch(/failed/i);
+    // event with no useful detail. The event only records the sighting;
+    // the watchdog labels at exit.
+    vi.useFakeTimers();
+    try {
+      const openai: Record<string, unknown> = {};
+      const m = mountWidget(html(), openai);
+      const empty = m.widgetWin.document.getElementById(
+        "tako-empty",
+      ) as HTMLElement;
+      expect(empty.classList.contains("hidden")).toBe(true);
+      openai.toolResponseMetadata = {
+        _meta: { "tako/error": { kind: "http", status: 502 } },
+      };
+      fireSetGlobals(m, undefined, "openai:set_globals");
+      // Sighted, not yet labelled — a payload could still arrive.
+      expect(empty.classList.contains("hidden")).toBe(true);
+      vi.advanceTimersByTime(10_000);
+      expect(empty.classList.contains("hidden")).toBe(false);
+      expect(empty.textContent).toMatch(/failed/i);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ERROR: a renderable payload wins over a stale error signal", () => {

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -137,6 +137,16 @@ function renderedIframe(m: Mounted): boolean {
   );
 }
 
+/**
+ * Fire the committed iframe's `load` event as if the embed page painted.
+ * The widget defers its reveal (unhide + host height notification) to this
+ * event so the card expands with pixels in it, not seconds before.
+ */
+function fireFrameLoad(m: Mounted): void {
+  const WidgetEvent = (m.widgetWin as unknown as { Event: typeof Event }).Event;
+  frame(m).dispatchEvent(new WidgetEvent("load"));
+}
+
 afterEach(() => {
   for (const dom of mounted.splice(0)) dom.window.close();
 });
@@ -145,6 +155,11 @@ describe("ChatGPT Apps SDK delivery paths", () => {
   it("PATH 1: window.openai.toolOutput present before the script runs", () => {
     const m = mountWidget(html(), { toolOutput: PROD_STRUCTURED_CONTENT });
     expect(renderedIframe(m)).toBe(true);
+    // Committed but veiled (height 0, layout box live) until the embed page
+    // loads — reveal-on-load.
+    expect(frame(m).classList.contains("veiled")).toBe(true);
+    fireFrameLoad(m);
+    expect(frame(m).classList.contains("veiled")).toBe(false);
     expect(frame(m).classList.contains("hidden")).toBe(false);
   });
 
@@ -299,6 +314,7 @@ describe("ChatGPT reload rehydration", () => {
     });
     // Without the fallback this collapses to the labelled empty state.
     expect(renderedIframe(m)).toBe(true);
+    fireFrameLoad(m);
     expect(frame(m).classList.contains("hidden")).toBe(false);
   });
 
@@ -397,6 +413,7 @@ describe("ChatGPT reload rehydration", () => {
     openai.widgetState = PROD_STRUCTURED_CONTENT;
     fireSetGlobals(m, { toolOutput: STRIPPED_TOOL_OUTPUT }, "openai:set_globals");
     expect(renderedIframe(m)).toBe(true);
+    fireFrameLoad(m);
     expect(frame(m).classList.contains("hidden")).toBe(false);
   });
 

--- a/workers/test/widget/chatgpt-path.test.ts
+++ b/workers/test/widget/chatgpt-path.test.ts
@@ -276,6 +276,95 @@ describe("ChatGPT Apps SDK delivery paths", () => {
     // bundle does not fall back to the remote image_url either.
     expect(img(m).getAttribute("src")).toBeNull();
   });
+
+  it("ERROR: a failed call labels the box instead of leaving it blank", () => {
+    // The reported bug: an expanded Tako tool call showing a tall, pure-blank
+    // area. An `isError` result carries no `structuredContent`, ChatGPT mounts
+    // the widget from static registration metadata anyway, holds it at its
+    // default height, and ignores shrink notifications — so the no-data
+    // watchdog's unlabelled collapse reads as a broken card for ten seconds
+    // and a blank one forever after. But a failed call is not unknowable:
+    // every mapped upstream failure carries `_meta["tako/error"]`, and
+    // `toolResponseMetadata` preserves the result envelope for the widget.
+    // Reading it turns the blank into the same intentional labelled state a
+    // zero-card search already gets — synchronously, not after 10 s.
+    const heights: number[] = [];
+    const m = mountWidget(html(), {
+      toolOutput: null,
+      toolResponseMetadata: {
+        _meta: {
+          "tako/error": { kind: "timeout", path: "/api/v3/search/", method: "POST" },
+        },
+      },
+      theme: "light",
+      notifyIntrinsicHeight: (h: number) => heights.push(h),
+    });
+    const empty = m.widgetWin.document.getElementById(
+      "tako-empty",
+    ) as HTMLElement;
+    expect(empty.classList.contains("hidden")).toBe(false);
+    expect(empty.textContent).toMatch(/failed/i);
+    expect(renderedIframe(m)).toBe(false);
+    // Same contract as the zero-card empty state: the mount-time floor, then
+    // the collapse. Labelling a box the host kept is not a request for one.
+    expect(heights).toEqual([1, 0]);
+  });
+
+  it("ERROR: the envelope's own isError flag is enough (SDK-wrapped errors)", () => {
+    // Handler bugs and wire-guard throws re-throw to the MCP SDK, which wraps
+    // them in a generic error result WITHOUT `_meta["tako/error"]`. The
+    // envelope's `isError: true` is the one signal those still carry, on
+    // whichever spelling ChatGPT's envelope uses.
+    const m = mountWidget(html(), {
+      toolOutput: null,
+      toolResponseMetadata: {
+        mcp_tool_result: {
+          isError: true,
+          content: [{ type: "text", text: "Tako search endpoint returned an unexpected shape." }],
+        },
+      },
+    });
+    const empty = m.widgetWin.document.getElementById(
+      "tako-empty",
+    ) as HTMLElement;
+    expect(empty.classList.contains("hidden")).toBe(false);
+    expect(empty.textContent).toMatch(/failed/i);
+  });
+
+  it("ERROR: a late-arriving error on the event path labels too", () => {
+    // Same failure, delivered the way PATH 3 delivers success: the host
+    // populates `toolResponseMetadata` after mount and fires the globals
+    // event with no useful detail.
+    const openai: Record<string, unknown> = {};
+    const m = mountWidget(html(), openai);
+    const empty = m.widgetWin.document.getElementById(
+      "tako-empty",
+    ) as HTMLElement;
+    expect(empty.classList.contains("hidden")).toBe(true);
+    openai.toolResponseMetadata = {
+      _meta: { "tako/error": { kind: "http", status: 502 } },
+    };
+    fireSetGlobals(m, undefined, "openai:set_globals");
+    expect(empty.classList.contains("hidden")).toBe(false);
+    expect(empty.textContent).toMatch(/failed/i);
+  });
+
+  it("ERROR: a renderable payload wins over a stale error signal", () => {
+    // Payload first, error check second, on every delivery path. A chart that
+    // can paint must never be pre-empted into a failure label by leftover
+    // metadata from another channel.
+    const m = mountWidget(html(), {
+      toolOutput: PROD_STRUCTURED_CONTENT,
+      toolResponseMetadata: {
+        _meta: { "tako/error": { kind: "timeout" } },
+      },
+    });
+    expect(renderedIframe(m)).toBe(true);
+    const empty = m.widgetWin.document.getElementById(
+      "tako-empty",
+    ) as HTMLElement;
+    expect(empty.classList.contains("hidden")).toBe(true);
+  });
 });
 
 // The reported bug: a chart that renders fine, then comes back as an empty box

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -176,9 +176,20 @@ function deliverEmbedHeight(m: Mounted, height: number): void {
     new WidgetMessageEvent("message", {
       data: { type: "tako-embed-height", height },
       origin: "https://staging.trytako.com",
-      source: m.widgetWin as unknown as MessageEventSource,
+      // The handler is gated on `event.source === frame.contentWindow` —
+      // only the widget's OWN embed iframe may drive resize/reveal, not any
+      // other same-origin browsing context that can reach this window.
+      source: widgetFrame(m).contentWindow as unknown as MessageEventSource,
     }),
   );
+}
+
+/** Every `size-changed` height the widget has posted to the host so far. */
+function sizeChangesOf(m: Mounted): Array<{ params: { height: number } }> {
+  return m.toParent.filter(
+    (msg) =>
+      (msg as { method?: string }).method === "ui/notifications/size-changed",
+  ) as Array<{ params: { height: number } }>;
 }
 
 /** Fire the probe iframe's `load` event as if the embed page loaded. */
@@ -608,8 +619,10 @@ describe("interactive iframe capability probe (executed)", () => {
     const m = mountWidget(staticWidgetHtml());
     (m.widgetWin as unknown as { openai: object }).openai = {};
     deliver(m, CHART_RESULT, m.wrapperWin);
-    // ChatGPT path: no PNG detour, no probe — straight to the iframe.
+    // ChatGPT path: no PNG detour, no probe — straight to the iframe,
+    // which stays hidden until the embed page loads (reveal-on-load).
     expect(widgetFrame(m).getAttribute("src")).toBe(EMBED_IFRAME_SRC);
+    fireFrameLoad(m);
     expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
     expect(widgetImg(m).getAttribute("src")).toBeNull();
   });
@@ -685,12 +698,112 @@ describe("committed iframe watchdog (executed)", () => {
     expect(widgetFrame(m).getAttribute("height")).toBe(String(expected));
     // Explicitly NOT the requested height.
     expect(widgetFrame(m).getAttribute("height")).not.toBe("720");
-    // The host is told the same number, or the outer container keeps the band.
-    const sizeChanges = m.toParent.filter(
-      (msg) =>
-        (msg as { method?: string }).method === "ui/notifications/size-changed",
-    ) as Array<{ params: { height: number } }>;
-    expect(sizeChanges.at(-1)?.params.height).toBe(expected);
+    // The host is told the same number — at reveal (the frame's `load`),
+    // or the outer container keeps the band.
+    fireFrameLoad(m);
+    expect(sizeChangesOf(m).at(-1)?.params.height).toBe(expected);
+  });
+
+  it("keeps the committed iframe veiled until the embed loads, then reveals", () => {
+    // The "weird loading phase" on ChatGPT: the widget used to unhide the
+    // iframe and notify the full chart height at delivery, expanding the
+    // host's card seconds before tako.com/embed had painted anything — a
+    // full-height blank box. Reveal-on-load makes the expansion and the
+    // pixels arrive together. Failure paths are unchanged: a CSP violation
+    // or the watchdog timeout still downgrade to the PNG.
+    //
+    // Veiled, NOT display:none-hidden: the frame keeps its layout box (at
+    // height 0) so the embed page boots with the REAL column width. Under
+    // display:none the embed would lay out at a 0-width viewport, and a
+    // `tako-embed-height` measured in that degenerate layout would be
+    // notified and permanently pinned by ChatGPT's max-height quirk.
+    const m = mountChatGpt();
+    setColumnWidth(m, COLUMN_WIDTH);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 720 },
+        { image_natural_width: 2400, image_natural_height: 1101 },
+      ),
+      m.wrapperWin,
+    );
+    // Committed (src pinned, height staged, layout box live) but veiled —
+    // and the host has not been told to expand: the last size-changed is
+    // still the 1 px mount floor.
+    expect(widgetFrame(m).getAttribute("src")).toBe(EMBED_IFRAME_SRC);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(true);
+    expect(sizeChangesOf(m).at(-1)?.params.height).toBe(1);
+    fireFrameLoad(m);
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(false);
+    expect(sizeChangesOf(m).at(-1)?.params.height).toBe(
+      Math.round((COLUMN_WIDTH * 1101) / 2400),
+    );
+  });
+
+  it("re-fits at reveal when layout settled between commit and load", () => {
+    // The resize listener stands down while the frame is hidden, so the
+    // reveal must re-derive the height itself — otherwise a widget whose
+    // tool-result arrived before layout (clientWidth 0 → the 720 fallback)
+    // would reveal at 720 even though the column is known by then.
+    const m = mountChatGpt();
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 720 },
+        { image_natural_width: 2400, image_natural_height: 1101 },
+      ),
+      m.wrapperWin,
+    );
+    expect(widgetFrame(m).getAttribute("height")).toBe("720");
+    setColumnWidth(m, COLUMN_WIDTH);
+    fireFrameLoad(m);
+    expect(widgetFrame(m).getAttribute("height")).toBe(
+      String(Math.round((COLUMN_WIDTH * 1101) / 2400)),
+    );
+  });
+
+  it("an embed-height report while awaiting load reveals AND settles the watchdog", () => {
+    // `tako-embed-height` can only come from the running embed page, so it
+    // is an even stronger "it rendered" signal than `load`. Without the
+    // unveil, the handler's notify would expand the host card around an
+    // invisible frame — the exact blank box reveal-on-load removes.
+    const m = mountChatGpt();
+    deliver(m, CHATGPT_RESULT, m.wrapperWin);
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(true);
+    deliverEmbedHeight(m, 500);
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(false);
+    expect(widgetFrame(m).getAttribute("height")).toBe("500");
+    // The handshake must also SETTLE the committed-iframe watchdog: the
+    // embed has proven it rendered, so a late `load` (slow font, stalled
+    // subresource) must not let the 8 s timeout downgrade a chart the user
+    // is already looking at. A frame-src violation after the handshake is
+    // the synchronous probe for that — with the watchdog settled its
+    // listener is gone, so nothing downgrades.
+    fireFrameSrcViolation(m);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(false);
+    expect(widgetFrame(m).getAttribute("src")).toBe(EMBED_IFRAME_SRC);
+  });
+
+  it("ignores an embed-height report whose sender is not our embed frame", () => {
+    // Origin alone would admit any browsing context on the pinned Tako
+    // origin that can reach this window through the frame tree — and the
+    // branch now controls visibility, not just size. The sender must be the
+    // widget's OWN embed iframe.
+    const m = mountChatGpt();
+    deliver(m, CHATGPT_RESULT, m.wrapperWin);
+    const WidgetMessageEvent = (
+      m.widgetWin as unknown as { MessageEvent: typeof MessageEvent }
+    ).MessageEvent;
+    m.widgetWin.dispatchEvent(
+      new WidgetMessageEvent("message", {
+        data: { type: "tako-embed-height", height: 500 },
+        origin: "https://staging.trytako.com", // right origin...
+        source: m.widgetWin as unknown as MessageEventSource, // ...wrong window
+      }),
+    );
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(true);
+    expect(widgetFrame(m).getAttribute("height")).not.toBe("500");
   });
 
   it("sizes a tall list card taller than a wide chart card", () => {
@@ -756,6 +869,9 @@ describe("committed iframe watchdog (executed)", () => {
     expect(widgetFrame(m).getAttribute("height")).toBe(
       String(Math.round((400 * 1101) / 2400)),
     );
+    // Reveal first: the resize listener stands down while the frame is
+    // hidden awaiting its `load`.
+    fireFrameLoad(m);
     setColumnWidth(m, 900);
     fireResize(m);
     expect(widgetFrame(m).getAttribute("height")).toBe(
@@ -784,6 +900,7 @@ describe("committed iframe watchdog (executed)", () => {
     );
     // Mounted on the fallback, as it must be — there is nothing to fit to yet.
     expect(widgetFrame(m).getAttribute("height")).toBe("720");
+    fireFrameLoad(m);
 
     // Layout settles and the host reflows.
     setColumnWidth(m, COLUMN_WIDTH);

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -968,6 +968,125 @@ describe("committed iframe watchdog (executed)", () => {
     expect(widgetImg(m).getAttribute("src")).toBeNull();
   });
 
+  it("ignores the srcless iframe's stray about:blank load", () => {
+    // #tako-embed is parser-inserted with no `src`, so the browser queues a
+    // `load` for its initial about:blank document — delivered right after
+    // the watchdog attaches its listener on the synchronous toolOutput
+    // path. Unguarded, that one event settled the watchdog (killing the
+    // CSP/timeout → PNG downgrade for the widget's life) and revealed the
+    // veiled frame at full height around nothing. The guard keys on the one
+    // fact that separates the stray from the real embed: about:blank is
+    // same-origin-readable, the cross-origin embed is not. jsdom navigates
+    // the frame's document synchronously on src assignment, so the stray
+    // state is modelled by pinning contentDocument back to an about:blank
+    // reading.
+    const m = mountChatGpt();
+    setColumnWidth(m, COLUMN_WIDTH);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 720 },
+        { image_natural_width: 2400, image_natural_height: 1101 },
+      ),
+      m.wrapperWin,
+    );
+    Object.defineProperty(widgetFrame(m), "contentDocument", {
+      configurable: true,
+      get: () => ({ location: { href: "about:blank" } }) as unknown as Document,
+    });
+    fireFrameLoad(m); // the stray
+    // No reveal — the frame stays veiled, and the host was not told to grow.
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(true);
+    expect(sizeChangesOf(m).at(-1)?.params.height).toBe(1);
+    // No settle either — the watchdog must still be armed, so a CSP block
+    // arriving after the stray still downgrades to the PNG.
+    fireFrameSrcViolation(m);
+    expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+    expect(widgetImg(m).getAttribute("src")).toBe(IMAGE_URL);
+  });
+
+  it("still reveals on the genuine load after ignoring the stray", () => {
+    const m = mountChatGpt();
+    setColumnWidth(m, COLUMN_WIDTH);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 720 },
+        { image_natural_width: 2400, image_natural_height: 1101 },
+      ),
+      m.wrapperWin,
+    );
+    Object.defineProperty(widgetFrame(m), "contentDocument", {
+      configurable: true,
+      get: () => ({ location: { href: "about:blank" } }) as unknown as Document,
+    });
+    fireFrameLoad(m); // stray — ignored
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(true);
+    // The embed responds: cross-origin, so contentDocument reads null.
+    Object.defineProperty(widgetFrame(m), "contentDocument", {
+      configurable: true,
+      get: () => null,
+    });
+    fireFrameLoad(m); // the genuine load
+    expect(widgetFrame(m).classList.contains("veiled")).toBe(false);
+    expect(sizeChangesOf(m).at(-1)?.params.height).toBe(
+      Math.round((COLUMN_WIDTH * 1101) / 2400),
+    );
+  });
+
+  it("downgrades a veiled frame to the PNG when nothing loads in the settle window", () => {
+    // The veiled→timeout→PNG path end to end: every other downgrade test
+    // reaches downgrade() via a CSP violation, so the timeout branch — and
+    // the `remove("veiled")` before `add("hidden")`, and the PNG revealing
+    // itself out of a veiled frame — never ran under test.
+    vi.useFakeTimers();
+    try {
+      const m = mountChatGpt();
+      setColumnWidth(m, COLUMN_WIDTH);
+      deliver(m, CHATGPT_RESULT, m.wrapperWin);
+      expect(widgetFrame(m).classList.contains("veiled")).toBe(true);
+      vi.advanceTimersByTime(8000); // IFRAME_SETTLE_MS
+      // Downgraded: unveiled AND hidden (an element carrying both classes
+      // would resurrect at height 0 if `hidden` were ever lifted), frame
+      // unloaded, PNG painted in its place.
+      expect(widgetFrame(m).classList.contains("veiled")).toBe(false);
+      expect(widgetFrame(m).classList.contains("hidden")).toBe(true);
+      expect(widgetFrame(m).getAttribute("src")).toBe("about:blank");
+      expect(widgetImg(m).getAttribute("src")).toBe(IMAGE_URL);
+      // The PNG reveals itself on its own load, exactly like the CSP path.
+      fireImageLoad(m);
+      expect(widgetLink(m).classList.contains("hidden")).toBe(false);
+      expect(widgetLink(m).getAttribute("href")).toBe(EMBED_URL);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stands down the resize re-fit while the frame is veiled", () => {
+    // The reveal re-fits for the veiled window (test above), so the live
+    // listener must not fight it: a column change before `load` is picked
+    // up at reveal time, not mid-veil.
+    const m = mountChatGpt();
+    setColumnWidth(m, COLUMN_WIDTH);
+    deliver(
+      m,
+      toolResult(
+        { embed_url: EMBED_URL, image_url: IMAGE_URL, height: 720 },
+        { image_natural_width: 2400, image_natural_height: 1101 },
+      ),
+      m.wrapperWin,
+    );
+    const staged = widgetFrame(m).getAttribute("height");
+    setColumnWidth(m, 900);
+    fireResize(m);
+    expect(widgetFrame(m).getAttribute("height")).toBe(staged);
+    // Reveal picks up the new width.
+    fireFrameLoad(m);
+    expect(widgetFrame(m).getAttribute("height")).toBe(
+      String(Math.round((900 * 1101) / 2400)),
+    );
+  });
+
   it("falls back to the remote PNG when the host CSP blocks the iframe", () => {
     const m = mountChatGpt();
     deliver(m, CHATGPT_RESULT, m.wrapperWin);

--- a/workers/test/widget/widget-dom.test.ts
+++ b/workers/test/widget/widget-dom.test.ts
@@ -451,6 +451,37 @@ describe("static widget bundle (executed)", () => {
     }
   });
 
+  it("labels the collapse when the tool-result itself says the call failed", () => {
+    // The MCP-Apps twin of the ChatGPT failed-call case: the host delivers
+    // the error result as a `ui/notifications/tool-result` whose params carry
+    // `isError: true` and `_meta["tako/error"]` but no `structuredContent`.
+    // That is a positive signal — unlike the silent 10 s watchdog — so the
+    // widget can collapse immediately AND label the box for hosts that keep
+    // it visible anyway.
+    const m = mountWidget(staticWidgetHtml());
+    deliver(
+      m,
+      {
+        jsonrpc: "2.0",
+        method: "ui/notifications/tool-result",
+        params: {
+          isError: true,
+          content: [{ type: "text", text: "Django returned 502 for POST /api/v3/search/" }],
+          _meta: { "tako/error": { kind: "http", status: 502 } },
+        },
+      },
+      m.wrapperWin,
+    );
+    expect(widgetEmpty(m).classList.contains("hidden")).toBe(false);
+    expect(widgetEmpty(m).textContent).toMatch(/failed/i);
+    expect(m.widgetWin.document.documentElement.style.height).toBe("0px");
+    const sizeChanges = m.toParent.filter(
+      (msg) =>
+        (msg as { method?: string }).method === "ui/notifications/size-changed",
+    ) as Array<{ params: { height: number } }>;
+    expect(sizeChanges.at(-1)?.params.height).toBe(0);
+  });
+
   it("does not collapse a chart that already rendered", () => {
     // The watchdog must be a no-op once anything painted, or a slow host
     // would have its working chart yanked at the 10 s mark.


### PR DESCRIPTION
## Problem

On the ChatGPT desktop app (and chatgpt.com), a `tako_search` chart had an ugly loading phase: the widget committed its cross-origin `tako.com/embed/...` iframe the moment the tool result arrived, immediately unhid it, and notified the host of the full chart height. The card expanded to full size seconds before the embed had painted anything — a full-height blank box in the chat.

A second route to the same symptom: a **failed** tool call. An `isError` result carries no `structuredContent`, but ChatGPT mounts the widget from static `openai/outputTemplate` registration anyway, holds it at its default mount height, and ignores shrink notifications — so the no-data watchdog's deliberately unlabelled collapse left a tall, pure-blank card next to the model's apology text.

## Fix 1 — reveal-on-load, with a veil instead of `display:none` (`212f736`)

The committed frame is now **veiled** at commit time: a `.veiled` class pins it to height 0 while keeping its layout box alive, so the embed page boots at the **real column width**. (Plain `display:none` would give the embed a 0-width viewport — mobile media queries, degenerate layout — and a `tako-embed-height` measured there would be notified and made permanent by ChatGPT's pin-the-max-height quirk.)

The frame is revealed only when one of two render-proof signals fires:

- **`load` on the frame** — via the existing committed-iframe watchdog, which was already listening. The reveal re-fits the aspect height at the settled column width, then notifies the host. Expansion and pixels arrive together.
- **an accepted `tako-embed-height` message** — the embed is demonstrably running, so the handler unveils, and now also **settles the watchdog**: previously a stalled subresource holding `load` past the 8s timeout would downgrade a chart the user was already looking at.

Failure paths are unchanged: a `frame-src` CSP violation or the watchdog timeout still downgrade to the PNG (which reveals itself on `img.load`), and a search returning zero cards still collapses. The veil itself is confined to the `window.openai` committed-iframe branch (ChatGPT + codex desktop only).

## Fix 2 — label the box a failed call leaves behind (`daf3289`)

Every server-built failure carries `_meta["tako/error"]` (Django errors, free-tier credits/capacity, and — since the review round — both free-tier rate limiters), and SDK-wrapped throws carry the envelope's `isError: true`. The widget now reads that signal from `window.openai.toolResponseMetadata` / `openai.widget` on the ChatGPT path and from `params` on the MCP-Apps `ui/notifications/tool-result` path, and collapses with a labelled empty state ("No chart: the call failed.") instead of an unlabelled blank. Hosts that honour shrink notifications still get the zero-height collapse; hosts that keep the box (ChatGPT) show a space that reads as intentional. A host exposing no failure signal degrades to exactly the old watchdog path.

**This commit does touch the MCP Apps path** (`isErrorSignal(params)` on `ui/notifications/tool-result`): on claude.ai-class hosts a failed call now labels the collapse instead of collapsing blank. Chart-bearing and zero-card deliveries there are byte-identical to before.

## Hardening from review

A 4-way pre-landing review pass caught the veil's `display:none` viewport bug, the watchdog/handshake race, a stale-height notify, and the `tako-embed-height` sender-pinning gap (`event.source === frame.contentWindow` on top of the origin gate) — all fixed in `212f736`.

robertabbott's review round, addressed in `472ecb0`:

- **Stray `about:blank` load (blocking)**: the srcless `#tako-embed` queues a `load` for its initial empty document, delivered right after the watchdog attaches on the synchronous `toolOutput` path — one event that settled the watchdog (killing the PNG downgrade for the widget's life, latent pre-veil) and revealed the veiled frame around nothing. `onLoad` now ignores a load whose `contentDocument` is readable and still `about:blank`; the real embed is cross-origin and reads null.
- **Terminal error collapse (blocking)**: an error sighting on the sniffed ChatGPT channels is now only recorded (`errorSeen`); the poll runs its full window so a late payload always wins, and the watchdog turns the sighting into the labelled collapse at exit. The MCP-Apps path keeps the immediate label — there the host has delivered THE result.
- Free-tier limiters now carry the `tako/error` discriminant; `pickErrorFromOpenAi` probes `openai.widget`; the veiled→timeout→PNG path and the mid-veil resize stand-down are now under test; three pre-veil comments swept; the unreachable `embedReportedHeight` guard kept but honestly labelled as a defensive invariant.

## Test plan

- [x] Committed frame stays veiled with the 1px mount floor notified, reveals at the fitted height on `load`; re-fits when layout settles between commit and `load` (`widget-dom.test.ts`)
- [x] `tako-embed-height` while veiled reveals AND settles the watchdog (violation-after-handshake does not downgrade); wrong-sender reports ignored
- [x] Stray `about:blank` load ignored — veil kept, watchdog still armed (a later CSP violation downgrades); genuine load after the stray still reveals
- [x] Veiled→timeout→PNG downgrade end to end, PNG self-revealing on `img.load`; resize re-fit stands down mid-veil
- [x] Failed calls: `tako/error` via `toolResponseMetadata` labels at the watchdog exit; envelope `isError` spellings covered; a payload landing after an error sighting still renders; MCP-Apps `isError` params label immediately; a renderable payload always beats a stale error signal
- [x] Free-tier limiter results pin `_meta["tako/error"]`
- [x] Full suites green: 1,159 main + 134 widget + 68 scripts; all four `tsc --noEmit` projects clean
- [ ] Live check on the ChatGPT desktop app (`tako_probe` + `enable_mcp_apps` in `~/.codex/config.toml`) before flipping prod traffic — including one forced failure to confirm `toolResponseMetadata` actually carries the error envelope

## Risk

The veil is scoped to the `window.openai` committed-iframe branch (ChatGPT + codex desktop only); if `load` never fires and no handshake arrives, behavior is identical to today's 8s timeout path. The failed-call labelling additionally touches the MCP-Apps `tool-result` delivery, where it activates only on `isError` results that previously collapsed blank — success deliveries are unchanged. The widget only ever notifies larger-after-smaller heights, working *with* ChatGPT's height pinning rather than against it. If a host exposes no failure signal under `isError`, the labelling degrades to the pre-existing silent watchdog collapse.
