### PR TITLE
test(smoke): read the id the visualize tool still advertises, and gate the release PR on it

### DIFF
--- a/.github/workflows/workers-smoke.yml
+++ b/.github/workflows/workers-smoke.yml
@@ -7,6 +7,9 @@ name: workers-smoke
 #     `push` to main -> staging, `release: published` -> production. Because both
 #     sides read the same signal, the badge cannot claim to have smoked an env
 #     the deploy did not touch.
+#   - `pull_request` on the release-please branch: gate cutting a release on a
+#     staging that still answers. Smokes STAGING, not production — see the
+#     comment on the trigger.
 #   - `workflow_dispatch`: manual trigger to smoke any base URL.
 #
 # We still DO NOT auto-smoke after a `workflow_dispatch` deploy: that one takes
@@ -30,6 +33,22 @@ on:
   workflow_run:
     workflows: [workers-deploy]
     types: [completed]
+  # Release gate. The release-please PR is the last human decision point before
+  # a production deploy, and until now nothing about the deployed worker was
+  # asserted there: `typecheck-and-test` proves the code compiles, not that the
+  # thing serving traffic answers. The target here is STAGING, deliberately —
+  # the tip being released is already deployed to staging, and production has
+  # nothing new on it yet. So this check does not verify production; it refuses
+  # to cut a release out of a staging that cannot answer a tools/call.
+  #
+  # `.release-please-manifest.json` as the only path: release-please is the sole
+  # writer of that file, so a normal PR never starts this workflow and never
+  # shows a skipped check. The head_ref guard on the job is the correctness
+  # half — the path filter only keeps other PRs quiet.
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - '.release-please-manifest.json'
   workflow_dispatch:
     inputs:
       base_url:
@@ -52,9 +71,15 @@ env:
 # smoke if a newer deploy to the SAME env lands while it's running. Keyed by the
 # resolved env rather than by base_url alone, so a release-triggered prod smoke
 # does not cancel a staging one that is still running.
+# The release-PR arm gets its OWN lane, keyed by PR number. It resolves to the
+# staging base URL like a post-deploy staging smoke does, so sharing the lane
+# would let a release-PR run cancel the post-deploy run that actually gates the
+# staging badge (and the reverse).
 concurrency:
   group: >-
-    workers-smoke-${{ github.event.inputs.base_url ||
+    workers-smoke-${{ github.event_name == 'pull_request' &&
+    format('release-pr-{0}', github.event.number) ||
+    github.event.inputs.base_url ||
     (github.event.workflow_run.event == 'release' && 'production' || 'staging') }}
   cancel-in-progress: true
 
@@ -75,8 +100,15 @@ jobs:
     #
     # Upstream `workflow_dispatch` runs are still skipped: their env comes from
     # an input this event does not expose.
+    #
+    # The `pull_request` arm is guarded on `head_ref`, not on the path filter
+    # alone: a path filter decides whether the WORKFLOW starts, and any PR that
+    # touched `.release-please-manifest.json` for its own reasons would start it.
+    # Only release-please's branch may spend a credit and publish a card here.
     if: |
       github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.head_ref == 'release-please--branches--main') ||
       (github.event.workflow_run.conclusion == 'success' &&
        (github.event.workflow_run.event == 'push' ||
         github.event.workflow_run.event == 'release'))
@@ -136,7 +168,14 @@ jobs:
       # passed — tighten this once the case set has proven stable.
       # Same target resolution as the Smoke step above — kept in lockstep so the
       # two steps in one job can never be pointed at different environments.
+      #
+      # Skipped on the release PR. It is `continue-on-error`, so it gates
+      # nothing there, and every case it runs is a metered call — spending them
+      # to print a result no one can block on is the wrong trade at the one
+      # trigger that fires per release. The post-deploy staging run still
+      # reports it on the same commit.
       - name: Golden queries
+        if: github.event_name != 'pull_request'
         continue-on-error: true
         env:
           GOLDEN_BASE_URL: >-

--- a/workers/scripts/smoke.ts
+++ b/workers/scripts/smoke.ts
@@ -79,6 +79,13 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 // drift from the route the worker serves and the shim points at.
 import { EMBED_DATA_PREFIX } from "../src/embed_proxy.js";
 
+// Imported for the same reason: the visualize step validates the deployed
+// result against the tool's OWN `outputSchema`, so a field the tool stops
+// advertising breaks this file's typecheck instead of only its post-deploy
+// run. Reading a dropped field is exactly how this file's old `card_id`
+// assert kept the deploy smoke red for 17 days after PR #210 removed it.
+import takoVisualize from "../src/tools/tako_visualize.js";
+
 const CANARY_QUERY = "US GDP";
 
 // Both env vars are required — no in-script defaults. The single source of
@@ -379,19 +386,26 @@ try {
       },
     ],
   });
