### PR TITLE
fix(mcp): recovery paths and retry semantics for model-facing errors

### DIFF
--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -5,6 +5,7 @@ import type { Env, RateLimit } from "./env.js";
 import {
   checkFreeTierRateLimit,
   FREE_TIER_BATCH_MESSAGE,
+  FREE_TIER_COMMERCE_UPSELL,
   FREE_TIER_CREDITS_MESSAGE,
   FREE_TIER_GLOBAL_LIMIT_MESSAGE,
   FREE_TIER_LIMIT_MESSAGE,
@@ -795,6 +796,69 @@ describe("wrangler.jsonc ↔ message drift", () => {
   });
 });
 
+describe("commerce-gated upsell (FREE_TIER_COMMERCE_UPSELL)", () => {
+  // The base messages above stay commerce-free because they reach ChatGPT's
+  // model. On connections POSITIVELY identified as Anthropic clients
+  // (`commerceCopyAllowedForUa` in mcp.ts — the same allowlist that gates
+  // the authenticated 402 remedy), the anonymous limit moment is the one
+  // place a caller can be told that an account lifts the limits — the same
+  // conversion point Exa's keyless tier uses. The flag defaults to false,
+  // so every producer fails closed.
+
+  it("is absent from every producer by default (fails closed)", async () => {
+    const limited = (await freeTierLimitResponse(1).json()) as {
+      result: { content: Array<{ text: string }> };
+    };
+    expect(limited.result.content[0]?.text).toBe(FREE_TIER_LIMIT_MESSAGE);
+    const global = (await freeTierGlobalLimitResponse(2).json()) as {
+      result: { content: Array<{ text: string }> };
+    };
+    expect(global.result.content[0]?.text).toBe(
+      FREE_TIER_GLOBAL_LIMIT_MESSAGE,
+    );
+    expect(freeTierCreditsToolResult().content[0]?.text).toBe(
+      FREE_TIER_CREDITS_MESSAGE,
+    );
+  });
+
+  it("is appended to all three limit/capacity surfaces when allowed, in both response shapes", async () => {
+    const limited = (await freeTierLimitResponse(1, true).json()) as {
+      result: { content: Array<{ text: string }> };
+    };
+    expect(limited.result.content[0]?.text).toBe(
+      `${FREE_TIER_LIMIT_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`,
+    );
+    const limited429 = (await freeTierLimitResponse(null, true).json()) as {
+      error: { message: string };
+    };
+    expect(limited429.error.message).toBe(
+      `${FREE_TIER_LIMIT_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`,
+    );
+    const global = (await freeTierGlobalLimitResponse("x", true).json()) as {
+      result: { content: Array<{ text: string }> };
+    };
+    expect(global.result.content[0]?.text).toBe(
+      `${FREE_TIER_GLOBAL_LIMIT_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`,
+    );
+    expect(freeTierCreditsToolResult(true).content[0]?.text).toBe(
+      `${FREE_TIER_CREDITS_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`,
+    );
+  });
+
+  it("obeys the hygiene rules that are not commerce-specific", () => {
+    // It exists to name the account path, so the commerce-word ban does not
+    // apply — but the other message rules still do: no scheme URL (bare
+    // domain only — deep links rot), no stale host, no rate figure, and no
+    // "free" (the tier never names itself).
+    expect(FREE_TIER_COMMERCE_UPSELL).not.toMatch(/https?:\/\//);
+    expect(FREE_TIER_COMMERCE_UPSELL).not.toContain("trytako.com");
+    expect(FREE_TIER_COMMERCE_UPSELL).not.toMatch(
+      /\d+\s*requests?\s*(\/|per)\s*(min|minute|sec|second)/i,
+    );
+    expect(FREE_TIER_COMMERCE_UPSELL).not.toMatch(/\bfree\b/i);
+  });
+});
+
 describe("free tier end-to-end (worker.fetch with stub env)", () => {
   const JSON_HEADERS = {
     "content-type": "application/json",
@@ -1329,6 +1393,63 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
       expect(text).not.toMatch(/https?:\/\//);
       expect(text).not.toMatch(/upgrade|add credits/i);
     }
+  });
+
+  it("anonymous rate limit on a claude client carries the account upsell", async () => {
+    // The one place an anonymous Anthropic-client caller can learn that an
+    // account lifts the limits — the same conversion moment Exa's keyless
+    // tier uses ("add your own API key to continue").
+    const res = await worker.fetch(
+      post(ANSWER_CALL_BODY, {
+        "user-agent": "claude-code/2.1.220 (sdk-cli)",
+        "cf-connecting-ip": "203.0.113.9",
+      }),
+      freeEnv(fakeLimiter(false)),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).toBe(
+      `${FREE_TIER_LIMIT_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`,
+    );
+  });
+
+  it("anonymous rate limit on ChatGPT-family and unrecognized clients stays neutral", async () => {
+    // Same fail-closed rule as the authenticated 402 remedy: commerce copy
+    // reaching ChatGPT's model violates OpenAI policy, and an unrecognized
+    // UA could be an OpenAI reviewer or crawler.
+    for (const userAgent of ["ChatGPT/1.0", "python-httpx/0.27"]) {
+      const res = await worker.fetch(
+        post(ANSWER_CALL_BODY, { "user-agent": userAgent }),
+        freeEnv(fakeLimiter(false)),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        result: { content: Array<{ text: string }> };
+      };
+      expect(body.result.content[0]?.text).toBe(FREE_TIER_LIMIT_MESSAGE);
+    }
+  });
+
+  it("anonymous shared-account 402 on a claude client keeps the neutral cause and adds the upsell", async () => {
+    // The cause stays masked (an anonymous caller must not learn the shared
+    // account's balance state), but an Anthropic-client caller does get told
+    // that connecting an account is the way past shared capacity.
+    mockFetchSequence([SUBSCRIPTION_402()]);
+    const res = await worker.fetch(
+      post(ANSWER_CALL_BODY, { "user-agent": "claude-mcp-client/1.0" }),
+      freeEnv(fakeLimiter(true)),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.result.isError).toBe(true);
+    expect(body.result.content[0]?.text).toBe(
+      `${FREE_TIER_CREDITS_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`,
+    );
   });
 
   it("a malformed Authorization header still 401s even with the free tier configured", async () => {

--- a/workers/src/freetier.test.ts
+++ b/workers/src/freetier.test.ts
@@ -1162,6 +1162,83 @@ describe("free tier end-to-end (worker.fetch with stub env)", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("anonymous call to a gated tool on claude.ai names the Connect step", async () => {
+    const res = await worker.fetch(
+      post(
+        {
+          jsonrpc: "2.0",
+          id: 9,
+          method: "tools/call",
+          params: { name: "tako_contents", arguments: { urls: ["https://x.com"] } },
+        },
+        { "user-agent": "Claude-User/1.0" },
+      ),
+      freeEnv(fakeLimiter(true)),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }>; isError: boolean };
+    };
+    expect(body.result.isError).toBe(true);
+    const text = body.result.content[0]?.text ?? "";
+    expect(text).toContain("This tool requires a Tako account.");
+    expect(text).toContain("Settings → Connectors");
+  });
+
+  it("anonymous call to a gated tool on Claude Code names the API-key step", async () => {
+    const res = await worker.fetch(
+      post(
+        {
+          jsonrpc: "2.0",
+          id: 10,
+          method: "tools/call",
+          params: { name: "tako_contents", arguments: { urls: ["https://x.com"] } },
+        },
+        { "user-agent": "claude-code/2.1.220 (sdk-cli)" },
+      ),
+      freeEnv(fakeLimiter(true)),
+    );
+    const body = (await res.json()) as {
+      result: { content: Array<{ text: string }> };
+    };
+    const text = body.result.content[0]?.text ?? "";
+    expect(text).toContain("Tako API key");
+    expect(text).toContain("Claude Code");
+  });
+
+  it("anonymous gated-tool text on ChatGPT and unknown UAs is unchanged", async () => {
+    for (const userAgent of ["ChatGPT/1.0", "python-httpx/0.27"]) {
+      // `tako_contents`, not `tako_visualize`: `tako_visualize` is opt-in
+      // (`OPTIONAL_TOOL_NAMES`) and default-on only for widget clients
+      // (`WIDGET_CLIENT_DEFAULT_ON_TOOL_NAMES` — chatgpt/claude/codex), so
+      // it is off the AUTHENTICATED surface for `python-httpx`'s "unknown"
+      // client and the pre-dispatch gate never answers for it, regardless
+      // of any sign-in hint — an unrelated surface gap, not something this
+      // task's hint logic controls. `tako_contents` is unconditionally on
+      // every client's authenticated surface, so it exercises the same
+      // "byte-identical when the client is not positively identified"
+      // path this test is actually about.
+      const res = await worker.fetch(
+        post(
+          {
+            jsonrpc: "2.0",
+            id: 11,
+            method: "tools/call",
+            params: { name: "tako_contents", arguments: { urls: ["https://x.com"] } },
+          },
+          { "user-agent": userAgent },
+        ),
+        freeEnv(fakeLimiter(true)),
+      );
+      const body = (await res.json()) as {
+        result: { content: Array<{ text: string }> };
+      };
+      expect(body.result.content[0]?.text).toBe(
+        "This tool requires a Tako account. Sign in with Tako, or connect with a Tako API key, to continue.",
+      );
+    }
+  });
+
   it("an anonymous call to a NONEXISTENT tool still gets the SDK's genuine tool-not-found", async () => {
     // The gate only answers for names the registry knows — claiming a
     // typo'd tool needs auth would send the caller on a pointless sign-in.

--- a/workers/src/freetier.ts
+++ b/workers/src/freetier.ts
@@ -346,9 +346,27 @@ async function hitPerIpLimiter(
  * (see `freeTierLimitResponse`). Paid-account functionality itself is
  * allowed — advertising it here is not. A caller who wants their own key
  * finds it the same way every other Tako API user does, on tako.com.
+ * The one exception is `FREE_TIER_COMMERCE_UPSELL` below, appended only on
+ * connections positively identified as Anthropic clients.
  */
 export const FREE_TIER_LIMIT_MESSAGE =
   "Rate limit reached for anonymous access. Try again in a minute.";
+
+/**
+ * Upsell sentence appended to the limit/capacity messages — ONLY when the
+ * caller passes `commerceCopyAllowed: true`, which `mcp.ts` derives from
+ * `commerceCopyAllowedForUa` (an allowlist of POSITIVELY-identified
+ * Anthropic clients; unknown UAs fail closed). The base messages stay
+ * commerce-free because they reach ChatGPT's model (see
+ * `FREE_TIER_LIMIT_MESSAGE`); Anthropic hosts have no such policy, and the
+ * anonymous limit is the natural moment to say an account exists — the
+ * same conversion point Exa's keyless tier uses ("add your own API key to
+ * continue"). Bare domain, no deep link: deep links rot (the `/account/`
+ * path a previous version of this copy used was already stale when it was
+ * removed — see `PAYMENT_REQUIRED_REMEDY_FALLBACK` in `mcp.ts`).
+ */
+export const FREE_TIER_COMMERCE_UPSELL =
+  "Connecting a Tako account (tako.com) lifts these anonymous-access limits.";
 
 /**
  * Response for an over-limit metered `tools/call`.
@@ -366,8 +384,18 @@ export const FREE_TIER_LIMIT_MESSAGE =
  * matching result cannot be built, so this degrades to the legacy 429
  * (`code: -32000`, distinct from `-32001` auth failures) with a
  * `Retry-After` matching the limiter window.
+ *
+ * `commerceCopyAllowed` (from `commerceCopyAllowedForUa` in `mcp.ts`)
+ * appends `FREE_TIER_COMMERCE_UPSELL`; defaults false so every caller
+ * fails closed.
  */
-export function freeTierLimitResponse(requestId: JsonRpcRequestId): Response {
+export function freeTierLimitResponse(
+  requestId: JsonRpcRequestId,
+  commerceCopyAllowed = false,
+): Response {
+  const message = commerceCopyAllowed
+    ? `${FREE_TIER_LIMIT_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`
+    : FREE_TIER_LIMIT_MESSAGE;
   if (requestId === null) {
     return new Response(
       JSON.stringify({
@@ -375,7 +403,7 @@ export function freeTierLimitResponse(requestId: JsonRpcRequestId): Response {
         id: null,
         error: {
           code: -32000,
-          message: FREE_TIER_LIMIT_MESSAGE,
+          message,
           data: { kind: "rate_limited" },
         },
       }),
@@ -393,7 +421,7 @@ export function freeTierLimitResponse(requestId: JsonRpcRequestId): Response {
       jsonrpc: "2.0",
       id: requestId,
       result: {
-        content: [{ type: "text", text: FREE_TIER_LIMIT_MESSAGE }],
+        content: [{ type: "text", text: message }],
         // Same discriminant every other failed tool result carries
         // (djangoErrorToToolResult, freeTierCreditsToolResult, …), same
         // spelling as the 429 branch's `data.kind` above. The chart widget
@@ -431,10 +459,16 @@ export const FREE_TIER_GLOBAL_LIMIT_MESSAGE =
  * tool-error result the model can read; otherwise (handshake methods,
  * unparseable bodies, batches) a plain 429 with `Retry-After` is the only
  * shape available.
+ *
+ * Same `commerceCopyAllowed` semantics as `freeTierLimitResponse`.
  */
 export function freeTierGlobalLimitResponse(
   requestId: JsonRpcRequestId,
+  commerceCopyAllowed = false,
 ): Response {
+  const message = commerceCopyAllowed
+    ? `${FREE_TIER_GLOBAL_LIMIT_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`
+    : FREE_TIER_GLOBAL_LIMIT_MESSAGE;
   if (requestId === null) {
     return new Response(
       JSON.stringify({
@@ -450,7 +484,7 @@ export function freeTierGlobalLimitResponse(
           // topology ever needs to be genuinely opaque, the MESSAGES have to
           // converge first — and that costs the caller the difference between
           // "slow down" and "come back later".
-          message: FREE_TIER_GLOBAL_LIMIT_MESSAGE,
+          message,
           data: { kind: "global_rate_limited" },
         },
       }),
@@ -468,7 +502,7 @@ export function freeTierGlobalLimitResponse(
       jsonrpc: "2.0",
       id: requestId,
       result: {
-        content: [{ type: "text", text: FREE_TIER_GLOBAL_LIMIT_MESSAGE }],
+        content: [{ type: "text", text: message }],
         // See freeTierLimitResponse: the widget's failed-call label keys on
         // this. Kind mirrors the 429 branch's `data.kind`, distinct from the
         // per-IP bucket on purpose (comment above).
@@ -588,14 +622,23 @@ export const FREE_TIER_CREDITS_MESSAGE =
  * account is. "capacity" says only that the request cannot be served right
  * now. The guard test therefore bans credit and billing wording from the
  * kind, and does NOT ban "shared".
+ *
+ * `commerceCopyAllowed` (same semantics as `freeTierLimitResponse`) appends
+ * the account upsell WITHOUT unmasking the cause: "connect an account to
+ * get past shared capacity" is true and actionable whether the shared
+ * account is rate-limited or dry, so the balance-gauge concern above is
+ * untouched.
  */
-export function freeTierCreditsToolResult(): {
+export function freeTierCreditsToolResult(commerceCopyAllowed = false): {
   content: Array<{ type: "text"; text: string }>;
   _meta: Record<string, unknown>;
   isError: true;
 } {
+  const text = commerceCopyAllowed
+    ? `${FREE_TIER_CREDITS_MESSAGE} ${FREE_TIER_COMMERCE_UPSELL}`
+    : FREE_TIER_CREDITS_MESSAGE;
   return {
-    content: [{ type: "text", text: FREE_TIER_CREDITS_MESSAGE }],
+    content: [{ type: "text", text }],
     _meta: { "tako/error": { kind: "capacity" } },
     isError: true,
   };

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -16,6 +16,7 @@ import {
 import type { Env } from "./env.js";
 import { FREE_TIER_TOOL_NAMES } from "./freetier.js";
 import {
+  AUTH_INVALID_MESSAGE,
   commerceCopyAllowedForUa,
   createMcpServer,
   detectMcpClient,
@@ -1160,6 +1161,8 @@ describe("auth challenges (ChatGPT link-account flow)", () => {
       expect(
         (result._meta?.["tako/error"] as { kind?: string } | undefined)?.kind,
       ).toBe("unauthorized");
+      const text = (result.content?.[0] as { text?: string } | undefined)?.text;
+      expect(text).toBe(AUTH_INVALID_MESSAGE);
     },
   );
 
@@ -1189,7 +1192,7 @@ describe("auth challenges (ChatGPT link-account flow)", () => {
     ).toBe("unauthorized");
   });
 
-  it("a Django 401 on non-ChatGPT clients keeps the error result unchanged", async () => {
+  it("a Django 401 on an authenticated claude client gets the recovery message and re-auth challenge", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse(401, { detail: "Invalid API key." })),
@@ -1200,7 +1203,15 @@ describe("auth challenges (ChatGPT link-account flow)", () => {
       { query: "US GDP" },
     );
     expect(result.isError).toBe(true);
-    expect(result._meta?.["mcp/www_authenticate"]).toBeUndefined();
+    const text = (result.content?.[0] as { text?: string } | undefined)?.text ?? "";
+    expect(text).toBe(AUTH_INVALID_MESSAGE);
+    expect(text).not.toContain("Django");
+    const challenges = result._meta?.["mcp/www_authenticate"] as string[] | undefined;
+    expect(challenges?.[0]).toContain('error="invalid_token"');
+    // the structured detail survives for clients that key on it
+    expect(
+      (result._meta?.["tako/error"] as { kind?: string } | undefined)?.kind,
+    ).toBe("unauthorized");
   });
 });
 

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -330,6 +330,20 @@ describe("djangoErrorToToolResult", () => {
     expect(text).toContain("retry the SAME call once");
   });
 
+  it("a Django timeout carries the transient-retry sentence", () => {
+    const result = djangoErrorToToolResult(
+      new DjangoTimeoutError({
+        path: "/api/v1/answer/",
+        method: "POST",
+        timeoutMs: 130000,
+      }),
+    );
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("timed out");
+    expect(text).toContain("transient upstream condition");
+  });
+
   it("does NOT invite a retry on a non-transient 5xx", () => {
     const err = new DjangoHttpError({
       path: "/api/v1/whatever", method: "GET", status: 501, body: "boom",

--- a/workers/src/mcp.test.ts
+++ b/workers/src/mcp.test.ts
@@ -316,9 +316,23 @@ describe("djangoErrorToToolResult", () => {
     expect(result.content[0]?.text).toContain("retry the SAME call once");
   });
 
+  it("a Django 500 carries the transient-retry sentence (most common upstream fault)", () => {
+    const err = new DjangoHttpError({
+      path: "/api/v3/search/",
+      method: "POST",
+      status: 500,
+      body: "boom",
+    });
+    const result = djangoErrorToToolResult(err);
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("transient upstream condition");
+    expect(text).toContain("retry the SAME call once");
+  });
+
   it("does NOT invite a retry on a non-transient 5xx", () => {
     const err = new DjangoHttpError({
-      path: "/api/v1/whatever", method: "GET", status: 500, body: "boom",
+      path: "/api/v1/whatever", method: "GET", status: 501, body: "boom",
     });
     const text = djangoErrorToToolResult(err).content[0]?.text ?? "";
     expect(text).toBe(err.message);

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -1220,23 +1220,24 @@ function registerTool(
           }
           const mapped = djangoErrorToToolResult(err);
           // A 401 from Django on an AUTHENTICATED connection means the
-          // caller's own credential was rejected — for an OAuth-linked
-          // user, a stale or revoked Tako token. Attach the
-          // `_meta["mcp/www_authenticate"]` challenge on ChatGPT so its
-          // client offers re-linking (the OpenAI Apps SDK keys the reauth
-          // UI on this exact field); other clients keep the unchanged
-          // error result. Free-tier connections are excluded: there the
+          // caller's own credential was rejected — a stale/revoked OAuth
+          // token or a rotated raw API key. Curated text (AUTH_INVALID_MESSAGE)
+          // plus the `mcp/www_authenticate` challenge, on EVERY client:
+          // ChatGPT keys its re-link UI on the challenge, and hosts that
+          // don't understand the `_meta` key ignore it, so attaching it
+          // universally costs nothing and future OAuth-capable hosts get it
+          // for free. Free-tier connections are excluded: there the
           // rejected credential is the SHARED free-tier key, so "your
           // session expired" would be false for a caller with no session
           // — and funneling anonymous users into (working) sign-in would
           // mask a shared-key outage as a per-user auth failure.
           if (
-            isChatGptFamilyClient(options.client) &&
             options.tier === "authenticated" &&
             err instanceof DjangoUnauthorizedError
           ) {
             return {
               ...mapped,
+              content: [{ type: "text" as const, text: AUTH_INVALID_MESSAGE }],
               _meta: {
                 ...mapped._meta,
                 "mcp/www_authenticate": [
@@ -1556,6 +1557,25 @@ export const PAYMENT_REQUIRED_MESSAGE =
   "This Tako account is out of credits, so the call could not run. " +
   "Priced calls will keep failing until the account has credits again; " +
   "`tako_available_data` is free and still works.";
+
+/**
+ * Model-visible message for an AUTHENTICATED caller whose Tako credential
+ * Django rejected (401) — an expired/revoked OAuth-linked API token, or a
+ * raw key the user rotated at tako.com. Before this, only ChatGPT-family
+ * clients got recovery guidance (the `mcp/www_authenticate` challenge);
+ * everyone else saw the raw "Django returned 401 …" text — internal
+ * jargon, no next step, and no host flow triggered because the result is
+ * HTTP 200. Names both remedies for the same reason
+ * `authRequiredToolResult` does: connector hosts re-link, config-file
+ * clients re-key. The free tier NEVER gets this message — there the
+ * rejected credential is the shared free-tier key (see the 401 mapping in
+ * `registerTool`), and "sign in again" would mask a shared-key outage as
+ * a per-user failure.
+ */
+export const AUTH_INVALID_MESSAGE =
+  "This connection's Tako authorization is no longer valid, so the call could not run. " +
+  "Calls will keep failing until it is re-authorized: sign in with Tako again " +
+  "(reconnect the Tako connector), or update the API key if this connection uses one.";
 
 /**
  * Remedy line appended when the 402 body carries no recognizable message

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -1429,8 +1429,11 @@ function registerTool(
 }
 
 /** Upstream statuses that clear on their own: worth one retry of the same
- *  call, as opposed to a 4xx that needs the request changed. */
-const RETRYABLE_STATUS = new Set([408, 429, 502, 503, 504]);
+ *  call, as opposed to a 4xx that needs the request changed. Includes 500
+ *  (transient handler crash or proxy error) since 5xx bodies are stripped from
+ *  the text channel, making the 500 indistinguishable from permanent failure
+ *  without the retry sentence — a 500 clears on retry exactly like a 502. */
+const RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504]);
 
 /**
  * Convert a `DjangoError` into an MCP `CallToolResult` with `isError: true`.

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -1215,7 +1215,7 @@ function registerTool(
           // caller-supplied input masquerade as credit exhaustion.
           if (err instanceof DjangoHttpError && err.status === 402) {
             return callCtx.tier === "free"
-              ? freeTierCreditsToolResult()
+              ? freeTierCreditsToolResult(options.commerceCopyAllowed)
               : paymentRequiredToolResult(err, options.commerceCopyAllowed);
           }
           const mapped = djangoErrorToToolResult(err);
@@ -1812,16 +1812,27 @@ export async function handleMcpRequest(
     // ceiling → body-size bound → batch rejection → per-IP metering of
     // free-tool calls), then act as the shared free-tier account
     // downstream. See `checkFreeTierRateLimit` for the ordering rationale.
+    //
+    // The commerce flag gates the account-upsell suffix on the two limit
+    // messages (see `FREE_TIER_COMMERCE_UPSELL`). Computed here AND at
+    // `createMcpServer` below; `commerceCopyAllowedForUa` is pure, so the
+    // double call cannot disagree (same reasoning as `detectMcpClient`).
+    const commerceCopyAllowed = commerceCopyAllowedForUa(
+      request.headers.get("user-agent"),
+    );
     const meterResult = await checkFreeTierRateLimit(request, freeTier);
     switch (meterResult.kind) {
       case "global_limited":
-        return freeTierGlobalLimitResponse(meterResult.requestId);
+        return freeTierGlobalLimitResponse(
+          meterResult.requestId,
+          commerceCopyAllowed,
+        );
       case "too_large":
         return freeTierTooLargeResponse();
       case "batch":
         return freeTierBatchResponse();
       case "limited":
-        return freeTierLimitResponse(meterResult.requestId);
+        return freeTierLimitResponse(meterResult.requestId, commerceCopyAllowed);
       case "allowed": {
         // Known-but-auth-required tool called anonymously: answer with
         // sign-in guidance instead of letting the SDK say "tool not

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -1510,16 +1510,16 @@ export function djangoErrorToToolResult(err: DjangoError): {
       : is4xx && detailText !== undefined
         ? `${err.message}: ${detailText}`
         : err.message;
-  // Transient statuses carry no LLM-actionable body, so without this they
-  // reach the model as a bare "Django returned 408 for POST /api/v1/answer/" —
-  // indistinguishable from a permanent failure, which pushes the agent to
-  // abandon Tako on an error that a single retry clears. Observed live: a
-  // cold-path answer call 408'd, then returned the figure on the very next
-  // attempt. `_graph.ts` already gives graph calls this treatment; this is the
-  // same signal for every other endpoint. A handler's own `modelGuidance`
-  // wins untouched — it is already self-correcting by construction.
+  // Retryable = a transient HTTP status OR a timeout. DjangoTimeoutError is
+  // constructed without a status (there was no response), which used to
+  // exclude the single most retry-worthy failure — the 130s search/answer
+  // ceilings — from this guidance. The comment above argues this exact case
+  // for 408; a timeout is the same condition observed from our side.
+  const retryable =
+    err instanceof DjangoTimeoutError ||
+    (err.status !== undefined && RETRYABLE_STATUS.has(err.status));
   const text =
-    err.modelGuidance === undefined && err.status !== undefined && RETRYABLE_STATUS.has(err.status)
+    err.modelGuidance === undefined && retryable
       ? `${base} This is a transient upstream condition, not a bad request: retry the SAME call once after a short backoff before changing approach.`
       : base;
   return {

--- a/workers/src/mcp.ts
+++ b/workers/src/mcp.ts
@@ -387,6 +387,28 @@ export function commerceCopyAllowedForUa(userAgent: string | null): boolean {
   return detectMcpClient(userAgent) === "claude";
 }
 
+/**
+ * The client-specific sign-in step appended to `authRequiredToolResult`,
+ * or undefined when the client cannot be positively identified as an
+ * Anthropic host (fails closed like `commerceCopyAllowedForUa` — an
+ * unrecognized UA could be OpenAI's review crawler, and ChatGPT's own
+ * link-account UI acts on the `_meta` challenge instead of prose). UA
+ * (not `McpClientKind`) is the input because Claude Code deliberately
+ * buckets as "unknown" for widget routing yet has a completely different
+ * sign-in step (config-file API key) than claude.ai (connector Connect
+ * button). No URLs, no UI deep paths beyond the settings pane name —
+ * copy rots (see PAYMENT_REQUIRED_REMEDY_FALLBACK).
+ */
+export function anonymousSignInHint(userAgent: string | null): string | undefined {
+  if (userAgent === null || userAgent === "") return undefined;
+  if (userAgent.toLowerCase().includes("claude-code")) {
+    return "In Claude Code, re-add this Tako server with a Tako API key to enable it.";
+  }
+  return detectMcpClient(userAgent) === "claude"
+    ? "In Claude, open Settings → Connectors and connect Tako, then retry this call."
+    : undefined;
+}
+
 // Per-client annotation resolution lives with the tool surface config in
 // `tools/_surface.ts` (each tool declares its own `annotationsByClient`
 // next to its canonical MCP annotations — see `annotationsByClient` in
@@ -439,6 +461,15 @@ export function createMcpServer(
      * messages).
      */
     commerceCopyAllowed?: boolean;
+    /**
+     * Client-specific sign-in step for the free-tier dispatch gate; from
+     * `anonymousSignInHint`. Appended to `authRequiredToolResult`'s base
+     * text when the calling client is positively identified as an
+     * Anthropic host. Omitted (the default) → no hint, byte-identical to
+     * today's text — the correct behavior for tests, non-HTTP callers,
+     * ChatGPT, and unrecognized UAs.
+     */
+    signInHint?: string;
   } = {},
 ): McpServer {
   // Hosts (Claude.ai connector cards, ChatGPT app directory, etc.) pick
@@ -570,6 +601,9 @@ export function createMcpServer(
       tier,
       commerceCopyAllowed: options.commerceCopyAllowed ?? false,
       origin: options.requestOrigin,
+      ...(options.signInHint !== undefined
+        ? { signInHint: options.signInHint }
+        : {}),
       widgetSuppressedForTool:
         isChatGptFamilyClient(client) &&
         CHATGPT_NO_WIDGET_TOOL_NAMES.has(tool.name),
@@ -752,6 +786,13 @@ function registerTool(
      * `error_description` (the parts ChatGPT's sign-in UI keys on).
      */
     origin: string | undefined;
+    /**
+     * Client-specific sign-in step appended to `authRequiredToolResult`
+     * by the free-tier dispatch gate below (see `anonymousSignInHint`).
+     * `undefined` in tests / non-HTTP contexts, on ChatGPT, and on
+     * unrecognized UAs — the base text stays byte-identical there.
+     */
+    signInHint?: string;
     /**
      * Set of `appUiResource` URIs already registered with the SDK on
      * this `McpServer` instance. Tools whose `appUiResource.uri`
@@ -1181,7 +1222,7 @@ function registerTool(
         console.log(
           `[mcp] auth-required tool blocked on free tier tool=${tool.name} client=${options.client}`,
         );
-        return authRequiredToolResult(options.origin);
+        return authRequiredToolResult(options.origin, options.signInHint);
       }
       let output: unknown;
       try {
@@ -1744,6 +1785,7 @@ export function freeTierHiddenToolResponse(
   origin: string,
   client: McpClientKind,
   enabledOptionalToolNames: ReadonlySet<string>,
+  signInHint?: string,
 ): Response | null {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return null;
@@ -1774,7 +1816,7 @@ export function freeTierHiddenToolResponse(
     JSON.stringify({
       jsonrpc: "2.0",
       id,
-      result: authRequiredToolResult(origin),
+      result: authRequiredToolResult(origin, signInHint),
     }),
     {
       status: 200,
@@ -1869,6 +1911,7 @@ export async function handleMcpRequest(
           parseEnabledOptionalToolNames(
             new URL(request.url).searchParams.get("tools"),
           ),
+          anonymousSignInHint(request.headers.get("user-agent")),
         );
         if (gated !== null) return gated;
         break;
@@ -1971,6 +2014,7 @@ export async function handleMcpRequest(
         }`,
       );
     }
+    const signInHint = anonymousSignInHint(userAgent);
     const server = createMcpServer(ctx, {
       iconsBaseUrl: requestOrigin,
       requestOrigin,
@@ -1978,6 +2022,7 @@ export async function handleMcpRequest(
       enabledOptionalToolNames,
       tier,
       commerceCopyAllowed: commerceCopyAllowedForUa(userAgent),
+      ...(signInHint !== undefined ? { signInHint } : {}),
     });
     // Omitting `sessionIdGenerator` puts the transport in stateless mode — no
     // `Mcp-Session-Id` header is issued or validated. This matches the Worker

--- a/workers/src/tools/_security.ts
+++ b/workers/src/tools/_security.ts
@@ -140,11 +140,16 @@ export function wwwAuthenticate(
  * `error="insufficient_scope"` mirrors OpenAI's own login example — the
  * anonymous grant lacks the access this tool needs.
  */
-export function authRequiredToolResult(origin: string | undefined): {
+export function authRequiredToolResult(
+  origin: string | undefined,
+  recoveryHint?: string,
+): {
   content: Array<{ type: "text"; text: string }>;
   _meta: Record<string, unknown>;
   isError: true;
 } {
+  const base =
+    "This tool requires a Tako account. Sign in with Tako, or connect with a Tako API key, to continue.";
   return {
     content: [
       {
@@ -155,8 +160,13 @@ export function authRequiredToolResult(origin: string | undefined): {
         // UI (ChatGPT; OAuth-capable clients like claude.ai and Claude
         // Code) sign in, config-file clients (Cursor et al.) connect with
         // an API key. "Sign in" alone told a config-file user to do
-        // something their host has no flow for.
-        text: "This tool requires a Tako account. Sign in with Tako, or connect with a Tako API key, to continue.",
+        // something their host has no flow for. `recoveryHint` (from
+        // `anonymousSignInHint` in mcp.ts) appends the CLIENT-SPECIFIC
+        // step where the client is positively identified — absent for
+        // ChatGPT (its link-account UI acts on the `_meta` challenge
+        // instead) and for unknown UAs (fails closed; could be OpenAI's
+        // review crawler).
+        text: recoveryHint === undefined ? base : `${base} ${recoveryHint}`,
       },
     ],
     _meta: {


### PR DESCRIPTION
## Summary

Fixes the four highest-severity findings from the 2026-08-19 model-facing-message audit. Every change is additive and rides inside the existing HTTP-200 tool-result envelopes — no HTTP status changes, no `_meta` removals, ChatGPT-anonymous surface byte-identical (test-enforced).

**⚠️ STACKS ON #247 — merge that first** (this branch includes its commit; after #247 merges this PR shrinks to its own four commits).

1. **HTTP 500 is now retryable** (audit F4): added to `RETRYABLE_STATUS`, so the most common upstream fault carries the "transient — retry the same call once" sentence instead of reading as permanent.
2. **Timeouts carry the transient-retry sentence** (audit F2): `DjangoTimeoutError` has no status so the old status-gated sentence never fired for the likeliest transient failure (130s search/answer ceilings). New `retryable` predicate treats timeout-or-transient-status as one rule; a tool's own `modelGuidance` still wins.
3. **Authenticated 401s get a recovery path on every client** (audit F1): previously only ChatGPT-family got the `mcp/www_authenticate` re-link challenge; claude.ai/Claude Code users with a rotated or revoked key got a dead-end `Django returned 401…`. Now every authenticated client gets curated text (`AUTH_INVALID_MESSAGE`: reconnect the connector / update the API key) plus the challenge (hosts that don't read it ignore `_meta`). Free-tier 401s untouched — there the rejected credential is the shared key, and "sign in again" would mask an outage as a per-user failure (guard test unedited).
4. **Anonymous gated-tool guidance names the concrete step on Claude clients** (audit F6): `anonymousSignInHint` appends "Settings → Connectors → connect Tako" on claude.ai and "re-add with a Tako API key" on Claude Code. Fails closed: ChatGPT, codex, and unrecognized UAs get byte-identical text to today (an unknown UA could be OpenAI's review crawler).

## Test plan

- [x] New: 500 carries retry sentence; 501 (non-transient 5xx) still doesn't
- [x] New: direct `DjangoTimeoutError` result carries "timed out" + retry sentence
- [x] Rewritten: claude-client authenticated 401 → `AUTH_INVALID_MESSAGE`, no "Django", `invalid_token` challenge, `tako/error.kind` preserved; ChatGPT/codex 401 tests extended to assert the same text
- [x] Unedited guard: free-tier 401 gets no challenge and no session language
- [x] New e2e: claude.ai UA hint, Claude Code UA hint, ChatGPT + unknown UA byte-identity (hardcoded literal, both gate layers)
- [x] Full suites green: main 1170, widget 134, scripts 68; typecheck 4/4; `registry:check` + `schemas:check` clean
- [x] Whole-branch review (per-task spec+quality reviews plus final cross-task pass): clean, no blocking findings