### PR TITLE
test: run the workers pool in one runtime so a second npm test doesn't exhaust macOS ports

### DIFF
--- a/workers/vitest.config.ts
+++ b/workers/vitest.config.ts
@@ -38,6 +38,20 @@ export default defineWorkersConfig({
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },
+        // One workerd instance per test file exhausts macOS's ephemeral port
+        // range, so the second `npm test` inside a minute fails while every
+        // test still passes. Each instance fetches every module from its own
+        // module-fallback service over a fresh loopback connection with no
+        // keep-alive - ~40 test files is ~10,000 sockets per run, parked in
+        // TIME_WAIT for ~60s against a 16,384-port range (49152-65535).
+        // connect() then fails as `No such module "node:vm"`, a missing
+        // @vitest/mocker, or an ECONNREFUSED rejection at teardown - never as
+        // a recognisable port error. CI is unaffected (fresh container).
+        //
+        // singleWorker shares one runtime and one module cache: ~10,000
+        // sockets -> ~400, four back-to-back runs green, same wall time.
+        // Tradeoff: module-level state now persists BETWEEN test files.
+        singleWorker: true,
       },
     },
   },


### PR DESCRIPTION
`npm test` exits 1 on the second run inside a minute while every test passes. The cause is **ephemeral port exhaustion**, not the stale vite cache we assumed.

`@cloudflare/vitest-pool-workers` starts one workerd instance per test file, and each instance fetches its whole module graph from its own module-fallback service over fresh loopback connections with **no keep-alive**. Measured during a run: 133 listener ports in TIME_WAIT, of which ~40 carry 182–359 connections each — one per test file. That's **~10,000 sockets per run** against macOS's ephemeral range of 16,384 (`net.inet.ip.portrange` 49152–65535), all parked in TIME_WAIT for ~60s. The next run has nothing to connect with.

`rm -rf node_modules/.vite` looked like a fix only because clearing the cache takes long enough for TIME_WAIT to drain. Proof, same untouched cache, only the port state varied:

| Ports before run | Result |
|---|---|
| 12,636 TIME_WAIT | exit 1 |
| 155 TIME_WAIT | exit 0, all tests passed |

## Measurement

A/B on `origin/main` a50d646, clean `npm ci`, fresh vite cache, full `npm test` (all three projects):

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| **without** `singleWorker` | exit 0, 9,923 TIME_WAIT | **exit 1**, 16,275 | — |
| **with** `singleWorker` | exit 0, 405 | exit 0, 451 | exit 0, 456 |

With the fix: 41 + 3 + 8 files, 1,583 tests, all green on every run. Wall time is unchanged (~14s for the workers project either way), so the lost file parallelism costs nothing at this suite size.

## Why the failure was never recognisable

connect() fails on a random module, so the error names whatever module lost the race — never a port. Signatures seen across runs: `No such module "node:vm"`, `No such module ".../@vitest/mocker"`, `No such module ".../expect-type/dist/overloads"`, and an unhandled `ECONNREFUSED 127.0.0.1:59264` rejection at teardown. `AGENTS.md` tells contributors to run `npm test` before submitting, and CI never reproduces it (fresh container per run), so a contributor either chases a phantom config bug or learns to ignore a red exit code.

## Tradeoff

`singleWorker` shares one runtime **and one module cache** across all test files, so module-level state now persists between files. All 1,583 tests pass today, but a future test that mutates a module singleton can leak into the next file. That's the real cost of this change and it's recorded at the point of use in `vitest.config.ts`.

## What I did not do

- **No `AGENTS.md` change.** The three fixes floated earlier — clear the cache in the `test` script, split the workers-pool project out of `npm test`, document both modes — all rested on the cache diagnosis and none of them addresses port exhaustion. With the suite green there is no workaround left to document.
- **Did not raise the ephemeral port range.** `sudo sysctl -w net.inet.ip.portrange.first=16384` (49k ports) also fixes it without touching test isolation, but it's per-machine, doesn't survive reboot, and doesn't help anyone else on the team.
- **Did not chase one anomaly.** In an early exploratory sequence a `singleWorker` run failed at teardown with `ECONNREFUSED` after consuming ~9.8k ports. It did not recur across nine later runs, including the nine in the table, and I have no explanation for it.
- **Did not file an upstream issue.** The no-keep-alive module fallback service is arguably a `vitest-pool-workers` bug; `singleWorker` works around it rather than fixing it.

Separately, and not addressed here: local `node_modules` in the main checkout is stale (Jun 28 vs. an Aug 26 `package.json`), so `npm run typecheck` fails there on two missing devDeps (`@anthropic-ai/sdk`, `@iarna/toml`). A plain `npm ci` clears it.

Lines changed: 14 logic (all in `workers/vitest.config.ts`, of which 13 are the explanatory comment), 0 tests, 0 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6hppcfHVYv87i77W6mNem