-  const tvStructured = tvResult.structuredContent as
-    | { card_id?: string; embed_url?: string }
-    | undefined;
-  assert(tvStructured, "tako_visualize missing structuredContent");
+  const tvParsed = takoVisualize.outputSchema.safeParse(tvResult.structuredContent);
   assert(
-    typeof tvStructured.card_id === "string" && tvStructured.card_id.length > 0,
-    "tako_visualize returned no card_id",
+    tvParsed.success,
+    `tako_visualize structuredContent does not match its outputSchema: ` +
+      JSON.stringify(tvParsed.error?.issues ?? []).slice(0, 400),
+  );
+  const tvStructured = tvParsed.data;
+  // `pub_id`, not `card_id` — PR #210 dropped `card_id` from the schema
+  // (OpenAI app review: one id in front of the model, not two) and `pub_id`
+  // carries the identical string. Both are `.optional()` in `autoChainShape`,
+  // so the parse above cannot assert presence; these two do.
+  assert(
+    typeof tvStructured.pub_id === "string" && tvStructured.pub_id.length > 0,
+    "tako_visualize returned no pub_id",
   );
   assert(
     typeof tvStructured.embed_url === "string" && /^https?:\/\//.test(tvStructured.embed_url),
     `tako_visualize.embed_url is not http(s): ${JSON.stringify(tvStructured?.embed_url)}`,
   );
-  ok(`tako_visualize → card_id ${tvStructured.card_id}`);
+  ok(`tako_visualize → pub_id ${tvStructured.pub_id}`);
 
   // -------------------------------------------------------------------------
   // 6. Native-card proxy — the interactive/themed chart path on claude.ai
@@ -428,14 +442,14 @@ try {
   // between creating a card and its embed page existing, which is not something
   // to redden a deploy over.
   const nativeRes = await fetch(
-    `${baseUrl}/embed-html/${encodeURIComponent(tvStructured.card_id)}`,
+    `${baseUrl}/embed-html/${encodeURIComponent(tvStructured.pub_id)}`,
   );
   const nativeBody = await nativeRes.text();
   if (nativeRes.status === 404) {
     if (nativeBody.includes("chart not found")) {
       console.warn(
         `[warn] /embed-html/ → 404 "chart not found": the route is LIVE, but ` +
-          `card ${tvStructured.card_id} did not resolve upstream (likely lag ` +
+          `card ${tvStructured.pub_id} did not resolve upstream (likely lag ` +
           `between creating it and its embed page existing).`,
       );
     } else {
@@ -556,7 +570,7 @@ try {
     // which is exactly what shipped and what a user reported.
     //
     // Two distinct things to check, because either alone passes while broken:
-    const dataUrl = `${baseUrl}${EMBED_DATA_PREFIX}${tvStructured.card_id}`;
+    const dataUrl = `${baseUrl}${EMBED_DATA_PREFIX}${tvStructured.pub_id}`;
     assert(
       nativeBody.includes(dataUrl),
       `/embed-html/ served a page with no data-proxy shim pointing at ` +
@@ -646,7 +660,7 @@ try {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           ...config.params,
-          pub_id: tvStructured.card_id,
+          pub_id: tvStructured.pub_id,
           dark_mode: false,
         }),
       });


### PR DESCRIPTION
The deploy smoke has failed on every push to main since 2026-08-04, always at
step 5e with `✘ tako_visualize returned no card_id`. Nothing is broken in
staging or in the tool: PR #210 (`2f83f24`, "strip upsells, request ids, and
iframe analytics for app review") removed `card_id` from `tako_visualize`'s
`outputSchema` on purpose — `pub_id` carries the identical string, so one id
faces the model instead of two — and `scripts/smoke.ts` kept reading the
dropped field.

Last green run: [30876728163](https://github.com/TakoData/tako-mcp/actions/runs/30876728163)
(2026-08-04 04:07Z, worker 0.16.1). First red:
[30945468252](https://github.com/TakoData/tako-mcp/actions/runs/30945468252)
(2026-08-04 19:55Z). 17 days, 30 red runs.

## What the red hid

`scripts/smoke.ts` exits on the first failed assert, so for 17 days these never
executed:

- steps 6a-6c — the native-card proxy routes (`/embed-html/`, `/cdn-asset/`,
  `/embed-data/{pub_id}`), including the assert that a non-empty `pub_id` body
  is rejected 400 before it reaches an upstream write with no ownership check
- the `Golden queries` step, which runs after Smoke in the same job

## Why the typecheck now catches this class

The visualize step parsed `structuredContent` through a hand-written
`as { card_id?: string }` cast, which cannot disagree with anything. It now
parses through `takoVisualize.outputSchema` — the tool's own contract, the same
reason this file already imports `EMBED_DATA_PREFIX` rather than spelling the
route out. `scripts/tsconfig.json` is in `npm run typecheck`, so the next field
the tool stops advertising breaks the build in this file instead of reddening a
deploy nobody reads.

The two presence asserts stay: `pub_id` and `embed_url` are both `.optional()`
in `autoChainShape`, so a schema parse alone cannot prove either is there.

## Second commit: the release PR now runs the smoke

`workers-smoke.yml` gains a `pull_request` arm scoped to release-please's
branch, so `release: X.Y.Z` PRs carry a live smoke check. It smokes **staging**,
not production — the tip being released is already deployed to staging, and
production has nothing new on it yet. The check does not verify production; it
refuses to cut a release out of a staging that cannot answer a `tools/call`.

That is a gate, not new coverage. The same assertions already run after every
push to main; what changes is that a red one now sits on the PR someone is about
to merge instead of on a badge nobody opens. A `card_id` assert reading a
dropped field would have been caught at the first release, not the thirtieth.

Two guards doing different jobs: the `.release-please-manifest.json` path filter
keeps the workflow from starting on ordinary PRs (release-please is that file's
only writer, so no PR shows a skipped check), and the `head_ref` guard on the
job is the correctness half — a path filter only decides whether the workflow
starts, so any PR touching that file would start it, and only release-please's
branch may spend a credit and publish a card. The arm gets its own concurrency
lane keyed by PR number: it resolves to the same staging URL as a post-deploy
staging smoke, so a shared lane would let one cancel the other.

`Golden queries` is skipped on the release PR — it is `continue-on-error`, so it
gates nothing there, and every case is a metered call. The post-deploy staging
run still reports it for the same commit.

Cost: one credit and one public staging card per push to the release branch,
i.e. one per commit that lands on main during a release cycle.

Merge order matters: until the first commit lands, this check is red on
[#251](https://github.com/TakoData/tako-mcp/pull/251) for the same `card_id`
reason it is red on main.

## Note for whoever reviews the workflow

`workers-smoke.yml` runs only on `workflow_run` after a successful
`workers-deploy` (push to main → staging, published release → production) or on
`workflow_dispatch`. It never runs on a pull request, which is why 17 days of
red produced no failing check on any PR — including this one.

Worse, the production smoke has never run once. All 33 release-triggered
`workers-deploy` runs — every prod deploy back to v0.12.0 on 2026-07-24 — failed
at the wrangler step with `A request to the Cloudflare API
(/zones/533c…/workers/routes) failed. Authentication error [code: 10000]`. The
smoke gates on `github.event.workflow_run.conclusion == 'success'`, so it
skipped each time; those are the `skipped` rows in its history, one per release.
`mcp.tako.com` nonetheless serves 0.21.1, so production is being deployed by
hand and ships with no automated verification at all. The token the `production`
GitHub environment resolves needs Zone → Workers Routes → Edit on the tako.com
zone. Both findings are out of scope for this PR — `TAKO-N stays open` style
follow-ups, not fixes bundled here.

## What I did not do

Did not run the smoke against a deployed worker — it needs
`TAKO_SMOKE_API_TOKEN` and charges one credit. Verified locally:
`npm run typecheck` (all four projects) and
`vitest run -c vitest.scripts.config.ts` (68 tests) pass, and the tool's
`outputSchema` parses a representative visualize payload under `tsx`. Steps
6a-6c have not run since 2026-08-04 and may surface their own failures on the
first green run.

Lines changed: 65 insertions, 12 deletions across two files.
`workers/scripts/smoke.ts` 25/11 (logic 11, comments 14);
`.github/workflows/workers-smoke.yml` 40/1 (config 12, comments 28).
Tests 0, docs 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LReQxJhnB2LaUCUdYxkogA
